### PR TITLE
Bump JS SDK to v2.7 and Python SDK to v1.5, remove project_id from API calls

### DIFF
--- a/python/amazon-global-price-comparison/main.py
+++ b/python/amazon-global-price-comparison/main.py
@@ -114,7 +114,6 @@ async def get_products_for_country(
     print(f"Creating Browserbase session with {country.name} proxy...")
     session = await asyncio.to_thread(
         bb.sessions.create,
-        project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
         proxies=[
             {
                 "type": "browserbase",  # Use Browserbase's managed proxy infrastructure

--- a/python/amazon-global-price-comparison/pyproject.toml
+++ b/python/amazon-global-price-comparison/pyproject.toml
@@ -5,7 +5,7 @@ description = "Compare Amazon product prices across multiple countries using geo
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
-    "browserbase",
+    "browserbase>=1.5.0",
     "python-dotenv",
     "pydantic>=2.0.0",
     "stagehand",

--- a/python/basic-recaptcha/main.py
+++ b/python/basic-recaptcha/main.py
@@ -22,7 +22,6 @@ def main():
 
     # Create session with captcha solving enabled
     session = bb.sessions.create(
-        project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
         browser_settings={
             "solveCaptchas": solve_captchas,
         },

--- a/python/browserbase-reducto/pyproject.toml
+++ b/python/browserbase-reducto/pyproject.toml
@@ -5,7 +5,7 @@ description = "Download Apple's Q4 Financial Statement and Parse with Reducto us
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
-    "browserbase",
+    "browserbase>=1.5.0",
     "python-dotenv",
     "reductoai",
     "stagehand",

--- a/python/business-lookup/main.py
+++ b/python/business-lookup/main.py
@@ -27,9 +27,6 @@ async def main():
         project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
         model_name="openai/gpt-4.1",
         model_api_key=os.environ.get("OPENAI_API_KEY"),
-        browserbase_session_create_params={
-            "project_id": os.environ.get("BROWSERBASE_PROJECT_ID"),
-        },
         verbose=1,  # 0 = errors only, 1 = info, 2 = debug
         # (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
         # https://docs.stagehand.dev/configuration/logging

--- a/python/company-address-finder/main.py
+++ b/python/company-address-finder/main.py
@@ -80,7 +80,6 @@ async def process_company(company_name: str) -> CompanyData:
                 # (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
                 # https://docs.stagehand.dev/configuration/logging
                 browserbase_session_create_params={
-                    "project_id": os.environ.get("BROWSERBASE_PROJECT_ID"),
                     "region": "us-east-1",
                     "timeout": 900,
                     "browser_settings": {

--- a/python/context/main.py
+++ b/python/context/main.py
@@ -18,14 +18,13 @@ def create_session_context_id():
     print("Creating new Browserbase context...")
     # First create a context using Browserbase SDK to get a context ID.
     bb = Browserbase(api_key=os.environ.get("BROWSERBASE_API_KEY"))
-    context = bb.contexts.create(project_id=os.environ.get("BROWSERBASE_PROJECT_ID"))
+    context = bb.contexts.create()
 
     print(f"Created context ID: {context.id}")
 
     # Create a single session using the context ID to perform initial login.
     print("Creating session for initial login...")
     session = bb.sessions.create(
-        project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
         browser_settings={
             "context": {
                 "id": context.id,
@@ -124,7 +123,6 @@ def main():
     # persist: true ensures any new changes (cookies, cache) are saved back to context.
     bb = Browserbase(api_key=os.environ.get("BROWSERBASE_API_KEY"))
     session = bb.sessions.create(
-        project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
         browser_settings={
             "context": {
                 "id": context_id["id"],

--- a/python/extend-browserbase/pyproject.toml
+++ b/python/extend-browserbase/pyproject.toml
@@ -5,7 +5,7 @@ description = "Download expense receipts and parse with Extend AI using Stagehan
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
-    "browserbase>=1.4.0",
+    "browserbase>=1.5.0",
     "extend-ai>=1.0.0",
     "python-dotenv>=1.2.1",
     "stagehand>=3.5.0",

--- a/python/gemini-cua/main.py
+++ b/python/gemini-cua/main.py
@@ -41,7 +41,6 @@ async def main():
             "GOOGLE_API_KEY"
         ),  # this is the model stagehand uses in act, observe, extract (not agent)
         browserbase_session_create_params={
-            "project_id": os.environ.get("BROWSERBASE_PROJECT_ID"),
             "proxies": True,  # Using proxies will give the agent a better chance of success - requires Developer Plan or higher, comment out if you don't have access
             "region": "us-west-2",
             "browser_settings": {"block_ads": True, "viewport": {"width": 1288, "height": 711}},

--- a/python/manual-mfa-with-contexts/main.py
+++ b/python/manual-mfa-with-contexts/main.py
@@ -21,14 +21,13 @@ def create_session_with_context():
     """First session: Create context and login (with MFA)"""
     print("Creating new Browserbase context...")
 
-    context = bb.contexts.create(project_id=os.environ.get("BROWSERBASE_PROJECT_ID"))
+    context = bb.contexts.create()
 
     print(f"Context created: {context.id}")
     print("First session: Performing login with MFA...")
 
     # Create session with context
     session = bb.sessions.create(
-        project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
         browser_settings={
             "context": {
                 "id": context.id,
@@ -139,7 +138,6 @@ def reuse_context(context_id: str):
 
     # Create session with existing context
     session = bb.sessions.create(
-        project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
         browser_settings={
             "context": {
                 "id": context_id,

--- a/python/manual-mfa-with-contexts/requirements.txt
+++ b/python/manual-mfa-with-contexts/requirements.txt
@@ -1,4 +1,4 @@
-browserbase
+browserbase>=1.5.0
 python-dotenv
 pydantic
 stagehand

--- a/python/playwright-mfa-handling/.env.example
+++ b/python/playwright-mfa-handling/.env.example
@@ -1,3 +1,2 @@
 # Browserbase Configuration
-BROWSERBASE_PROJECT_ID=your_browserbase_project_id
 BROWSERBASE_API_KEY=your_browserbase_api_key

--- a/python/playwright-mfa-handling/README.md
+++ b/python/playwright-mfa-handling/README.md
@@ -75,7 +75,7 @@ has_failure = await page.locator('text="Login Failure"').is_visible()
 3. pip install .
 4. playwright install chromium
 5. cp .env.example .env
-6. Add required API keys/IDs to .env (BROWSERBASE_PROJECT_ID, BROWSERBASE_API_KEY)
+6. Add required API keys/IDs to .env (BROWSERBASE_API_KEY)
 7. python main.py
 
 ## EXPECTED OUTPUT
@@ -94,7 +94,7 @@ has_failure = await page.locator('text="Login Failure"').is_visible()
 
 - Dependency install errors: ensure pip install . completed
 - Missing Playwright browsers: run `playwright install chromium` after installing dependencies
-- Missing credentials: verify .env contains BROWSERBASE_PROJECT_ID and BROWSERBASE_API_KEY
+- Missing credentials: verify .env contains BROWSERBASE_API_KEY
 - TOTP code expiration: codes are valid for 30 seconds - if authentication fails, the script automatically retries with a fresh code
 - CDP connection issues: ensure stable internet connection for reliable Browserbase connection
 - Selector changes: if the demo site structure changes, Playwright selectors may need updating

--- a/python/playwright-mfa-handling/main.py
+++ b/python/playwright-mfa-handling/main.py
@@ -72,15 +72,12 @@ def generate_totp(secret: str, window: int = 0) -> str:
 async def create_browserbase_session() -> tuple[Browser, BrowserContext, Page, str]:
     """Create a Browserbase session and connect via CDP."""
     api_key = os.environ.get("BROWSERBASE_API_KEY")
-    project_id = os.environ.get("BROWSERBASE_PROJECT_ID")
 
     if not api_key:
         raise ValueError("BROWSERBASE_API_KEY environment variable is required")
-    if not project_id:
-        raise ValueError("BROWSERBASE_PROJECT_ID environment variable is required")
 
     bb = Browserbase(api_key=api_key)
-    session = bb.sessions.create(project_id=project_id)
+    session = bb.sessions.create()
 
     print(f"Session created: https://browserbase.com/sessions/{session.id}")
 

--- a/python/playwright-mfa-handling/main.py
+++ b/python/playwright-mfa-handling/main.py
@@ -241,7 +241,7 @@ if __name__ == "__main__":
     except Exception as err:
         print(f"\nError in MFA handling: {err}")
         print("\nCommon issues:")
-        print("  - Check .env file has BROWSERBASE_PROJECT_ID and BROWSERBASE_API_KEY")
+        print("  - Check .env file has BROWSERBASE_API_KEY")
         print("  - TOTP code may have expired (try running again)")
         print("  - Page structure may have changed")
         exit(1)

--- a/python/playwright-mfa-handling/pyproject.toml
+++ b/python/playwright-mfa-handling/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
     "playwright",
-    "browserbase",
+    "browserbase>=1.5.0",
     "python-dotenv",
 ]
 

--- a/python/playwright/basic-recaptcha/.env.example
+++ b/python/playwright/basic-recaptcha/.env.example
@@ -1,3 +1,2 @@
 # Browserbase credentials - Get these from https://www.browserbase.com/overview
 BROWSERBASE_API_KEY=your_browserbase_api_key_here
-BROWSERBASE_PROJECT_ID=your_browserbase_project_id_here

--- a/python/playwright/basic-recaptcha/README.md
+++ b/python/playwright/basic-recaptcha/README.md
@@ -43,7 +43,6 @@ For non-standard or custom captcha providers, you can specify CSS selectors to g
 
 ```python
 session = bb.sessions.create(
-    project_id=project_id,
     browser_settings={
         "solveCaptchas": True,
         "captchaImageSelector": "#custom-captcha-image-id",
@@ -64,7 +63,6 @@ If you want to disable automatic captcha solving, set `solveCaptchas: False` in 
 
 ```python
 session = bb.sessions.create(
-    project_id=project_id,
     browser_settings={"solveCaptchas": False},
 )
 ```
@@ -75,7 +73,6 @@ Enable proxies alongside CAPTCHA solving for better success rates:
 
 ```python
 session = bb.sessions.create(
-    project_id=project_id,
     browser_settings={"solveCaptchas": True},
     proxies=True,  # Enable Browserbase managed proxies
 )
@@ -88,7 +85,7 @@ session = bb.sessions.create(
 3. `source venv/bin/activate` # On Windows: `venv\Scripts\activate`
 4. `uv pip install .` # Install dependencies from pyproject.toml
 5. `playwright install chromium` # Install browser binaries
-6. `cp .env.example .env` # Add your Browserbase API key and Project ID to .env
+6. `cp .env.example .env` # Add your Browserbase API key to .env
 7. `python main.py`
 
 ## EXPECTED OUTPUT
@@ -106,7 +103,7 @@ session = bb.sessions.create(
 
 ## COMMON PITFALLS
 
-- Missing credentials: verify .env contains BROWSERBASE_PROJECT_ID and BROWSERBASE_API_KEY
+- Missing credentials: verify .env contains BROWSERBASE_API_KEY
 - Browser not installed: run `playwright install chromium` to install browser binaries
 - Captcha solving timeout: the template uses a 60-second timeout; increase if needed for complex CAPTCHAs
 - No browser context: ensure the Browserbase session was created successfully before connecting

--- a/python/playwright/basic-recaptcha/main.py
+++ b/python/playwright/basic-recaptcha/main.py
@@ -141,7 +141,7 @@ if __name__ == "__main__":
     except Exception as err:
         print(f"Application error: {err}")
         print("\nCommon issues:")
-        print("  - Check .env file has BROWSERBASE_PROJECT_ID and BROWSERBASE_API_KEY")
+        print("  - Check .env file has BROWSERBASE_API_KEY")
         print("  - Verify solveCaptchas is enabled (True by default)")
         print("  - Allow up to 60 seconds for CAPTCHA solving to complete")
         print("  - Enable proxies for higher success rates")

--- a/python/playwright/basic-recaptcha/main.py
+++ b/python/playwright/basic-recaptcha/main.py
@@ -16,32 +16,29 @@ DEMO_URL = "https://google.com/recaptcha/api2/demo"
 SOLVE_CAPTCHAS = True  # Set to False to disable automatic captcha solving
 
 
-def validate_env() -> tuple[str, str]:
+def validate_env() -> str:
     """Validate required environment variables before starting.
 
     Browserbase credentials are required to create browser sessions.
 
     Returns:
-        Tuple of (api_key, project_id)
+        The api_key string
 
     Raises:
         ValueError: If required environment variables are missing
     """
     api_key = os.environ.get("BROWSERBASE_API_KEY")
-    project_id = os.environ.get("BROWSERBASE_PROJECT_ID")
 
     if not api_key:
         raise ValueError("BROWSERBASE_API_KEY environment variable is required")
-    if not project_id:
-        raise ValueError("BROWSERBASE_PROJECT_ID environment variable is required")
 
-    return api_key, project_id
+    return api_key
 
 
 async def main():
     print("Starting Playwright + Browserbase reCAPTCHA Example...")
 
-    api_key, project_id = validate_env()
+    api_key = validate_env()
 
     # Initialize the Browserbase SDK client.
     bb = Browserbase(api_key=api_key)
@@ -52,7 +49,6 @@ async def main():
     # Docs: https://docs.browserbase.com/features/stealth-mode#captcha-solving
     print("Creating Browserbase session with captcha solving enabled...")
     session = bb.sessions.create(
-        project_id=project_id,
         browser_settings={"solveCaptchas": SOLVE_CAPTCHAS},
     )
 

--- a/python/playwright/basic-recaptcha/pyproject.toml
+++ b/python/playwright/basic-recaptcha/pyproject.toml
@@ -5,7 +5,7 @@ description = "Basic reCAPTCHA solving with Playwright and Browserbase"
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
-    "browserbase",
+    "browserbase>=1.5.0",
     "playwright",
     "python-dotenv",
 ]

--- a/python/proxies-weather/main.py
+++ b/python/proxies-weather/main.py
@@ -66,7 +66,6 @@ def get_weather_for_location(geolocation: GeolocationConfig) -> WeatherResult:
 
     # Create session with geolocation proxy
     session = bb.sessions.create(
-        project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
         proxies=[proxy_config],
     )
     session_id = session.id

--- a/python/proxies/main.py
+++ b/python/proxies/main.py
@@ -32,7 +32,6 @@ class GeoInfo(BaseModel):
 def create_session_with_built_in_proxies():
     # Use Browserbase's default proxy rotation for enhanced privacy and IP diversity.
     session = bb.sessions.create(
-        project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
         proxies=True,
     )
     return session
@@ -41,7 +40,6 @@ def create_session_with_built_in_proxies():
 def create_session_with_geo_location():
     # Route traffic through specific geographic location to test location-based restrictions.
     session = bb.sessions.create(
-        project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
         proxies=[
             {
                 "type": "browserbase",
@@ -59,7 +57,6 @@ def create_session_with_geo_location():
 def create_session_with_custom_proxies():
     # Use external proxy servers for custom routing or specific proxy requirements.
     session = bb.sessions.create(
-        project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
         proxies=[
             {
                 "type": "external",

--- a/typescript/amazon-global-price-comparison/index.ts
+++ b/typescript/amazon-global-price-comparison/index.ts
@@ -84,7 +84,6 @@ async function getProductsForCountry(
     // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
     // https://docs.stagehand.dev/configuration/logging
     browserbaseSessionCreateParams: {
-      projectId: process.env.BROWSERBASE_PROJECT_ID!,
       proxies: [
         {
           type: "browserbase", // Use Browserbase's managed proxy infrastructure for reliable geolocation routing

--- a/typescript/basic-caching/index.ts
+++ b/typescript/basic-caching/index.ts
@@ -20,9 +20,6 @@ async function runWithoutCache() {
     // https://docs.stagehand.dev/configuration/logging
     model: "google/gemini-2.5-flash",
     enableCaching: false,
-    browserbaseSessionCreateParams: {
-      projectId: process.env.BROWSERBASE_PROJECT_ID!,
-    },
   });
 
   await stagehand.init();
@@ -69,9 +66,6 @@ async function runWithCache() {
     model: "google/gemini-2.5-flash",
     enableCaching: true,
     cacheDir: CACHE_DIR,
-    browserbaseSessionCreateParams: {
-      projectId: process.env.BROWSERBASE_PROJECT_ID!,
-    },
   });
 
   await stagehand.init();

--- a/typescript/browserbase-reducto/package.json
+++ b/typescript/browserbase-reducto/package.json
@@ -8,7 +8,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@browserbasehq/sdk": "latest",
+    "@browserbasehq/sdk": "^2.7.0",
     "@browserbasehq/stagehand": "latest",
     "adm-zip": "latest",
     "dotenv": "latest",

--- a/typescript/company-value-prop-generator/index.ts
+++ b/typescript/company-value-prop-generator/index.ts
@@ -16,9 +16,6 @@ async function generateOneLiner(domain: string): Promise<string> {
     env: "BROWSERBASE",
     model: "openai/gpt-4.1",
     verbose: 0, //  0 = errors only, 1 = info, 2 = debug
-    browserbaseSessionCreateParams: {
-      projectId: process.env.BROWSERBASE_PROJECT_ID!,
-    },
   });
 
   try {

--- a/typescript/context/index.ts
+++ b/typescript/context/index.ts
@@ -10,7 +10,7 @@ async function createSessionContextID() {
   console.log("Creating new Browserbase context...");
   // First create a context using Browserbase SDK to get a context ID.
   const bb = new Browserbase({ apiKey: process.env.BROWSERBASE_API_KEY! });
-  const context = await bb.contexts.create({});
+  const context = await bb.contexts.create();
 
   console.log("Created context ID:", context.id);
 

--- a/typescript/context/index.ts
+++ b/typescript/context/index.ts
@@ -10,16 +10,13 @@ async function createSessionContextID() {
   console.log("Creating new Browserbase context...");
   // First create a context using Browserbase SDK to get a context ID.
   const bb = new Browserbase({ apiKey: process.env.BROWSERBASE_API_KEY! });
-  const context = await bb.contexts.create({
-    projectId: process.env.BROWSERBASE_PROJECT_ID!,
-  });
+  const context = await bb.contexts.create({});
 
   console.log("Created context ID:", context.id);
 
   // Create a single session using the context ID to perform initial login.
   console.log("Creating session for initial login...");
   const session = await bb.sessions.create({
-    projectId: process.env.BROWSERBASE_PROJECT_ID!,
     browserSettings: {
       context: {
         id: context.id,
@@ -96,7 +93,6 @@ async function main() {
     model: "openai/gpt-4.1",
     verbose: 1,
     browserbaseSessionCreateParams: {
-      projectId: process.env.BROWSERBASE_PROJECT_ID!,
       browserSettings: {
         context: {
           id: contextId.id,

--- a/typescript/extend-browserbase/package.json
+++ b/typescript/extend-browserbase/package.json
@@ -8,7 +8,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@browserbasehq/sdk": "^2.6.0",
+    "@browserbasehq/sdk": "^2.7.0",
     "@browserbasehq/stagehand": "^3.0.8",
     "adm-zip": "^0.5.16",
     "dotenv": "^17.2.4",

--- a/typescript/form-filling/index.ts
+++ b/typescript/form-filling/index.ts
@@ -21,9 +21,6 @@ async function main() {
     env: "BROWSERBASE",
     model: "openai/gpt-4.1",
     verbose: 1,
-    browserbaseSessionCreateParams: {
-      projectId: process.env.BROWSERBASE_PROJECT_ID!,
-    },
   });
 
   try {

--- a/typescript/gemini-3-flash/index.ts
+++ b/typescript/gemini-3-flash/index.ts
@@ -29,7 +29,6 @@ async function main() {
     // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
     // https://docs.stagehand.dev/configuration/logging
     browserbaseSessionCreateParams: {
-      projectId: process.env.BROWSERBASE_PROJECT_ID!,
       proxies: true, // Using proxies will give the agent a better chance of success - requires Developer Plan or higher, comment out if you don't have access
       region: "us-west-2",
       browserSettings: {

--- a/typescript/gemini-cua/index.ts
+++ b/typescript/gemini-cua/index.ts
@@ -29,7 +29,6 @@ async function main() {
     // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
     // https://docs.stagehand.dev/configuration/logging
     browserbaseSessionCreateParams: {
-      projectId: process.env.BROWSERBASE_PROJECT_ID!,
       proxies: true, // Using proxies will give the agent a better chance of success - requires Developer Plan or higher, comment out if you don't have access
       region: "us-west-2",
       browserSettings: {

--- a/typescript/gift-finder/index.ts
+++ b/typescript/gift-finder/index.ts
@@ -236,7 +236,6 @@ async function main(): Promise<void> {
       // https://docs.stagehand.dev/configuration/logging
       model: "openai/gpt-4.1",
       browserbaseSessionCreateParams: {
-        projectId: process.env.BROWSERBASE_PROJECT_ID!,
         // Proxies require Developer Plan or higher - comment in if you have a Developer Plan or higher
         //   proxies: [
         //     {

--- a/typescript/manual-mfa-with-contexts/index.ts
+++ b/typescript/manual-mfa-with-contexts/index.ts
@@ -28,7 +28,6 @@ async function createSessionWithContext() {
     // https://docs.stagehand.dev/configuration/logging
     model: "openai/gpt-4.1-mini",
     browserbaseSessionCreateParams: {
-      projectId: process.env.BROWSERBASE_PROJECT_ID!,
       browserSettings: {
         context: {
           id: context.id,
@@ -127,7 +126,6 @@ async function reuseContext(contextId: string) {
     // https://docs.stagehand.dev/configuration/logging
     model: "openai/gpt-4.1-mini",
     browserbaseSessionCreateParams: {
-      projectId: process.env.BROWSERBASE_PROJECT_ID!,
       browserSettings: {
         context: {
           id: contextId,

--- a/typescript/manual-mfa-with-contexts/package.json
+++ b/typescript/manual-mfa-with-contexts/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch index.ts"
   },
   "dependencies": {
-    "@browserbasehq/sdk": "^1.0.0",
+    "@browserbasehq/sdk": "^2.7.0",
     "@browserbasehq/stagehand": "^3.0.0",
     "dotenv": "^16.4.5",
     "zod": "^3.23.8"

--- a/typescript/microsoft-cua/index.ts
+++ b/typescript/microsoft-cua/index.ts
@@ -29,7 +29,6 @@ async function main() {
     // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
     // https://docs.stagehand.dev/configuration/logging
     browserbaseSessionCreateParams: {
-      projectId: process.env.BROWSERBASE_PROJECT_ID!,
       proxies: true, // Using proxies will give the agent a better chance of success - requires Developer Plan or higher, comment out if you don't have access
       region: "us-west-2",
       browserSettings: {

--- a/typescript/pickleball/index.ts
+++ b/typescript/pickleball/index.ts
@@ -401,7 +401,6 @@ async function bookTennisPaddleCourt() {
     // https://docs.stagehand.dev/configuration/logging
     model: "openai/gpt-4.1",
     browserbaseSessionCreateParams: {
-      projectId: process.env.BROWSERBASE_PROJECT_ID!,
       timeout: 900,
       region: "us-west-2",
     },

--- a/typescript/playwright-mfa-handling/.env.example
+++ b/typescript/playwright-mfa-handling/.env.example
@@ -1,3 +1,2 @@
 # Browserbase Configuration
-BROWSERBASE_PROJECT_ID=your_browserbase_project_id
 BROWSERBASE_API_KEY=your_browserbase_api_key

--- a/typescript/playwright-mfa-handling/README.md
+++ b/typescript/playwright-mfa-handling/README.md
@@ -61,7 +61,7 @@ const hasFailure = await page.locator('text="Login Failure"').isVisible();
 1. cd playwright-mfa-handling
 2. pnpm install
 3. cp .env.example .env
-4. Add required API keys/IDs to .env (BROWSERBASE_PROJECT_ID, BROWSERBASE_API_KEY)
+4. Add required API keys/IDs to .env (BROWSERBASE_API_KEY)
 5. pnpm start
 
 ## EXPECTED OUTPUT
@@ -79,7 +79,7 @@ const hasFailure = await page.locator('text="Login Failure"').isVisible();
 ## COMMON PITFALLS
 
 - Dependency install errors: ensure pnpm install completed
-- Missing credentials: verify .env contains BROWSERBASE_PROJECT_ID and BROWSERBASE_API_KEY
+- Missing credentials: verify .env contains BROWSERBASE_API_KEY
 - TOTP code expiration: codes are valid for 30 seconds - if authentication fails, the script automatically retries with a fresh code
 - CDP connection issues: ensure stable internet connection for reliable Browserbase connection
 - Selector changes: if the demo site structure changes, Playwright selectors may need updating

--- a/typescript/playwright-mfa-handling/index.ts
+++ b/typescript/playwright-mfa-handling/index.ts
@@ -73,10 +73,6 @@ async function createBrowserbaseSession(): Promise<BrowserSession> {
   if (!process.env.BROWSERBASE_API_KEY) {
     throw new Error("BROWSERBASE_API_KEY environment variable is required");
   }
-  if (!process.env.BROWSERBASE_PROJECT_ID) {
-    throw new Error("BROWSERBASE_PROJECT_ID environment variable is required");
-  }
-
   const bb = new Browserbase({ apiKey: process.env.BROWSERBASE_API_KEY });
 
   const session = await bb.sessions.create();
@@ -234,7 +230,7 @@ async function main() {
 main().catch((err) => {
   console.error("\nError in MFA handling:", err);
   console.error("\nCommon issues:");
-  console.error("  - Check .env file has BROWSERBASE_PROJECT_ID and BROWSERBASE_API_KEY");
+  console.error("  - Check .env file has BROWSERBASE_API_KEY");
   console.error("  - TOTP code may have expired (try running again)");
   console.error("  - Page structure may have changed");
   process.exit(1);

--- a/typescript/playwright-mfa-handling/index.ts
+++ b/typescript/playwright-mfa-handling/index.ts
@@ -79,9 +79,7 @@ async function createBrowserbaseSession(): Promise<BrowserSession> {
 
   const bb = new Browserbase({ apiKey: process.env.BROWSERBASE_API_KEY });
 
-  const session = await bb.sessions.create({
-    projectId: process.env.BROWSERBASE_PROJECT_ID,
-  });
+  const session = await bb.sessions.create({});
 
   console.log(`Session created: https://browserbase.com/sessions/${session.id}`);
 

--- a/typescript/playwright-mfa-handling/index.ts
+++ b/typescript/playwright-mfa-handling/index.ts
@@ -79,7 +79,7 @@ async function createBrowserbaseSession(): Promise<BrowserSession> {
 
   const bb = new Browserbase({ apiKey: process.env.BROWSERBASE_API_KEY });
 
-  const session = await bb.sessions.create({});
+  const session = await bb.sessions.create();
 
   console.log(`Session created: https://browserbase.com/sessions/${session.id}`);
 

--- a/typescript/playwright-mfa-handling/package.json
+++ b/typescript/playwright-mfa-handling/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@browserbasehq/sdk": "^2.0.0",
+    "@browserbasehq/sdk": "^2.7.0",
     "dotenv": "^16.0.0",
     "playwright-core": "^1.40.0"
   },

--- a/typescript/playwright/basic-recaptcha/.env.example
+++ b/typescript/playwright/basic-recaptcha/.env.example
@@ -1,3 +1,2 @@
 # Browserbase Configuration
-BROWSERBASE_PROJECT_ID=your_browserbase_project_id
 BROWSERBASE_API_KEY=your_browserbase_api_key

--- a/typescript/playwright/basic-recaptcha/README.md
+++ b/typescript/playwright/basic-recaptcha/README.md
@@ -70,7 +70,7 @@ browserSettings: {
 1. cd typescript/playwright/basic-recaptcha
 2. pnpm install
 3. cp .env.example .env
-4. Add your Browserbase API key and Project ID to .env
+4. Add your Browserbase API key to .env
 5. pnpm start
 
 ## EXPECTED OUTPUT
@@ -88,7 +88,7 @@ browserSettings: {
 
 ## COMMON PITFALLS
 
-- Missing credentials: verify .env contains BROWSERBASE_PROJECT_ID and BROWSERBASE_API_KEY
+- Missing credentials: verify .env contains BROWSERBASE_API_KEY
 - Captcha solving timeout: the template uses a 60-second timeout; increase if needed for complex CAPTCHAs
 - No browser context: ensure the Browserbase session was created successfully before connecting
 - Proxies not enabled: enable proxies in browserSettings for higher CAPTCHA solving success rates

--- a/typescript/playwright/basic-recaptcha/index.ts
+++ b/typescript/playwright/basic-recaptcha/index.ts
@@ -12,24 +12,20 @@ const SOLVE_CAPTCHAS = true; // Set to false to disable automatic captcha solvin
 
 // Validate required environment variables before starting.
 // Browserbase credentials are required to create browser sessions.
-function validateEnv(): { apiKey: string; projectId: string } {
+function validateEnv(): { apiKey: string } {
   const apiKey = process.env.BROWSERBASE_API_KEY;
-  const projectId = process.env.BROWSERBASE_PROJECT_ID;
 
   if (!apiKey) {
     throw new Error("BROWSERBASE_API_KEY environment variable is required");
   }
-  if (!projectId) {
-    throw new Error("BROWSERBASE_PROJECT_ID environment variable is required");
-  }
 
-  return { apiKey, projectId };
+  return { apiKey };
 }
 
 async function main() {
   console.log("Starting Playwright + Browserbase reCAPTCHA Example...");
 
-  const { apiKey, projectId } = validateEnv();
+  const { apiKey } = validateEnv();
 
   // Initialize the Browserbase SDK client.
   const bb = new Browserbase({ apiKey });
@@ -39,7 +35,6 @@ async function main() {
   // Docs: https://docs.browserbase.com/features/stealth-mode#captcha-solving
   console.log("Creating Browserbase session with captcha solving enabled...");
   const session = await bb.sessions.create({
-    projectId,
     browserSettings: {
       solveCaptchas: SOLVE_CAPTCHAS,
     },

--- a/typescript/playwright/basic-recaptcha/index.ts
+++ b/typescript/playwright/basic-recaptcha/index.ts
@@ -138,7 +138,7 @@ async function main() {
 main().catch((err) => {
   console.error("Application error:", err);
   console.error("\nCommon issues:");
-  console.error("  - Check .env file has BROWSERBASE_PROJECT_ID and BROWSERBASE_API_KEY");
+  console.error("  - Check .env file has BROWSERBASE_API_KEY");
   console.error("  - Verify solveCaptchas is enabled (true by default)");
   console.error("  - Allow up to 60 seconds for CAPTCHA solving to complete");
   console.error("  - Enable proxies for higher success rates");

--- a/typescript/playwright/basic-recaptcha/package.json
+++ b/typescript/playwright/basic-recaptcha/package.json
@@ -6,7 +6,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@browserbasehq/sdk": "latest",
+    "@browserbasehq/sdk": "^2.7.0",
     "playwright-core": "latest",
     "dotenv": "^16.4.7"
   },

--- a/typescript/proxies-weather/index.ts
+++ b/typescript/proxies-weather/index.ts
@@ -34,7 +34,6 @@ async function getWeatherForLocation(geolocation: GeolocationConfig): Promise<We
     // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
     // https://docs.stagehand.dev/configuration/logging
     browserbaseSessionCreateParams: {
-      projectId: process.env.BROWSERBASE_PROJECT_ID!,
       proxies: [
         {
           type: "browserbase", // Use Browserbase's managed proxy infrastructure for reliable geolocation routing

--- a/typescript/proxies/index.ts
+++ b/typescript/proxies/index.ts
@@ -13,7 +13,6 @@ const bb = new Browserbase({ apiKey: process.env.BROWSERBASE_API_KEY! });
 async function createSessionWithBuiltInProxies() {
   // Use Browserbase's default proxy rotation for enhanced privacy and IP diversity.
   const session = await bb.sessions.create({
-    projectId: process.env.BROWSERBASE_PROJECT_ID!,
     proxies: true, // Enables automatic proxy rotation across different IP addresses.
   });
   return session;
@@ -22,7 +21,6 @@ async function createSessionWithBuiltInProxies() {
 async function createSessionWithGeoLocation() {
   // Route traffic through specific geographic location to test location-based restrictions.
   const session = await bb.sessions.create({
-    projectId: process.env.BROWSERBASE_PROJECT_ID!,
     proxies: [
       {
         type: "browserbase", // Use Browserbase's managed proxy infrastructure.
@@ -40,7 +38,6 @@ async function createSessionWithGeoLocation() {
 async function createSessionWithCustomProxies() {
   // Use external proxy servers for custom routing or specific proxy requirements.
   const session = await bb.sessions.create({
-    projectId: process.env.BROWSERBASE_PROJECT_ID!,
     proxies: [
       {
         type: "external", // Connect to your own proxy server infrastructure.


### PR DESCRIPTION
- Bump @browserbasehq/sdk to ^2.7.0 in all TypeScript templates
- Bump browserbase to >=1.5.0 in all Python templates
- Remove projectId/project_id from bb.sessions.create(), bb.contexts.create(), and browserbaseSessionCreateParams/browserbase_session_create_params since it no longer needs to be explicitly set

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad template churn plus SDK version bumps could cause runtime breakages if any example still assumes `projectId/project_id` is required or if dependency resolution pulls incompatible versions.
> 
> **Overview**
> Updates Python and TypeScript templates to the newer Browserbase SDK APIs by **removing explicit `projectId/project_id` parameters** from `sessions.create()`, `contexts.create()`, and Stagehand `browserbaseSessionCreateParams`/`browserbase_session_create_params`.
> 
> Bumps dependencies to match the new behavior (`browserbase>=1.5.0` across Python templates and `@browserbasehq/sdk@^2.7.0` across TypeScript templates) and adjusts Playwright examples/docs/env samples to no longer require `BROWSERBASE_PROJECT_ID`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c25be661a486dbfd745d7ae58f1426e3cdd5077c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->