### PR TITLE
Bump @browserbasehq/sdk to ^2.7.0 and remove projectId from session creation

### DIFF
--- a/typescript/amazon-global-price-comparison/index.ts
+++ b/typescript/amazon-global-price-comparison/index.ts
@@ -84,7 +84,6 @@ async function getProductsForCountry(
     // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
     // https://docs.stagehand.dev/configuration/logging
     browserbaseSessionCreateParams: {
-      projectId: process.env.BROWSERBASE_PROJECT_ID!,
       proxies: [
         {
           type: "browserbase", // Use Browserbase's managed proxy infrastructure for reliable geolocation routing

--- a/typescript/basic-caching/index.ts
+++ b/typescript/basic-caching/index.ts
@@ -20,9 +20,7 @@ async function runWithoutCache() {
     // https://docs.stagehand.dev/configuration/logging
     model: "google/gemini-2.5-flash",
     enableCaching: false,
-    browserbaseSessionCreateParams: {
-      projectId: process.env.BROWSERBASE_PROJECT_ID!,
-    },
+    browserbaseSessionCreateParams: {},
   });
 
   await stagehand.init();
@@ -69,9 +67,7 @@ async function runWithCache() {
     model: "google/gemini-2.5-flash",
     enableCaching: true,
     cacheDir: CACHE_DIR,
-    browserbaseSessionCreateParams: {
-      projectId: process.env.BROWSERBASE_PROJECT_ID!,
-    },
+    browserbaseSessionCreateParams: {},
   });
 
   await stagehand.init();

--- a/typescript/browserbase-reducto/package.json
+++ b/typescript/browserbase-reducto/package.json
@@ -8,7 +8,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@browserbasehq/sdk": "latest",
+    "@browserbasehq/sdk": "^2.7.0",
     "@browserbasehq/stagehand": "latest",
     "adm-zip": "latest",
     "dotenv": "latest",

--- a/typescript/company-value-prop-generator/index.ts
+++ b/typescript/company-value-prop-generator/index.ts
@@ -16,9 +16,7 @@ async function generateOneLiner(domain: string): Promise<string> {
     env: "BROWSERBASE",
     model: "openai/gpt-4.1",
     verbose: 0, //  0 = errors only, 1 = info, 2 = debug
-    browserbaseSessionCreateParams: {
-      projectId: process.env.BROWSERBASE_PROJECT_ID!,
-    },
+    browserbaseSessionCreateParams: {},
   });
 
   try {

--- a/typescript/context/index.ts
+++ b/typescript/context/index.ts
@@ -10,16 +10,13 @@ async function createSessionContextID() {
   console.log("Creating new Browserbase context...");
   // First create a context using Browserbase SDK to get a context ID.
   const bb = new Browserbase({ apiKey: process.env.BROWSERBASE_API_KEY! });
-  const context = await bb.contexts.create({
-    projectId: process.env.BROWSERBASE_PROJECT_ID!,
-  });
+  const context = await bb.contexts.create({});
 
   console.log("Created context ID:", context.id);
 
   // Create a single session using the context ID to perform initial login.
   console.log("Creating session for initial login...");
   const session = await bb.sessions.create({
-    projectId: process.env.BROWSERBASE_PROJECT_ID!,
     browserSettings: {
       context: {
         id: context.id,
@@ -96,7 +93,6 @@ async function main() {
     model: "openai/gpt-4.1",
     verbose: 1,
     browserbaseSessionCreateParams: {
-      projectId: process.env.BROWSERBASE_PROJECT_ID!,
       browserSettings: {
         context: {
           id: contextId.id,

--- a/typescript/extend-browserbase/package.json
+++ b/typescript/extend-browserbase/package.json
@@ -8,7 +8,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@browserbasehq/sdk": "^2.6.0",
+    "@browserbasehq/sdk": "^2.7.0",
     "@browserbasehq/stagehand": "^3.0.8",
     "adm-zip": "^0.5.16",
     "dotenv": "^17.2.4",

--- a/typescript/form-filling/index.ts
+++ b/typescript/form-filling/index.ts
@@ -21,9 +21,7 @@ async function main() {
     env: "BROWSERBASE",
     model: "openai/gpt-4.1",
     verbose: 1,
-    browserbaseSessionCreateParams: {
-      projectId: process.env.BROWSERBASE_PROJECT_ID!,
-    },
+    browserbaseSessionCreateParams: {},
   });
 
   try {

--- a/typescript/gemini-3-flash/index.ts
+++ b/typescript/gemini-3-flash/index.ts
@@ -29,7 +29,6 @@ async function main() {
     // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
     // https://docs.stagehand.dev/configuration/logging
     browserbaseSessionCreateParams: {
-      projectId: process.env.BROWSERBASE_PROJECT_ID!,
       proxies: true, // Using proxies will give the agent a better chance of success - requires Developer Plan or higher, comment out if you don't have access
       region: "us-west-2",
       browserSettings: {

--- a/typescript/gemini-cua/index.ts
+++ b/typescript/gemini-cua/index.ts
@@ -29,7 +29,6 @@ async function main() {
     // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
     // https://docs.stagehand.dev/configuration/logging
     browserbaseSessionCreateParams: {
-      projectId: process.env.BROWSERBASE_PROJECT_ID!,
       proxies: true, // Using proxies will give the agent a better chance of success - requires Developer Plan or higher, comment out if you don't have access
       region: "us-west-2",
       browserSettings: {

--- a/typescript/gift-finder/index.ts
+++ b/typescript/gift-finder/index.ts
@@ -236,7 +236,6 @@ async function main(): Promise<void> {
       // https://docs.stagehand.dev/configuration/logging
       model: "openai/gpt-4.1",
       browserbaseSessionCreateParams: {
-        projectId: process.env.BROWSERBASE_PROJECT_ID!,
         // Proxies require Developer Plan or higher - comment in if you have a Developer Plan or higher
         //   proxies: [
         //     {

--- a/typescript/manual-mfa-with-contexts/index.ts
+++ b/typescript/manual-mfa-with-contexts/index.ts
@@ -28,7 +28,6 @@ async function createSessionWithContext() {
     // https://docs.stagehand.dev/configuration/logging
     model: "openai/gpt-4.1-mini",
     browserbaseSessionCreateParams: {
-      projectId: process.env.BROWSERBASE_PROJECT_ID!,
       browserSettings: {
         context: {
           id: context.id,
@@ -127,7 +126,6 @@ async function reuseContext(contextId: string) {
     // https://docs.stagehand.dev/configuration/logging
     model: "openai/gpt-4.1-mini",
     browserbaseSessionCreateParams: {
-      projectId: process.env.BROWSERBASE_PROJECT_ID!,
       browserSettings: {
         context: {
           id: contextId,

--- a/typescript/manual-mfa-with-contexts/package.json
+++ b/typescript/manual-mfa-with-contexts/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch index.ts"
   },
   "dependencies": {
-    "@browserbasehq/sdk": "^1.0.0",
+    "@browserbasehq/sdk": "^2.7.0",
     "@browserbasehq/stagehand": "^3.0.0",
     "dotenv": "^16.4.5",
     "zod": "^3.23.8"

--- a/typescript/microsoft-cua/index.ts
+++ b/typescript/microsoft-cua/index.ts
@@ -29,7 +29,6 @@ async function main() {
     // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
     // https://docs.stagehand.dev/configuration/logging
     browserbaseSessionCreateParams: {
-      projectId: process.env.BROWSERBASE_PROJECT_ID!,
       proxies: true, // Using proxies will give the agent a better chance of success - requires Developer Plan or higher, comment out if you don't have access
       region: "us-west-2",
       browserSettings: {

--- a/typescript/pickleball/index.ts
+++ b/typescript/pickleball/index.ts
@@ -401,7 +401,6 @@ async function bookTennisPaddleCourt() {
     // https://docs.stagehand.dev/configuration/logging
     model: "openai/gpt-4.1",
     browserbaseSessionCreateParams: {
-      projectId: process.env.BROWSERBASE_PROJECT_ID!,
       timeout: 900,
       region: "us-west-2",
     },

--- a/typescript/playwright-mfa-handling/index.ts
+++ b/typescript/playwright-mfa-handling/index.ts
@@ -79,9 +79,7 @@ async function createBrowserbaseSession(): Promise<BrowserSession> {
 
   const bb = new Browserbase({ apiKey: process.env.BROWSERBASE_API_KEY });
 
-  const session = await bb.sessions.create({
-    projectId: process.env.BROWSERBASE_PROJECT_ID,
-  });
+  const session = await bb.sessions.create({});
 
   console.log(`Session created: https://browserbase.com/sessions/${session.id}`);
 

--- a/typescript/playwright-mfa-handling/package.json
+++ b/typescript/playwright-mfa-handling/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@browserbasehq/sdk": "^2.0.0",
+    "@browserbasehq/sdk": "^2.7.0",
     "dotenv": "^16.0.0",
     "playwright-core": "^1.40.0"
   },

--- a/typescript/playwright/basic-recaptcha/index.ts
+++ b/typescript/playwright/basic-recaptcha/index.ts
@@ -4,7 +4,7 @@
 // For a higher-level API with natural language commands, see the Stagehand template instead.
 
 import { chromium, Browser, Page } from "playwright-core";
-import Browserbase from "@browserbasehq/sdk";
+import { Browserbase } from "@browserbasehq/sdk";
 import "dotenv/config";
 
 const DEMO_URL = "https://google.com/recaptcha/api2/demo";
@@ -12,24 +12,20 @@ const SOLVE_CAPTCHAS = true; // Set to false to disable automatic captcha solvin
 
 // Validate required environment variables before starting.
 // Browserbase credentials are required to create browser sessions.
-function validateEnv(): { apiKey: string; projectId: string } {
+function validateEnv(): { apiKey: string } {
   const apiKey = process.env.BROWSERBASE_API_KEY;
-  const projectId = process.env.BROWSERBASE_PROJECT_ID;
 
   if (!apiKey) {
     throw new Error("BROWSERBASE_API_KEY environment variable is required");
   }
-  if (!projectId) {
-    throw new Error("BROWSERBASE_PROJECT_ID environment variable is required");
-  }
 
-  return { apiKey, projectId };
+  return { apiKey };
 }
 
 async function main() {
   console.log("Starting Playwright + Browserbase reCAPTCHA Example...");
 
-  const { apiKey, projectId } = validateEnv();
+  const { apiKey } = validateEnv();
 
   // Initialize the Browserbase SDK client.
   const bb = new Browserbase({ apiKey });
@@ -39,7 +35,6 @@ async function main() {
   // Docs: https://docs.browserbase.com/features/stealth-mode#captcha-solving
   console.log("Creating Browserbase session with captcha solving enabled...");
   const session = await bb.sessions.create({
-    projectId,
     browserSettings: {
       solveCaptchas: SOLVE_CAPTCHAS,
     },
@@ -143,7 +138,7 @@ async function main() {
 main().catch((err) => {
   console.error("Application error:", err);
   console.error("\nCommon issues:");
-  console.error("  - Check .env file has BROWSERBASE_PROJECT_ID and BROWSERBASE_API_KEY");
+  console.error("  - Check .env file has BROWSERBASE_API_KEY set");
   console.error("  - Verify solveCaptchas is enabled (true by default)");
   console.error("  - Allow up to 60 seconds for CAPTCHA solving to complete");
   console.error("  - Enable proxies for higher success rates");

--- a/typescript/playwright/basic-recaptcha/package.json
+++ b/typescript/playwright/basic-recaptcha/package.json
@@ -6,7 +6,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@browserbasehq/sdk": "latest",
+    "@browserbasehq/sdk": "^2.7.0",
     "playwright-core": "latest",
     "dotenv": "^16.4.7"
   },

--- a/typescript/proxies-weather/index.ts
+++ b/typescript/proxies-weather/index.ts
@@ -34,7 +34,6 @@ async function getWeatherForLocation(geolocation: GeolocationConfig): Promise<We
     // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
     // https://docs.stagehand.dev/configuration/logging
     browserbaseSessionCreateParams: {
-      projectId: process.env.BROWSERBASE_PROJECT_ID!,
       proxies: [
         {
           type: "browserbase", // Use Browserbase's managed proxy infrastructure for reliable geolocation routing

--- a/typescript/proxies/index.ts
+++ b/typescript/proxies/index.ts
@@ -13,7 +13,6 @@ const bb = new Browserbase({ apiKey: process.env.BROWSERBASE_API_KEY! });
 async function createSessionWithBuiltInProxies() {
   // Use Browserbase's default proxy rotation for enhanced privacy and IP diversity.
   const session = await bb.sessions.create({
-    projectId: process.env.BROWSERBASE_PROJECT_ID!,
     proxies: true, // Enables automatic proxy rotation across different IP addresses.
   });
   return session;
@@ -22,7 +21,6 @@ async function createSessionWithBuiltInProxies() {
 async function createSessionWithGeoLocation() {
   // Route traffic through specific geographic location to test location-based restrictions.
   const session = await bb.sessions.create({
-    projectId: process.env.BROWSERBASE_PROJECT_ID!,
     proxies: [
       {
         type: "browserbase", // Use Browserbase's managed proxy infrastructure.
@@ -40,7 +38,6 @@ async function createSessionWithGeoLocation() {
 async function createSessionWithCustomProxies() {
   // Use external proxy servers for custom routing or specific proxy requirements.
   const session = await bb.sessions.create({
-    projectId: process.env.BROWSERBASE_PROJECT_ID!,
     proxies: [
       {
         type: "external", // Connect to your own proxy server infrastructure.

--- a/typescript/sec-filing-research/index.ts
+++ b/typescript/sec-filing-research/index.ts
@@ -58,7 +58,6 @@ async function main(): Promise<void> {
   const stagehand = new Stagehand({
     env: "BROWSERBASE",
     apiKey: process.env.BROWSERBASE_API_KEY,
-    projectId: process.env.BROWSERBASE_PROJECT_ID,
     verbose: 1,
     // 0 = errors only, 1 = info, 2 = debug
     // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)


### PR DESCRIPTION
## Summary

Bumps the `@browserbasehq/sdk` dependency to `^2.7.0` and removes `projectId` from all session creation bodies since it is no longer required by the API.

## Changes

### SDK version bump (5 files)
- `typescript/browserbase-reducto/package.json`: `"latest"` → `"^2.7.0"`
- `typescript/extend-browserbase/package.json`: `"^2.6.0"` → `"^2.7.0"`
- `typescript/manual-mfa-with-contexts/package.json`: `"^1.0.0"` → `"^2.7.0"`
- `typescript/playwright-mfa-handling/package.json`: `"^2.0.0"` → `"^2.7.0"`
- `typescript/playwright/basic-recaptcha/package.json`: `"latest"` → `"^2.7.0"`

### Remove `projectId` from session creation (16 files)
Removed `projectId` from:
- **`bb.sessions.create()`** calls: `context`, `playwright-mfa-handling`, `playwright/basic-recaptcha`, `proxies`
- **`bb.contexts.create()`** calls: `context`
- **`browserbaseSessionCreateParams`** (Stagehand config): `amazon-global-price-comparison`, `basic-caching`, `company-value-prop-generator`, `form-filling`, `gemini-3-flash`, `gemini-cua`, `gift-finder`, `manual-mfa-with-contexts`, `microsoft-cua`, `pickleball`, `proxies-weather`
- **Stagehand constructor top-level**: `sec-filing-research`

### Additional cleanup
- `playwright/basic-recaptcha`: Fixed SDK import from default to named (`import { Browserbase }`), removed `projectId` from `validateEnv()` function and error messages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a mechanical config/API-usage update across example templates; main risk is breaking runtime behavior if any environments still require `projectId` or if docs/env checks weren’t updated everywhere.
> 
> **Overview**
> Updates TypeScript templates to stop passing `projectId` when creating Browserbase contexts/sessions (including `Stagehand` `browserbaseSessionCreateParams`, direct `bb.sessions.create()` calls, and the SEC example’s Stagehand constructor), aligning examples with the updated API.
> 
> Bumps `@browserbasehq/sdk` to `^2.7.0` in several template `package.json`s, and adjusts the Playwright reCAPTCHA template to use the named `Browserbase` import and to only validate `BROWSERBASE_API_KEY` (dropping `BROWSERBASE_PROJECT_ID` references).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ada41506fc576b84b45a455734cbb6c9e9a8f6fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->