### PR TITLE
Fetch API demo - competitor pricing intelligence

### DIFF
--- a/typescript/fetch-competitive-pricing/.env.example
+++ b/typescript/fetch-competitive-pricing/.env.example
@@ -1,0 +1,7 @@
+# Browserbase API key (required)
+# Get yours at https://www.browserbase.com/settings
+BROWSERBASE_API_KEY=your-browserbase-api-key
+
+# Anthropic API key (required)
+# Get yours at https://console.anthropic.com
+ANTHROPIC_API_KEY=your-anthropic-api-key

--- a/typescript/fetch-competitive-pricing/.gitignore
+++ b/typescript/fetch-competitive-pricing/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.env
+analysis-summaries/
+*.md.bak
+.DS_Store

--- a/typescript/fetch-competitive-pricing/README.md
+++ b/typescript/fetch-competitive-pricing/README.md
@@ -1,0 +1,67 @@
+# Stagehand + Browserbase + Anthropic: Competitive Pricing Intelligence
+
+## AT A GLANCE
+
+- **Goal**: Fetch competitor pricing pages in parallel via the Browserbase Fetch API, extract structured pricing data with Claude Haiku, then aggregate everything into a polished competitive comparison report with Claude Opus.
+- **4-step pipeline**: Read URLs from `competitors.txt` → parallel fetch via Browserbase → parallel extraction with Claude Haiku → single aggregated report from Claude Opus.
+- **No browser session required**: Uses the Browserbase Fetch API (a lightweight HTTP endpoint) — no Playwright or Stagehand install needed, just an API key.
+- **Resilient by default**: Failed fetches are logged and skipped without aborting the run; each URL retries once automatically.
+- Docs → [Browserbase Fetch API](https://docs.browserbase.com/features/fetch) | [Claude Haiku](https://www.anthropic.com/claude/haiku) | [Claude Opus](https://www.anthropic.com/claude)
+
+## GLOSSARY
+
+- **Browserbase Fetch API**: A single HTTP endpoint that renders any URL in a headless browser and returns the resulting HTML — no SDK or session management required.
+  Docs → https://docs.browserbase.com/features/fetch
+- **Claude Haiku**: Anthropic's fastest, most cost-efficient Claude model. Used here to extract structured pricing JSON from each page in parallel.
+  Docs → https://www.anthropic.com/claude/haiku
+- **Claude Opus**: Anthropic's most capable Claude model. Used for the final aggregation step to produce a polished, analyst-quality markdown report.
+  Docs → https://www.anthropic.com/claude
+- **Promise.all**: JavaScript pattern for running async tasks concurrently — all fetches fire simultaneously, and all extractions run simultaneously.
+
+## QUICKSTART
+
+1.  cd typescript/fetch-competitive-pricing
+2.  npm install
+3.  cp .env.example .env
+4.  Add your `BROWSERBASE_API_KEY` and `ANTHROPIC_API_KEY` to .env
+5.  Edit `competitors.txt` — add one competitor pricing URL per line
+6.  npm start
+
+## EXPECTED OUTPUT
+
+- Reads URLs from `competitors.txt` and logs the count
+- Fetches all pages in parallel, logging per-URL progress and any failures
+- Runs Claude Haiku on each fetched page simultaneously to extract structured JSON (company name, tiers, prices, free-trial info, notes)
+- Passes all extracted JSON to Claude Opus to generate a markdown report
+- Saves the report to `analysis-summaries/<company1>-vs-<company2>-YYYY-MM-DD.md`
+- Logs fetch time, report generation time, and total token usage
+
+## COMMON PITFALLS
+
+- Missing credentials: verify .env contains `BROWSERBASE_API_KEY` and `ANTHROPIC_API_KEY`
+- Empty `competitors.txt`: add at least one URL (one per line; lines starting with `#` are comments)
+- Pricing not found: some pages require JavaScript-heavy rendering — the Fetch API handles this, but heavily gated pages (login walls) will return incomplete HTML
+- Haiku JSON parse errors: the model occasionally wraps JSON in markdown fences; the script strips these automatically, but malformed responses are skipped
+- Rate limits: reduce parallelism by batching URLs if you hit Anthropic or Browserbase rate limits
+- Find more information on your Browserbase dashboard → https://www.browserbase.com/sign-in
+
+## USE CASES
+
+• Competitive analysis: Monitor how competitors structure and price their tiers to inform your own pricing strategy.
+• Market research: Aggregate pricing across an entire category to identify positioning gaps and free-tier patterns.
+• Release prep: Run before major pricing changes to benchmark your new prices against the current competitive landscape.
+
+## NEXT STEPS
+
+• Schedule recurring runs: Set up a cron job or CI workflow to regenerate the report weekly and diff against the previous version.
+• Add change detection: Cache previous extractions and highlight tiers or prices that changed since the last run.
+• Expand the pipeline: Add more URLs to `competitors.txt` or swap Claude Opus for a custom summarisation prompt tailored to your industry.
+
+## HELPFUL RESOURCES
+
+📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+🎮 Browserbase: https://www.browserbase.com
+💡 Try it out: https://www.browserbase.com/playground
+🔧 Templates: https://www.browserbase.com/templates
+📧 Need help? support@browserbase.com
+💬 Discord: http://stagehand.dev/discord

--- a/typescript/fetch-competitive-pricing/competitors.txt
+++ b/typescript/fetch-competitive-pricing/competitors.txt
@@ -1,0 +1,8 @@
+# Competitor pricing pages — one URL per line
+# Lines starting with # or empty lines are ignored
+
+https://www.browserbase.com/pricing
+https://www.kernel.sh/pricing
+https://browser-use.com/pricing
+https://www.hyperbrowser.ai/pricing
+https://www.tinyfish.ai/pricing

--- a/typescript/fetch-competitive-pricing/index.ts
+++ b/typescript/fetch-competitive-pricing/index.ts
@@ -1,0 +1,311 @@
+// Stagehand + Browserbase + Anthropic: Competitive Pricing Intelligence - See README.md for full documentation
+
+import "dotenv/config";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import Anthropic from "@anthropic-ai/sdk";
+
+const BROWSERBASE_API_KEY = process.env.BROWSERBASE_API_KEY;
+if (!BROWSERBASE_API_KEY) {
+  console.error("Set BROWSERBASE_API_KEY to run this demo.");
+  process.exit(1);
+}
+
+const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
+if (!ANTHROPIC_API_KEY) {
+  console.error("Set ANTHROPIC_API_KEY to run this demo.");
+  process.exit(1);
+}
+
+const BB_FETCH_URL = "https://api.browserbase.com/v1/fetch";
+// const BB_FETCH_URL = "https://api.dev.browserbase.com/v1/fetch"; // dev only
+const COMPETITORS_FILE = "competitors.txt";
+const HTML_TRUNCATE = 80_000;
+
+interface FetchSuccess {
+  url: string;
+  html: string;
+  status: string | null;
+  title: string;
+}
+
+interface FetchFailure {
+  url: string;
+  error: string;
+}
+
+type FetchResult = FetchSuccess | FetchFailure;
+
+interface PricingTier {
+  name: string;
+  monthlyPrice: string;
+  annualPrice: string;
+  highlights: string[];
+}
+
+interface PricingData {
+  companyName: string;
+  pricingUrl: string;
+  tiers: PricingTier[];
+  freeTrialOrFreeTier: string;
+  notes: string;
+}
+
+// --- Step 1: Read URLs from competitors.txt ---
+
+async function readCompetitorUrls(): Promise<string[]> {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const filePath = join(__dirname, COMPETITORS_FILE);
+  const text = await readFile(filePath, "utf-8");
+  return text
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l && !l.startsWith("#"));
+}
+
+// --- Step 2: Fetch pages in parallel via Browserbase ---
+
+async function fetchPageOnce(url: string): Promise<FetchResult> {
+  const response = await fetch(BB_FETCH_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-bb-api-key": BROWSERBASE_API_KEY!,
+    },
+    body: JSON.stringify({ url, allowRedirects: true }),
+  });
+
+  if (!response.ok) {
+    return { url, error: `HTTP ${response.status} from Browserbase` };
+  }
+
+  const html = await response.text();
+  const status = response.headers.get("x-upstream-status");
+  const titleMatch = html.match(/<title[^>]*>(.*?)<\/title>/i);
+  const title = titleMatch ? titleMatch[1].trim() : url;
+
+  return { url, html, status, title };
+}
+
+async function fetchPage(url: string, index: number, total: number): Promise<FetchResult> {
+  console.log(`[${index}/${total}] Fetching ${url}...`);
+  try {
+    return await fetchPageOnce(url);
+  } catch (firstErr) {
+    console.log(`  [${index}/${total}] Fetch failed (${firstErr}), retrying...`);
+    try {
+      const result = await fetchPageOnce(url);
+      console.log(`  [${index}/${total}] Retry succeeded.`);
+      return result;
+    } catch (secondErr) {
+      return { url, error: String(secondErr) };
+    }
+  }
+}
+
+// --- Step 3: Extract pricing from each page with Claude Haiku (parallel) ---
+
+async function extractPricing(
+  result: FetchSuccess,
+  client: Anthropic,
+  index: number,
+  total: number
+): Promise<PricingData | null> {
+  console.log(`[${index}/${total}] Extracting pricing from ${result.title}...`);
+  try {
+    const message = await client.messages.create({
+      model: "claude-haiku-4-5-20251001",
+      max_tokens: 2048,
+      messages: [
+        {
+          role: "user",
+          content: `Extract pricing information from this web page and return ONLY valid JSON — no markdown fences, no explanation.
+
+The JSON must match this exact shape:
+{
+  "companyName": "string",
+  "pricingUrl": "string",
+  "tiers": [
+    {
+      "name": "string",
+      "monthlyPrice": "string",
+      "annualPrice": "string",
+      "highlights": ["string"]
+    }
+  ],
+  "freeTrialOrFreeTier": "string",
+  "notes": "string"
+}
+
+Rules:
+- monthlyPrice/annualPrice: use "$X/mo", "Free", "Custom", or "N/A"
+- highlights: top 3-5 bullet features per tier
+- freeTrialOrFreeTier: e.g. "14-day free trial", "Free tier up to 1k reqs/mo", "None"
+- notes: usage-based pricing, contact-sales requirements, anything notable
+- If a field is unknown, use "Unknown"
+
+Source URL: ${result.url}
+
+Page content:
+${result.html.slice(0, HTML_TRUNCATE)}`,
+        },
+      ],
+    });
+
+    const raw = message.content
+      .filter((b): b is Anthropic.TextBlock => b.type === "text")
+      .map((b) => b.text)
+      .join("");
+
+    // Strip markdown code fences if the model wrapped the JSON anyway
+    const text = raw.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/, "").trim();
+
+    return JSON.parse(text) as PricingData;
+  } catch (err) {
+    console.error(`  Failed to extract pricing for ${result.url}: ${err}`);
+    return null;
+  }
+}
+
+// --- Step 4: Aggregate into a report with Claude Opus (single call) ---
+
+async function generateReport(
+  pricingData: PricingData[],
+  client: Anthropic
+): Promise<string> {
+  console.log("\nGenerating competitive pricing report with Claude Opus 4.6...");
+
+  const dataJson = JSON.stringify(pricingData, null, 2);
+
+  const message = await client.messages.create({
+    model: "claude-opus-4-6",
+    max_tokens: 8192,
+    messages: [
+      {
+        role: "user",
+        content: `You are a competitive intelligence analyst. Using the structured pricing data below, produce a polished markdown pricing intelligence report.
+
+The report must include all of the following sections in order:
+
+## Executive Summary
+3-5 bullet points summarising the most important competitive takeaways.
+
+## Side-by-Side Comparison Table
+A markdown table comparing companies across their tiers, monthly prices, annual prices, and standout features.
+
+## Per-Competitor Deep Dive
+One ### subsection per company with a full tier breakdown (features, pricing, trial/free tier, notable caveats).
+
+## Competitive Insights
+Positioning gaps, pricing patterns, who has free tiers, who targets SMB vs enterprise, and any other strategic observations.
+
+Be factual and precise. Do not invent data that is not in the input.
+
+Pricing data:
+\`\`\`json
+${dataJson}
+\`\`\``,
+      },
+    ],
+  });
+
+  console.log(`Report token usage — input: ${message.usage.input_tokens.toLocaleString()}, output: ${message.usage.output_tokens.toLocaleString()}`);
+
+  return message.content
+    .filter((b): b is Anthropic.TextBlock => b.type === "text")
+    .map((b) => b.text)
+    .join("");
+}
+
+// --- Main ---
+
+function secs(ms: number) {
+  return (ms / 1000).toFixed(2) + "s";
+}
+
+async function main() {
+  const totalStart = Date.now();
+
+  // Read URLs
+  const urls = await readCompetitorUrls();
+  if (urls.length === 0) {
+    console.error(`No URLs found in ${COMPETITORS_FILE}. Add one URL per line.`);
+    process.exit(1);
+  }
+  console.log(`Found ${urls.length} competitor URL(s) in ${COMPETITORS_FILE}\n`);
+
+  // Parallel fetch
+  const fetchStart = Date.now();
+  const fetchResults = await Promise.all(
+    urls.map((url, i) => fetchPage(url, i + 1, urls.length))
+  );
+  const fetchMs = Date.now() - fetchStart;
+
+  const successes = fetchResults.filter((r): r is FetchSuccess => !("error" in r));
+  const failures = fetchResults.filter((r): r is FetchFailure => "error" in r);
+
+  if (failures.length > 0) {
+    console.log("\nFailed fetches (skipped):");
+    for (const f of failures) {
+      console.log(`  - ${f.url}: ${f.error}`);
+    }
+  }
+
+  if (successes.length === 0) {
+    console.error("\nAll fetches failed — nothing to process.");
+    process.exit(1);
+  }
+
+  console.log(`\nSuccessfully fetched ${successes.length}/${urls.length} pages — fetch took ${secs(fetchMs)}\n`);
+
+  // Parallel extraction
+  const client = new Anthropic({ apiKey: ANTHROPIC_API_KEY });
+
+  const extractionResults = await Promise.all(
+    successes.map((result, i) =>
+      extractPricing(result, client, i + 1, successes.length)
+    )
+  );
+
+  const pricingData = extractionResults.filter((d): d is PricingData => d !== null);
+
+  if (pricingData.length === 0) {
+    console.error("\nPricing extraction failed for all pages.");
+    process.exit(1);
+  }
+
+  console.log(`\nExtracted pricing data from ${pricingData.length}/${successes.length} pages\n`);
+
+  // Generate aggregated report
+  const reportStart = Date.now();
+  const report = await generateReport(pricingData, client);
+  const reportMs = Date.now() - reportStart;
+
+  // Build dynamic filename: "<company1>-vs-<company2>-...-YYYY-MM-DD.md"
+  const timestamp = new Date().toISOString().slice(0, 10);
+  const slug = pricingData
+    .slice(0, 3)
+    .map((d) => d.companyName.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, ""))
+    .join("-vs-");
+  const filename = `${slug}-${timestamp}.md`;
+
+  // Save report
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const outputDir = join(__dirname, "analysis-summaries");
+  await mkdir(outputDir, { recursive: true });
+  const outputPath = join(outputDir, filename);
+  await writeFile(outputPath, report, "utf-8");
+
+  console.log(`\nReport saved to: ${outputPath}`);
+  console.log(`Report size: ${report.length.toLocaleString()} characters`);
+  console.log(`\nTiming:`);
+  console.log(`  Fetch:   ${secs(fetchMs)}`);
+  console.log(`  Report:  ${secs(reportMs)}`);
+  console.log(`  Total:   ${secs(Date.now() - totalStart)}`);
+}
+
+main().catch((err) => {
+  console.error("Error:", err);
+  process.exit(1);
+});

