### PR TITLE
Migrate extend-browserbase templates to Extend API v2026-02-09

### DIFF
--- a/python/extend-browserbase/.env.example
+++ b/python/extend-browserbase/.env.example
@@ -8,6 +8,3 @@ GOOGLE_API_KEY=your_google_api_key
 
 # Extend AI (optional – enables receipt parsing; omit to only download receipts)
 EXTEND_API_KEY=your_extend_api_key
-
-# Optional: set after first run to reuse the created processor
-# EXTEND_PROCESSOR_ID=your_processor_id

--- a/python/extend-browserbase/README.md
+++ b/python/extend-browserbase/README.md
@@ -6,7 +6,7 @@
 - **Pattern Template**: Demonstrates the integration pattern of Browserbase (browser automation + download capture) + Extend AI (schema-based document extraction).
 - **Workflow**: Stagehand navigates the expense portal and clicks each receipt's download link; Browserbase captures downloads. The script polls for the session's download ZIP, extracts files, then optionally sends them to Extend for structured extraction (vendor, date, totals, line items, etc.).
 - **Download Handling**: Implements retry/polling around Browserbase's Session Downloads API until the ZIP is available.
-- **Structured Extraction**: Extend EXTRACT processor with a receipt JSON schema; results written to `output/results/receipts.json` and `receipts.csv`.
+- **Structured Extraction**: Extend AI extraction with inline receipt JSON schema config; results written to `output/results/receipts.json` and `receipts.csv`.
 - Docs → [Browserbase Downloads](https://docs.browserbase.com/features/downloads) | [Extend AI](https://docs.extend.app)
 
 ## GLOSSARY
@@ -17,7 +17,7 @@
   Docs → https://docs.stagehand.dev/basics/observe
 - **Browserbase Downloads**: When files are downloaded during a browser session, Browserbase captures and stores them. Files are retrieved via the Session Downloads API as a ZIP archive.
   Docs → https://docs.browserbase.com/features/downloads
-- **Extend EXTRACT processor**: A configurable document extraction pipeline that parses files against a JSON schema and returns structured data. Processors are reusable and persist across runs.
+- **Extend AI extraction**: A configurable document extraction pipeline that parses files against a JSON schema and returns structured data. Config can be passed inline or via a saved extractor resource.
   Docs → https://docs.extend.app
 - **Download polling**: Browserbase syncs downloads in real-time; the script retries every 2 seconds until the ZIP is available or a timeout is reached.
 
@@ -42,8 +42,7 @@
 - Navigates to the expense portal and finds all per-receipt download links via observe
 - Clicks each download button; Browserbase captures files
 - After closing the session, polls for the session's download ZIP and extracts to `output/documents/`
-- If `EXTEND_API_KEY` is set: creates/uses an Extend "Receipt Extractor" processor, uploads each file, runs extraction, writes `output/results/receipts.json` and `receipts.csv`
-- Opens the Extend dashboard runs page in your browser for review
+- If `EXTEND_API_KEY` is set: uploads each file to Extend and runs extraction with inline config, writes `output/results/receipts.json` and `receipts.csv`
 - Closes session cleanly
 
 ## COMMON PITFALLS

--- a/python/extend-browserbase/main.py
+++ b/python/extend-browserbase/main.py
@@ -5,7 +5,6 @@ import asyncio
 import csv
 import json
 import os
-import re
 import webbrowser
 import zipfile
 from pathlib import Path
@@ -17,17 +16,16 @@ from stagehand import AsyncStagehand
 
 # Load environment variables from .env file
 # Required: BROWSERBASE_API_KEY, BROWSERBASE_PROJECT_ID, GOOGLE_API_KEY
-# Optional: EXTEND_API_KEY, EXTEND_PROCESSOR_ID
+# Optional: EXTEND_API_KEY
 load_dotenv()
 
 
 # Receipt extraction config for Extend AI
-# Uses extraction_light base processor with parse_performance engine for low latency
+# Uses extraction_light base extractor with parse_performance engine for low latency
 RECEIPT_EXTRACTION_CONFIG = {
-    "type": "EXTRACT",
     "baseProcessor": "extraction_light",
     "baseVersion": "3.4.0",
-    "parser": {
+    "parseConfig": {
         "engine": "parse_performance",
         "target": "markdown",
         "blockOptions": {
@@ -285,69 +283,14 @@ def extract_files_from_zip(zip_path: str, output_dir: str = "output/documents") 
     return extracted_files
 
 
-# Gets existing Extend processor or creates a new one, saving the ID to .env for reuse.
-# This avoids recreating the processor on every run.
-async def get_or_create_processor(extend_client: Extend) -> str:
-    """
-    Get an existing Extend processor or create a new one.
-
-    Checks for EXTEND_PROCESSOR_ID in environment. If not found, creates a new
-    'Receipt Extractor' processor and saves the ID to .env for future runs.
-
-    Args:
-        extend_client: Extend client instance for API calls
-
-    Returns:
-        str: The processor ID
-    """
-    # Check if a processor ID already exists in environment
-    existing_id = os.environ.get("EXTEND_PROCESSOR_ID")
-    if existing_id and existing_id != "YOUR_EXTEND_PROCESSOR_ID_HERE":
-        print(f"Using existing processor: {existing_id}")
-        return existing_id
-
-    # Create a new Receipt Extractor processor via the Extend API
-    print("No EXTEND_PROCESSOR_ID found. Creating 'Receipt Extractor' processor...")
-
-    response = await asyncio.to_thread(
-        extend_client.processor.create,
-        name="Receipt Extractor",
-        type="EXTRACT",
-        config=RECEIPT_EXTRACTION_CONFIG,
-    )
-
-    processor_id = response.processor.id
-    print(f"Created processor: {processor_id}")
-    print(f"  View in dashboard: https://dashboard.extend.app/studio/processors/{processor_id}")
-
-    # Persist the processor ID to .env so we don't recreate on next run
-    env_path = Path(".env")
-    if env_path.exists():
-        env_content = env_path.read_text()
-        if "EXTEND_PROCESSOR_ID=" in env_content:
-            env_content = re.sub(
-                r"EXTEND_PROCESSOR_ID=.*",
-                f"EXTEND_PROCESSOR_ID={processor_id}",
-                env_content,
-            )
-        else:
-            env_content += f"\nEXTEND_PROCESSOR_ID={processor_id}\n"
-        env_path.write_text(env_content)
-    else:
-        with open(env_path, "a") as f:
-            f.write(f"EXTEND_PROCESSOR_ID={processor_id}\n")
-    print("  Saved EXTEND_PROCESSOR_ID to .env for future runs.")
-
-    return processor_id
-
-
 # Uploads receipt files to Extend AI, runs extraction, and saves results as JSON and CSV
 async def parse_receipts_with_extend(file_paths: list[str]) -> None:
     """
     Upload receipt files to Extend AI, run extraction, and save results.
 
-    Initializes the Extend client, gets or creates a processor, uploads each file,
-    runs synchronous extraction, and saves results as JSON and CSV.
+    Initializes the Extend client, uploads each file, runs synchronous extraction
+    using inline config (no need to pre-create an extractor resource), and saves
+    results as JSON and CSV.
 
     Args:
         file_paths: List of file paths to receipt documents
@@ -361,14 +304,10 @@ async def parse_receipts_with_extend(file_paths: list[str]) -> None:
 
     print("\n=== Parsing Receipts with Extend AI ===\n")
 
-    # Initialize Extend AI client and get or create the receipt processor
+    # Initialize Extend AI client
     extend_client = Extend(token=extend_api_key)
-    processor_id = await get_or_create_processor(extend_client)
 
-    print(f"Processing {len(file_paths)} receipts...")
-    runs_url = f"https://dashboard.extend.app/studio/processors/{processor_id}?tab=Runs"
-    print(f"View all runs: {runs_url}\n")
-    open_in_browser(runs_url)
+    print(f"Processing {len(file_paths)} receipts with inline config...\n")
 
     # Process all files with retry on rate limiting (429 errors)
     results: list[dict] = []
@@ -384,39 +323,31 @@ async def parse_receipts_with_extend(file_paths: list[str]) -> None:
                 with open(file_path, "rb") as f:
                     file_bytes = f.read()
                 upload_response = await asyncio.to_thread(
-                    extend_client.file.upload,
+                    extend_client.files.upload,
                     file=(file_name, file_bytes),
                 )
-                file_id = upload_response.file.id
+                file_id = upload_response.id
 
-                # Run extraction on the uploaded file
-                extraction_response = await asyncio.to_thread(
-                    extend_client.processor_run.create,
-                    processor_id=processor_id,
-                    file={"fileId": file_id},
-                    sync=True,
+                # Run extraction using inline config — no need to pre-create an extractor
+                result = await asyncio.to_thread(
+                    extend_client.extract,
                     config=RECEIPT_EXTRACTION_CONFIG,
+                    file={"id": file_id},
                 )
 
-                parsed_data = extraction_response.processor_run
-                run_id = parsed_data.id
-                run_url = (
-                    f"https://dashboard.extend.app/studio/processors/{processor_id}/runs/{run_id}"
-                )
-                print(f"  Parsed {file_name}")
-                print(f"    -> {run_url}")
+                run_id = result.id
+                print(f"  Parsed {file_name} (run: {run_id})")
 
                 # Convert to dict for JSON serialization
-                data = parsed_data
-                if hasattr(parsed_data, "to_dict"):
-                    data = parsed_data.to_dict()
-                elif hasattr(parsed_data, "dict"):
-                    data = parsed_data.dict()
+                data = result
+                if hasattr(result, "to_dict"):
+                    data = result.to_dict()
+                elif hasattr(result, "dict"):
+                    data = result.dict()
 
                 return {
                     "file": file_name,
                     "runId": run_id,
-                    "runUrl": run_url,
                     "data": data,
                 }
             except Exception as error:
@@ -457,7 +388,6 @@ async def parse_receipts_with_extend(file_paths: list[str]) -> None:
         writer.writerow(
             [
                 "file",
-                "run_url",
                 "vendor_name",
                 "receipt_date",
                 "receipt_number",
@@ -480,7 +410,6 @@ async def parse_receipts_with_extend(file_paths: list[str]) -> None:
             writer.writerow(
                 [
                     result.get("file", ""),
-                    result.get("runUrl", ""),
                     output.get("vendor_name", ""),
                     output.get("receipt_date", ""),
                     output.get("receipt_number", ""),
@@ -496,7 +425,6 @@ async def parse_receipts_with_extend(file_paths: list[str]) -> None:
             )
 
     print(f"Saved CSV:  {csv_path}")
-    print(f"\nView all runs: {runs_url}")
 
 
 async def main() -> None:

--- a/python/extend-browserbase/pyproject.toml
+++ b/python/extend-browserbase/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
     "browserbase>=1.4.0",
-    "extend-ai>=0.0.21",
+    "extend-ai>=1.0.0",
     "python-dotenv>=1.2.1",
     "stagehand>=3.5.0",
 ]

--- a/typescript/extend-browserbase/.env.example
+++ b/typescript/extend-browserbase/.env.example
@@ -7,6 +7,3 @@ GOOGLE_API_KEY=your_google_api_key
 
 # Extend AI (optional – enables receipt parsing; omit to only download receipts)
 EXTEND_API_KEY=your_extend_api_key
-
-# Optional: set after first run to reuse the created processor
-# EXTEND_PROCESSOR_ID=your_processor_id

--- a/typescript/extend-browserbase/README.md
+++ b/typescript/extend-browserbase/README.md
@@ -6,7 +6,7 @@
 - **Pattern Template**: Demonstrates the integration pattern of Browserbase (browser automation + download capture) + Extend AI (schema-based document extraction).
 - **Workflow**: Stagehand navigates the expense portal and clicks each receipt's download link; Browserbase captures downloads. The script polls for the session's download ZIP, extracts files, then optionally sends them to Extend for structured extraction (vendor, date, totals, line items, etc.).
 - **Download Handling**: Implements retry/polling around Browserbase's Session Downloads API until the ZIP is available.
-- **Structured Extraction**: Extend EXTRACT processor with a receipt JSON schema; results written to `output/results/receipts.json` and `receipts.csv`.
+- **Structured Extraction**: Extend AI extraction with inline receipt JSON schema config; results written to `output/results/receipts.json` and `receipts.csv`.
 - Docs → [Browserbase Downloads](https://docs.browserbase.com/features/downloads) | [Extend AI](https://docs.extend.app)
 
 ## GLOSSARY
@@ -17,7 +17,7 @@
   Docs → https://docs.stagehand.dev/basics/observe
 - **Browserbase Downloads**: When files are downloaded during a browser session, Browserbase captures and stores them. Files are retrieved via the Session Downloads API as a ZIP archive.
   Docs → https://docs.browserbase.com/features/downloads
-- **Extend EXTRACT processor**: A configurable document extraction pipeline that parses files against a JSON schema and returns structured data. Processors are reusable and persist across runs.
+- **Extend AI extraction**: A configurable document extraction pipeline that parses files against a JSON schema and returns structured data. Config can be passed inline or via a saved extractor resource.
   Docs → https://docs.extend.app
 - **Download polling**: Browserbase syncs downloads in real-time; the script retries every 2 seconds until the ZIP is available or a timeout is reached.
 
@@ -39,8 +39,7 @@
 - Navigates to the expense portal and finds all per-receipt download links via observe
 - Clicks each download button; Browserbase captures files
 - After closing the session, polls for the session's download ZIP and extracts to `output/documents/`
-- If `EXTEND_API_KEY` is set: creates/uses an Extend "Receipt Extractor" processor, uploads each file, runs extraction, writes `output/results/receipts.json` and `receipts.csv`
-- Opens the Extend dashboard runs page in your browser for review
+- If `EXTEND_API_KEY` is set: uploads each file to Extend and runs extraction with inline config, writes `output/results/receipts.json` and `receipts.csv`
 - Closes session cleanly
 
 ## COMMON PITFALLS

--- a/typescript/extend-browserbase/index.ts
+++ b/typescript/extend-browserbase/index.ts
@@ -91,12 +91,11 @@ function extractFilesFromZip(zipPath: string, outputDir: string = "output/docume
 }
 
 // Receipt extraction config for Extend AI
-// Uses extraction_light base processor with parse_performance engine for low latency
+// Uses extraction_light base extractor with parse_performance engine for low latency
 const receiptExtractionConfig = {
-  type: "EXTRACT",
   baseProcessor: "extraction_light",
   baseVersion: "3.4.0",
-  parser: {
+  parseConfig: {
     engine: "parse_performance",
     target: "markdown",
     blockOptions: {
@@ -228,50 +227,6 @@ const receiptExtractionConfig = {
   },
 };
 
-// Gets existing Extend processor or creates a new one, saving the ID to .env for reuse.
-// This avoids recreating the processor on every run.
-async function getOrCreateProcessor(client: ExtendClient): Promise<string> {
-  // Check if a processor ID already exists in environment
-  const existingId = process.env.EXTEND_PROCESSOR_ID;
-  if (existingId && existingId !== "YOUR_EXTEND_PROCESSOR_ID_HERE") {
-    console.log(`Using existing processor: ${existingId}`);
-    return existingId;
-  }
-
-  // Create a new Receipt Extractor processor via the Extend API
-  console.log("No EXTEND_PROCESSOR_ID found. Creating 'Receipt Extractor' processor...");
-
-  const response = await client.processor.create({
-    name: "Receipt Extractor",
-    type: "EXTRACT",
-    config: receiptExtractionConfig as Parameters<typeof client.processor.create>[0]["config"],
-  });
-
-  const processorId = response.processor.id;
-  console.log(`Created processor: ${processorId}`);
-  console.log(`  View in dashboard: https://dashboard.extend.app/studio/processors/${processorId}`);
-
-  // Persist the processor ID to .env so we don't recreate on next run
-  const envPath = path.resolve(".env");
-  if (fs.existsSync(envPath)) {
-    let envContent = fs.readFileSync(envPath, "utf-8");
-    if (envContent.includes("EXTEND_PROCESSOR_ID=")) {
-      envContent = envContent.replace(
-        /EXTEND_PROCESSOR_ID=.*/,
-        `EXTEND_PROCESSOR_ID=${processorId}`,
-      );
-    } else {
-      envContent += `\nEXTEND_PROCESSOR_ID=${processorId}\n`;
-    }
-    fs.writeFileSync(envPath, envContent);
-  } else {
-    fs.writeFileSync(envPath, `EXTEND_PROCESSOR_ID=${processorId}\n`, { flag: "a" });
-  }
-  console.log("  Saved EXTEND_PROCESSOR_ID to .env for future runs.");
-
-  return processorId;
-}
-
 // Uploads receipt files to Extend AI, runs extraction, and saves results as JSON and CSV
 async function parseReceiptsWithExtend(filePaths: string[]): Promise<void> {
   // Skip parsing if Extend API key is not configured
@@ -283,18 +238,14 @@ async function parseReceiptsWithExtend(filePaths: string[]): Promise<void> {
 
   console.log("\n=== Parsing Receipts with Extend AI ===\n");
 
-  // Initialize Extend AI client and get or create the receipt processor
+  // Initialize Extend AI client
   // SDK auto-retries 429s and 5xx errors with exponential backoff
   const client = new ExtendClient({ token: process.env.EXTEND_API_KEY });
-  const processorId = await getOrCreateProcessor(client);
 
-  console.log(`Processing ${filePaths.length} receipts...`);
-  const runsUrl = `https://dashboard.extend.app/studio/processors/${processorId}?tab=Runs`;
-  console.log(`View all runs: ${runsUrl}\n`);
-  openInBrowser(runsUrl);
+  console.log(`Processing ${filePaths.length} receipts with inline config...\n`);
 
   // Process all files - SDK handles retries automatically with exponential backoff
-  const results: { file: string; runId?: string; runUrl?: string; data: unknown }[] = [];
+  const results: { file: string; runId?: string; data: unknown }[] = [];
 
   // Process in batches of 9 to balance speed and reliability
   for (let i = 0; i < filePaths.length; i += 9) {
@@ -306,31 +257,24 @@ async function parseReceiptsWithExtend(filePaths: string[]): Promise<void> {
           // Upload the file to Extend
           const fileBuffer = fs.readFileSync(filePath);
           const blob = new Blob([fileBuffer]);
-          const uploadResponse = await client.file.upload(
-            blob as Parameters<typeof client.file.upload>[0],
+          const uploadResponse = await client.files.upload(
+            blob as Parameters<typeof client.files.upload>[0],
             { maxRetries: 4 },
           );
-          const fileId = uploadResponse.file.id;
+          const fileId = uploadResponse.id;
 
-          // Run extraction on the uploaded file
-          const extractionResponse = await client.processorRun.create(
+          // Run extraction using inline config — no need to pre-create an extractor resource
+          const result = await client.extract(
             {
-              processorId,
-              file: { fileId },
-              sync: true,
-              config: receiptExtractionConfig as Parameters<
-                typeof client.processorRun.create
-              >[0]["config"],
+              config: receiptExtractionConfig as Parameters<typeof client.extract>[0]["config"],
+              file: { id: fileId },
             },
             { maxRetries: 4 },
           );
 
-          const parsedData = extractionResponse.processorRun;
-          const runId = parsedData.id;
-          const runUrl = `https://dashboard.extend.app/studio/processors/${processorId}/runs/${runId}`;
-          console.log(`  Parsed ${fileName}`);
-          console.log(`    → ${runUrl}`);
-          return { file: fileName, runId, runUrl, data: parsedData };
+          const runId = result.id;
+          console.log(`  Parsed ${fileName} (run: ${runId})`);
+          return { file: fileName, runId, data: result };
         } catch (error) {
           const errorMsg = error instanceof Error ? error.message : String(error);
           console.error(`  Failed to parse ${fileName}:`, errorMsg);
@@ -349,10 +293,10 @@ async function parseReceiptsWithExtend(filePaths: string[]): Promise<void> {
   // Convert results to CSV for easy viewing in spreadsheet tools
   const csvRows: string[] = [];
   csvRows.push(
-    "file,run_url,vendor_name,receipt_date,receipt_number,total_amount,currency,subtotal,tax,payment_method,line_items_count",
+    "file,vendor_name,receipt_date,receipt_number,total_amount,currency,subtotal,tax,payment_method,line_items_count",
   );
 
-  // Shape of the extracted receipt data from Extend processor runs
+  // Shape of the extracted receipt data from Extend extract runs
   type ReceiptOutput = {
     vendor_name?: string;
     receipt_date?: string;
@@ -370,7 +314,6 @@ async function parseReceiptsWithExtend(filePaths: string[]): Promise<void> {
     const output: ReceiptOutput = data?.output?.value || {};
     const row = [
       result.file,
-      result.runUrl || "",
       output.vendor_name || "",
       output.receipt_date || "",
       output.receipt_number || "",
@@ -389,8 +332,6 @@ async function parseReceiptsWithExtend(filePaths: string[]): Promise<void> {
   const csvPath = "output/results/receipts.csv";
   fs.writeFileSync(csvPath, csvRows.join("\n"));
   console.log(`Saved CSV:  ${csvPath}`);
-
-  console.log(`\nView all runs: ${runsUrl}`);
 }
 
 async function main(): Promise<void> {

--- a/typescript/extend-browserbase/package.json
+++ b/typescript/extend-browserbase/package.json
@@ -12,7 +12,7 @@
     "@browserbasehq/stagehand": "^3.0.8",
     "adm-zip": "^0.5.16",
     "dotenv": "^17.2.4",
-    "extend-ai": "^0.0.18",
+    "extend-ai": "^1.0.2",
     "open": "^11.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Migrates both TypeScript and Python extend-browserbase templates to the new Extend AI API version `2026-02-09`
- Replaces the processor/processorRun pattern with inline config via `client.extract()` — users no longer need to create or manage an extractor resource
- Removes `EXTEND_PROCESSOR_ID` env var, `getOrCreateProcessor` function, and `.env` persistence logic

## Changes
- `client.file.upload()` → `client.files.upload()` (plural)
- `client.processorRun.create({ sync: true })` → `client.extract({ config })` (sync endpoint with inline config)
- `config.parser` → `config.parseConfig`
- `config.type: "EXTRACT"` removed (implicit from endpoint)
- Response unwrapping: `response.processor.id` → `response.id`
- `extend-ai` SDK bumped: TS `^0.0.18` → `^1.0.2`, Python `>=0.0.21` → `>=1.0.0`
- Updated READMEs and `.env.example` files

## Test plan
- [x] TypeScript template: 19/19 receipts downloaded and parsed end-to-end
- [x] Python template: 19/19 receipts downloaded and parsed end-to-end
- [x] Verified `parseConfig` rename works with test extraction call
- [x] Confirmed no remaining references to old API (`processor_run`, `PROCESSOR_ID`, `client.file.`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)