### PR TITLE
Update typescript example for manual-mfa-with-contexts template

### DIFF
--- a/typescript/manual-mfa-with-contexts/index.ts
+++ b/typescript/manual-mfa-with-contexts/index.ts
@@ -2,7 +2,7 @@
 
 import "dotenv/config";
 import { Stagehand } from "@browserbasehq/stagehand";
-import Browserbase from "@browserbasehq/sdk";
+import { Browserbase } from "@browserbasehq/sdk";
 import { z } from "zod";
 
 const bb = new Browserbase({
@@ -15,9 +15,7 @@ const bb = new Browserbase({
 async function createSessionWithContext() {
   console.log("Creating new Browserbase context...");
 
-  const context = await bb.contexts.create({
-    projectId: process.env.BROWSERBASE_PROJECT_ID!,
-  });
+  const context = await bb.createContext()
 
   console.log(`Context created: ${context.id}`);
   console.log("First session: Performing login with MFA...");
@@ -231,7 +229,7 @@ async function main() {
     // Clean up
     await deleteContext(contextId);
 
-    console.log("═══════════════════════════════════════════════════════════");
+    console.log("════════════════════════════════════���══════════════════════");
     console.log("Key Takeaway:");
     console.log("═══════════════════════════════════════════════════════════");
     console.log("✅ First session: User completes MFA once");

--- a/typescript/manual-mfa-with-contexts/index.ts
+++ b/typescript/manual-mfa-with-contexts/index.ts
@@ -229,7 +229,7 @@ async function main() {
     // Clean up
     await deleteContext(contextId);
 
-    console.log("════════════════════════════════════���══════════════════════");
+    console.log("═══════════════════════════════════════════════════════════");
     console.log("Key Takeaway:");
     console.log("═══════════════════════════════════════════════════════════");
     console.log("✅ First session: User completes MFA once");


### PR DESCRIPTION
Minor update to use correct import for Browserbase constructor + correct createContext() method

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small example/template fix that only updates SDK usage (import + context creation) with no production logic, auth, or data-path changes.
> 
> **Overview**
> Updates the `manual-mfa-with-contexts` TypeScript example to match the current Browserbase SDK API by switching to a named `Browserbase` import and replacing `bb.contexts.create({ projectId })` with `bb.createContext()` for context creation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea4aa68460ca42896a38bfed98b02c3c6ff58965. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->