--- a/typescript/fetch-competitive-pricing/package-lock.json
+++ b/typescript/fetch-competitive-pricing/package-lock.json
@@ -1,0 +1,664 @@
+{
+  "name": "bb-fetch-demo",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bb-fetch-demo",
+      "version": "1.0.0",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.78.0",
+        "@google/generative-ai": "^0.21.0",
+        "dotenv": "^17.3.1"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsx": "^4.21.0",
+        "typescript": "^5.9.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.78.0.tgz",
+      "integrity": "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.21.0.tgz",
+      "integrity": "sha512-7XhUbtnlkSEZK15kN3t+tzIMxsbKm/dSkKBFalj+20NvPKe1kBY7mR2P7vuijEn+f06z5+A8bVGKO0v39cr6Wg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
+      "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/typescript/fetch-competitive-pricing/package.json
+++ b/typescript/fetch-competitive-pricing/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "fetch-competitive-pricing",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.78.0",
+    "dotenv": "^17.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.0"
+  }
+}


### PR DESCRIPTION
Draft/ holding on merging til GA (need to update to prod API, convert to Python, etc.)

Using this demo for sales enablement walkthrough 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new standalone TypeScript demo that calls external Browserbase and Anthropic APIs and writes markdown output, but it is isolated to a new directory and does not modify existing application logic.
> 
> **Overview**
> Adds a new `typescript/fetch-competitive-pricing` demo that reads competitor pricing URLs, fetches each page in parallel via the Browserbase Fetch API (with retry/skip-on-failure), extracts structured tier/pricing JSON using Claude Haiku, and generates a consolidated markdown competitive report via Claude Opus.
> 
> Includes supporting project scaffolding (`package.json`/lock, `.env.example`, `.gitignore`, `competitors.txt`) and writes reports to `analysis-summaries/` with basic timing and token-usage logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2bf65a5a25618bff78b0b51686ddb1b482d6b0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->