### PR TITLE
Add getting-started-with-browserbase template (Search, Fetch, Sessions)

### DIFF
--- a/python/getting-started-with-browserbase/.env.example
+++ b/python/getting-started-with-browserbase/.env.example
@@ -1,5 +1,5 @@
 # Browserbase Configuration
-# Get your API key from: https://www.browserbase.com/overview
+# Get your API key from: https://www.browserbase.com/settings
 BROWSERBASE_API_KEY=your_browserbase_api_key
 
 # Optional — inferred from your API key if not provided

--- a/python/getting-started-with-browserbase/.env.example
+++ b/python/getting-started-with-browserbase/.env.example
@@ -1,0 +1,6 @@
+# Browserbase Configuration
+# Get your API key from: https://www.browserbase.com/overview
+BROWSERBASE_API_KEY=your_browserbase_api_key
+
+# Optional — inferred from your API key if not provided
+# BROWSERBASE_PROJECT_ID=your_browserbase_project_id

--- a/python/getting-started-with-browserbase/README.md
+++ b/python/getting-started-with-browserbase/README.md
@@ -4,7 +4,6 @@
 
 - Goal: demo all three core Browserbase capabilities in one script — Search API, Fetch API, and Browser Sessions.
 - No AI required: uses Playwright and the Browserbase SDK directly — no model API key needed.
-- Project ID optional: the API infers your project from your API key, so free-tier accounts only need `BROWSERBASE_API_KEY`.
 - Three demos in one: web search, lightweight HTTP fetch, and full cloud browser automation.
   Docs → https://docs.browserbase.com
 
@@ -27,7 +26,7 @@
 
 1. cd python/getting-started-with-browserbase
 2. cp .env.example .env
-3. Add BROWSERBASE_API_KEY to .env (get it from https://browserbase.com/overview)
+3. Add BROWSERBASE_API_KEY to .env (get it from https://browserbase.com/settings)
 4. `uv run python main.py`
 
 ### TypeScript
@@ -35,7 +34,7 @@
 1. cd typescript/getting-started-with-browserbase
 2. npm install
 3. cp .env.example .env
-4. Add BROWSERBASE_API_KEY to .env (get it from https://browserbase.com/overview)
+4. Add BROWSERBASE_API_KEY to .env (get it from https://browserbase.com/settings)
 5. npm start
 
 ## EXPECTED OUTPUT
@@ -53,8 +52,8 @@
 - Search API not enabled: if you get a 403, the Search API may need to be enabled on your account — check your dashboard
 - Fetch API size limit: responses over 1 MB return a 502 — use a browser session for large pages
 - Fetch API no JS: the Fetch API returns raw HTML without executing JavaScript — JS-rendered pages will be empty shells
-- Connection timeout: if CDP connection fails, check that your API key is valid at https://browserbase.com/overview
-- Wikipedia layout changes: if selectors like `input[name="search"]` stop working, Wikipedia may have updated their HTML — inspect the page and update selectors
+- Connection timeout: if CDP connection fails, check that your API key is valid at https://browserbase.com/settings
+- Wikipedia layout changes: if selectors like `input[name="search"]` stop working, Wikipedia may have updated their HTML — consider using Stagehand for self-healing selectors via AI
 - Playwright version mismatch: use `playwright-core` (not `playwright`) in TypeScript to avoid downloading unnecessary browser binaries — Browserbase provides the browser
 - Session not closing: always close the browser in a `finally` block to avoid leaked sessions
 - Find more information on your Browserbase dashboard → https://www.browserbase.com/sign-in

--- a/python/getting-started-with-browserbase/README.md
+++ b/python/getting-started-with-browserbase/README.md
@@ -1,0 +1,83 @@
+# Browserbase: Getting Started
+
+## AT A GLANCE
+
+- Goal: demo all three core Browserbase capabilities in one script — Search API, Fetch API, and Browser Sessions.
+- No AI required: uses Playwright and the Browserbase SDK directly — no model API key needed.
+- Project ID optional: the API infers your project from your API key, so free-tier accounts only need `BROWSERBASE_API_KEY`.
+- Three demos in one: web search, lightweight HTTP fetch, and full cloud browser automation.
+  Docs → https://docs.browserbase.com
+
+## GLOSSARY
+
+- Search API: run web searches through Browserbase — no browser session needed.
+  Docs → https://docs.browserbase.com/features/search
+- Fetch API: lightweight HTTP fetch through Browserbase infrastructure — no browser, no JS execution.
+  Docs → https://docs.browserbase.com/features/fetch
+- Session: a full cloud browser instance you connect to via CDP and control with Playwright.
+  Docs → https://docs.browserbase.com/introduction/getting-started
+- CDP (Chrome DevTools Protocol): the protocol Playwright uses to control the remote browser.
+  Docs → https://docs.browserbase.com/introduction/playwright
+- Playwright: browser automation library — `page.goto()`, `page.fill()`, `page.click()`, etc.
+  Docs → https://playwright.dev/docs/api/class-page
+
+## QUICKSTART
+
+### Python
+
+1. cd python/getting-started-with-browserbase
+2. cp .env.example .env
+3. Add BROWSERBASE_API_KEY to .env (get it from https://browserbase.com/overview)
+4. `uv run python main.py`
+
+### TypeScript
+
+1. cd typescript/getting-started-with-browserbase
+2. npm install
+3. cp .env.example .env
+4. Add BROWSERBASE_API_KEY to .env (get it from https://browserbase.com/overview)
+5. npm start
+
+## EXPECTED OUTPUT
+
+- Search API: searches the web for "Browser automation" and prints the top 5 results with titles and URLs
+- Fetch API: fetches a Wikipedia page (no browser), prints status code, content length, and page title
+- Browser Session: creates a cloud browser, connects via CDP, navigates to Wikipedia, searches, and extracts the article title, summary, and section headings
+- Prints a session replay link for the browser demo
+- Closes all resources cleanly
+
+## COMMON PITFALLS
+
+- Missing API key: verify .env contains BROWSERBASE_API_KEY — this is the only required credential
+- Project ID confusion: BROWSERBASE_PROJECT_ID is optional — the API infers it from your API key. You only need it if you have multiple projects
+- Search API not enabled: if you get a 403, the Search API may need to be enabled on your account — check your dashboard
+- Fetch API size limit: responses over 1 MB return a 502 — use a browser session for large pages
+- Fetch API no JS: the Fetch API returns raw HTML without executing JavaScript — JS-rendered pages will be empty shells
+- Connection timeout: if CDP connection fails, check that your API key is valid at https://browserbase.com/overview
+- Wikipedia layout changes: if selectors like `input[name="search"]` stop working, Wikipedia may have updated their HTML — inspect the page and update selectors
+- Playwright version mismatch: use `playwright-core` (not `playwright`) in TypeScript to avoid downloading unnecessary browser binaries — Browserbase provides the browser
+- Session not closing: always close the browser in a `finally` block to avoid leaked sessions
+- Find more information on your Browserbase dashboard → https://www.browserbase.com/sign-in
+
+## USE CASES
+
+• Getting started: understand all three Browserbase capabilities before deciding which to use in your project.
+• Quick prototyping: use Search to find targets, Fetch for static pages, Sessions for JS-heavy ones.
+• Cost-optimized scraping: Search and Fetch are cheaper than full browser sessions — use them when you can.
+• Building blocks: fork this template and build on whichever API fits your use case.
+
+## NEXT STEPS
+
+• Add AI extraction: swap in Stagehand for AI-powered `act()`, `extract()`, and `observe()` — see the other templates in this repo.
+• Chain the APIs: use Search to find URLs, Fetch to triage them, and Sessions for the ones that need a real browser.
+• Enable proxies: pass `proxies: true` in `bb.sessions.create()` or `bb.fetchAPI.create()` for residential proxy support.
+• Enable stealth mode: add `browserSettings: { advancedStealth: true, solveCaptchas: true }` to bypass bot detection.
+
+## HELPFUL RESOURCES
+
+📚 Browserbase Docs: https://docs.browserbase.com
+🎮 Browserbase: https://www.browserbase.com
+💡 Try it out: https://www.browserbase.com/playground
+🔧 Templates: https://www.browserbase.com/templates
+📧 Need help? support@browserbase.com
+💬 Discord: http://stagehand.dev/discord

--- a/python/getting-started-with-browserbase/main.py
+++ b/python/getting-started-with-browserbase/main.py
@@ -21,17 +21,6 @@ SEARCH_QUERY = "Browser automation"
 # =========================================
 
 
-def get_api_key() -> str:
-    """Validate that BROWSERBASE_API_KEY is set."""
-    api_key = os.environ.get("BROWSERBASE_API_KEY")
-    if not api_key:
-        raise RuntimeError(
-            "Missing BROWSERBASE_API_KEY environment variable.\n"
-            "Get your API key from: https://www.browserbase.com/overview"
-        )
-    return api_key
-
-
 # ---------------------------------------------------------------------------
 # 1. Search API — run a web search, no browser needed
 # ---------------------------------------------------------------------------
@@ -97,7 +86,7 @@ def demo_browser_session(bb: Browserbase) -> None:
     with sync_playwright() as pw:
         browser = pw.chromium.connect_over_cdp(session.connect_url)
         context = browser.contexts[0]
-        page = context.pages[0] if context else None
+        page = context.pages[0] if context.pages else None
 
         if not page:
             browser.close()
@@ -147,7 +136,7 @@ def main() -> None:
     print("=" * 50)
     print("Demos: Search API, Fetch API, and Browser Sessions\n")
 
-    bb = Browserbase(api_key=get_api_key())
+    bb = Browserbase(api_key=os.environ.get("BROWSERBASE_API_KEY"))
 
     demo_search_api(bb)
     demo_fetch_api(bb)
@@ -165,7 +154,7 @@ if __name__ == "__main__":
         print(f"Error: {err}")
         print("\nTroubleshooting:")
         print("  1. Check your .env file has BROWSERBASE_API_KEY")
-        print("  2. Verify your API key at https://browserbase.com/overview")
+        print("  2. Verify your API key at https://browserbase.com/settings")
         print("  3. View session logs at https://browserbase.com/sessions")
         print("Docs: https://docs.browserbase.com")
         exit(1)

--- a/python/getting-started-with-browserbase/main.py
+++ b/python/getting-started-with-browserbase/main.py
@@ -1,0 +1,171 @@
+# Browserbase: Getting Started
+# See README.md for full documentation
+#
+# Demos the three core Browserbase capabilities:
+#   1. Search API  — web search without a browser
+#   2. Fetch API   — lightweight HTTP fetch through Browserbase infra
+#   3. Sessions    — full cloud browser controlled via Playwright + CDP
+
+import os
+import re
+
+from browserbase import Browserbase
+from dotenv import load_dotenv
+from playwright.sync_api import sync_playwright
+
+load_dotenv()
+
+# ============= CONFIGURATION =============
+# The topic to search, fetch, and browse
+SEARCH_QUERY = "Browser automation"
+# =========================================
+
+
+def get_api_key() -> str:
+    """Validate that BROWSERBASE_API_KEY is set."""
+    api_key = os.environ.get("BROWSERBASE_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "Missing BROWSERBASE_API_KEY environment variable.\n"
+            "Get your API key from: https://www.browserbase.com/overview"
+        )
+    return api_key
+
+
+# ---------------------------------------------------------------------------
+# 1. Search API — run a web search, no browser needed
+# ---------------------------------------------------------------------------
+
+
+def demo_search_api(bb: Browserbase) -> None:
+    print("\n" + "=" * 50)
+    print("1. SEARCH API")
+    print("=" * 50)
+    print(f'Searching the web for "{SEARCH_QUERY}"...')
+
+    response = bb.search.web(query=SEARCH_QUERY, num_results=5)
+
+    print(f"\nTop {len(response.results)} results:")
+    for result in response.results:
+        print(f"  - {result.title}")
+        print(f"    {result.url}")
+
+
+# ---------------------------------------------------------------------------
+# 2. Fetch API — lightweight HTTP fetch, no browser session needed
+# ---------------------------------------------------------------------------
+
+
+def demo_fetch_api(bb: Browserbase) -> None:
+    print("\n" + "=" * 50)
+    print("2. FETCH API")
+    print("=" * 50)
+
+    target_url = "https://en.wikipedia.org/wiki/Browser_automation"
+    print(f"Fetching {target_url} (no browser)...")
+
+    response = bb.fetch_api.create(url=target_url, allow_redirects=True)
+
+    print(f"  Status: {response.status_code}")
+    print(f"  Content length: {len(response.content)} chars")
+
+    # Pull the title out of the raw HTML
+    title_match = re.search(r"<title[^>]*>([^<]+)</title>", response.content, re.IGNORECASE)
+    title = title_match.group(1).strip() if title_match else "Unknown"
+    print(f"  Page title: {title}")
+
+
+# ---------------------------------------------------------------------------
+# 3. Sessions + Playwright — full cloud browser via CDP
+# ---------------------------------------------------------------------------
+
+
+def demo_browser_session(bb: Browserbase) -> None:
+    print("\n" + "=" * 50)
+    print("3. BROWSER SESSION (Playwright + CDP)")
+    print("=" * 50)
+
+    # Create a session
+    print("Creating a Browserbase session...")
+    session = bb.sessions.create()
+
+    print(f"Session ID: {session.id}")
+    print(f"Live view: https://browserbase.com/sessions/{session.id}")
+
+    # Connect via CDP
+    print("Connecting to browser via CDP...")
+    with sync_playwright() as pw:
+        browser = pw.chromium.connect_over_cdp(session.connect_url)
+        context = browser.contexts[0]
+        page = context.pages[0] if context else None
+
+        if not page:
+            browser.close()
+            raise RuntimeError("No page found — session may have failed to start.")
+
+        print("Connected!")
+
+        try:
+            # Navigate to Wikipedia
+            print(f'\nSearching Wikipedia for "{SEARCH_QUERY}"...')
+            page.goto("https://www.wikipedia.org/", wait_until="domcontentloaded", timeout=30000)
+
+            # Search
+            page.fill('input[name="search"]', SEARCH_QUERY)
+            page.click('button[type="submit"]')
+            page.wait_for_load_state("domcontentloaded")
+            page.wait_for_selector("h1", state="visible", timeout=10000)
+
+            # Extract content
+            title = page.text_content("h1") or "No title found"
+            summary_text = page.locator(
+                "#mw-content-text p:not(.mw-empty-elt)"
+            ).first.text_content()
+            summary = (summary_text or "").strip()
+            headings = page.locator("#mw-content-text .mw-heading2 h2").all_text_contents()
+            sections = [h.replace("[edit]", "").strip() for h in headings if h.strip()]
+
+            print(f"\n  Title: {title}")
+            print(f"  Summary: {summary}")
+            print(f"  Sections ({len(sections)}):")
+            for section in sections:
+                print(f"    - {section}")
+            print(f"\n  Session replay: https://browserbase.com/sessions/{session.id}")
+        finally:
+            browser.close()
+            print("  Browser closed.")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    print("=" * 50)
+    print("GETTING STARTED WITH BROWSERBASE")
+    print("=" * 50)
+    print("Demos: Search API, Fetch API, and Browser Sessions\n")
+
+    bb = Browserbase(api_key=get_api_key())
+
+    demo_search_api(bb)
+    demo_fetch_api(bb)
+    demo_browser_session(bb)
+
+    print("\n" + "=" * 50)
+    print("ALL DEMOS COMPLETE!")
+    print("=" * 50)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as err:
+        print(f"Error: {err}")
+        print("\nTroubleshooting:")
+        print("  1. Check your .env file has BROWSERBASE_API_KEY")
+        print("  2. Verify your API key at https://browserbase.com/overview")
+        print("  3. View session logs at https://browserbase.com/sessions")
+        print("Docs: https://docs.browserbase.com")
+        exit(1)

--- a/python/getting-started-with-browserbase/pyproject.toml
+++ b/python/getting-started-with-browserbase/pyproject.toml
@@ -1,0 +1,33 @@
+[project]
+name = "getting-started-with-browserbase"
+version = "1.0.0"
+description = "Browserbase + Playwright: Getting Started — connect to a cloud browser, navigate, and extract data"
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = [
+    "browserbase",
+    "playwright",
+    "python-dotenv",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "black>=23.0.0",
+    "ruff>=0.1.0",
+]
+
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.black]
+line-length = 100
+target-version = ['py39', 'py310', 'py311']
+
+[tool.ruff]
+line-length = 100
+target-version = "py39"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "W"]

--- a/typescript/getting-started-with-browserbase/.env.example
+++ b/typescript/getting-started-with-browserbase/.env.example
@@ -1,5 +1,5 @@
 # Browserbase Configuration
-# Get your API key from: https://www.browserbase.com/overview
+# Get your API key from: https://www.browserbase.com/settings
 BROWSERBASE_API_KEY=your_browserbase_api_key
 
 # Optional — inferred from your API key if not provided

--- a/typescript/getting-started-with-browserbase/.env.example
+++ b/typescript/getting-started-with-browserbase/.env.example
@@ -1,0 +1,6 @@
+# Browserbase Configuration
+# Get your API key from: https://www.browserbase.com/overview
+BROWSERBASE_API_KEY=your_browserbase_api_key
+
+# Optional — inferred from your API key if not provided
+# BROWSERBASE_PROJECT_ID=your_browserbase_project_id

--- a/typescript/getting-started-with-browserbase/README.md
+++ b/typescript/getting-started-with-browserbase/README.md
@@ -4,7 +4,6 @@
 
 - Goal: demo all three core Browserbase capabilities in one script — Search API, Fetch API, and Browser Sessions.
 - No AI required: uses Playwright and the Browserbase SDK directly — no model API key needed.
-- Project ID optional: the API infers your project from your API key, so free-tier accounts only need `BROWSERBASE_API_KEY`.
 - Three demos in one: web search, lightweight HTTP fetch, and full cloud browser automation.
   Docs → https://docs.browserbase.com
 
@@ -27,7 +26,7 @@
 
 1. cd python/getting-started-with-browserbase
 2. cp .env.example .env
-3. Add BROWSERBASE_API_KEY to .env (get it from https://browserbase.com/overview)
+3. Add BROWSERBASE_API_KEY to .env (get it from https://browserbase.com/settings)
 4. `uv run python main.py`
 
 ### TypeScript
@@ -35,7 +34,7 @@
 1. cd typescript/getting-started-with-browserbase
 2. npm install
 3. cp .env.example .env
-4. Add BROWSERBASE_API_KEY to .env (get it from https://browserbase.com/overview)
+4. Add BROWSERBASE_API_KEY to .env (get it from https://browserbase.com/settings)
 5. npm start
 
 ## EXPECTED OUTPUT
@@ -53,8 +52,8 @@
 - Search API not enabled: if you get a 403, the Search API may need to be enabled on your account — check your dashboard
 - Fetch API size limit: responses over 1 MB return a 502 — use a browser session for large pages
 - Fetch API no JS: the Fetch API returns raw HTML without executing JavaScript — JS-rendered pages will be empty shells
-- Connection timeout: if CDP connection fails, check that your API key is valid at https://browserbase.com/overview
-- Wikipedia layout changes: if selectors like `input[name="search"]` stop working, Wikipedia may have updated their HTML — inspect the page and update selectors
+- Connection timeout: if CDP connection fails, check that your API key is valid at https://browserbase.com/settings
+- Wikipedia layout changes: if selectors like `input[name="search"]` stop working, Wikipedia may have updated their HTML — consider using Stagehand for self-healing selectors via AI
 - Playwright version mismatch: use `playwright-core` (not `playwright`) in TypeScript to avoid downloading unnecessary browser binaries — Browserbase provides the browser
 - Session not closing: always close the browser in a `finally` block to avoid leaked sessions
 - Find more information on your Browserbase dashboard → https://www.browserbase.com/sign-in

--- a/typescript/getting-started-with-browserbase/README.md
+++ b/typescript/getting-started-with-browserbase/README.md
@@ -1,0 +1,83 @@
+# Browserbase: Getting Started
+
+## AT A GLANCE
+
+- Goal: demo all three core Browserbase capabilities in one script — Search API, Fetch API, and Browser Sessions.
+- No AI required: uses Playwright and the Browserbase SDK directly — no model API key needed.
+- Project ID optional: the API infers your project from your API key, so free-tier accounts only need `BROWSERBASE_API_KEY`.
+- Three demos in one: web search, lightweight HTTP fetch, and full cloud browser automation.
+  Docs → https://docs.browserbase.com
+
+## GLOSSARY
+
+- Search API: run web searches through Browserbase — no browser session needed.
+  Docs → https://docs.browserbase.com/features/search
+- Fetch API: lightweight HTTP fetch through Browserbase infrastructure — no browser, no JS execution.
+  Docs → https://docs.browserbase.com/features/fetch
+- Session: a full cloud browser instance you connect to via CDP and control with Playwright.
+  Docs → https://docs.browserbase.com/introduction/getting-started
+- CDP (Chrome DevTools Protocol): the protocol Playwright uses to control the remote browser.
+  Docs → https://docs.browserbase.com/introduction/playwright
+- Playwright: browser automation library — `page.goto()`, `page.fill()`, `page.click()`, etc.
+  Docs → https://playwright.dev/docs/api/class-page
+
+## QUICKSTART
+
+### Python
+
+1. cd python/getting-started-with-browserbase
+2. cp .env.example .env
+3. Add BROWSERBASE_API_KEY to .env (get it from https://browserbase.com/overview)
+4. `uv run python main.py`
+
+### TypeScript
+
+1. cd typescript/getting-started-with-browserbase
+2. npm install
+3. cp .env.example .env
+4. Add BROWSERBASE_API_KEY to .env (get it from https://browserbase.com/overview)
+5. npm start
+
+## EXPECTED OUTPUT
+
+- Search API: searches the web for "Browser automation" and prints the top 5 results with titles and URLs
+- Fetch API: fetches a Wikipedia page (no browser), prints status code, content length, and page title
+- Browser Session: creates a cloud browser, connects via CDP, navigates to Wikipedia, searches, and extracts the article title, summary, and section headings
+- Prints a session replay link for the browser demo
+- Closes all resources cleanly
+
+## COMMON PITFALLS
+
+- Missing API key: verify .env contains BROWSERBASE_API_KEY — this is the only required credential
+- Project ID confusion: BROWSERBASE_PROJECT_ID is optional — the API infers it from your API key. You only need it if you have multiple projects
+- Search API not enabled: if you get a 403, the Search API may need to be enabled on your account — check your dashboard
+- Fetch API size limit: responses over 1 MB return a 502 — use a browser session for large pages
+- Fetch API no JS: the Fetch API returns raw HTML without executing JavaScript — JS-rendered pages will be empty shells
+- Connection timeout: if CDP connection fails, check that your API key is valid at https://browserbase.com/overview
+- Wikipedia layout changes: if selectors like `input[name="search"]` stop working, Wikipedia may have updated their HTML — inspect the page and update selectors
+- Playwright version mismatch: use `playwright-core` (not `playwright`) in TypeScript to avoid downloading unnecessary browser binaries — Browserbase provides the browser
+- Session not closing: always close the browser in a `finally` block to avoid leaked sessions
+- Find more information on your Browserbase dashboard → https://www.browserbase.com/sign-in
+
+## USE CASES
+
+• Getting started: understand all three Browserbase capabilities before deciding which to use in your project.
+• Quick prototyping: use Search to find targets, Fetch for static pages, Sessions for JS-heavy ones.
+• Cost-optimized scraping: Search and Fetch are cheaper than full browser sessions — use them when you can.
+• Building blocks: fork this template and build on whichever API fits your use case.
+
+## NEXT STEPS
+
+• Add AI extraction: swap in Stagehand for AI-powered `act()`, `extract()`, and `observe()` — see the other templates in this repo.
+• Chain the APIs: use Search to find URLs, Fetch to triage them, and Sessions for the ones that need a real browser.
+• Enable proxies: pass `proxies: true` in `bb.sessions.create()` or `bb.fetchAPI.create()` for residential proxy support.
+• Enable stealth mode: add `browserSettings: { advancedStealth: true, solveCaptchas: true }` to bypass bot detection.
+
+## HELPFUL RESOURCES
+
+📚 Browserbase Docs: https://docs.browserbase.com
+🎮 Browserbase: https://www.browserbase.com
+💡 Try it out: https://www.browserbase.com/playground
+🔧 Templates: https://www.browserbase.com/templates
+📧 Need help? support@browserbase.com
+💬 Discord: http://stagehand.dev/discord

--- a/typescript/getting-started-with-browserbase/index.ts
+++ b/typescript/getting-started-with-browserbase/index.ts
@@ -14,17 +14,6 @@ import "dotenv/config";
 const SEARCH_QUERY = "Browser automation";
 // =========================================
 
-function getApiKey(): string {
-  const apiKey = process.env.BROWSERBASE_API_KEY;
-  if (!apiKey) {
-    throw new Error(
-      "Missing BROWSERBASE_API_KEY environment variable.\n" +
-        "Get your API key from: https://www.browserbase.com/overview",
-    );
-  }
-  return apiKey;
-}
-
 // ---------------------------------------------------------------------------
 // 1. Search API — run a web search, no browser needed
 // ---------------------------------------------------------------------------
@@ -57,7 +46,7 @@ async function demoFetchApi(bb: Browserbase): Promise<void> {
   console.log("=".repeat(50));
 
   const targetUrl = "https://en.wikipedia.org/wiki/Browser_automation";
-  console.log(`Fetching ${targetUrl} (no browser...`);
+  console.log(`Fetching ${targetUrl} (no browser)...`);
 
   const response = await bb.fetchAPI.create({ url: targetUrl, allowRedirects: true });
 
@@ -146,7 +135,7 @@ async function main(): Promise<void> {
   console.log("=".repeat(50));
   console.log("Demos: Search API, Fetch API, and Browser Sessions\n");
 
-  const bb = new Browserbase({ apiKey: getApiKey() });
+  const bb = new Browserbase({ apiKey: process.env.BROWSERBASE_API_KEY });
 
   await demoSearchApi(bb);
   await demoFetchApi(bb);
@@ -161,7 +150,7 @@ main().catch((error) => {
   console.error("Error:", error.message);
   console.error("\nTroubleshooting:");
   console.error("  1. Check your .env file has BROWSERBASE_API_KEY");
-  console.error("  2. Verify your API key at https://browserbase.com/overview");
+  console.error("  2. Verify your API key at https://browserbase.com/settings");
   console.error("  3. View session logs at https://browserbase.com/sessions");
   console.error("Docs: https://docs.browserbase.com");
   process.exit(1);

--- a/typescript/getting-started-with-browserbase/index.ts
+++ b/typescript/getting-started-with-browserbase/index.ts
@@ -1,0 +1,168 @@
+// Browserbase: Getting Started - See README.md for full documentation
+//
+// Demos the three core Browserbase capabilities:
+//   1. Search API  — web search without a browser
+//   2. Fetch API   — lightweight HTTP fetch through Browserbase infra
+//   3. Sessions    — full cloud browser controlled via Playwright + CDP
+
+import { chromium } from "playwright-core";
+import Browserbase from "@browserbasehq/sdk";
+import "dotenv/config";
+
+// ============= CONFIGURATION =============
+// The topic to search, fetch, and browse
+const SEARCH_QUERY = "Browser automation";
+// =========================================
+
+function getApiKey(): string {
+  const apiKey = process.env.BROWSERBASE_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "Missing BROWSERBASE_API_KEY environment variable.\n" +
+        "Get your API key from: https://www.browserbase.com/overview",
+    );
+  }
+  return apiKey;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Search API — run a web search, no browser needed
+// ---------------------------------------------------------------------------
+
+async function demoSearchApi(bb: Browserbase): Promise<void> {
+  console.log("\n" + "=".repeat(50));
+  console.log("1. SEARCH API");
+  console.log("=".repeat(50));
+  console.log(`Searching the web for "${SEARCH_QUERY}"...`);
+
+  const response = await bb.search.web({
+    query: SEARCH_QUERY,
+    numResults: 5,
+  });
+
+  console.log(`\nTop ${response.results.length} results:`);
+  for (const result of response.results) {
+    console.log(`  - ${result.title}`);
+    console.log(`    ${result.url}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Fetch API — lightweight HTTP fetch, no browser session needed
+// ---------------------------------------------------------------------------
+
+async function demoFetchApi(bb: Browserbase): Promise<void> {
+  console.log("\n" + "=".repeat(50));
+  console.log("2. FETCH API");
+  console.log("=".repeat(50));
+
+  const targetUrl = "https://en.wikipedia.org/wiki/Browser_automation";
+  console.log(`Fetching ${targetUrl} (no browser...`);
+
+  const response = await bb.fetchAPI.create({ url: targetUrl, allowRedirects: true });
+
+  console.log(`  Status: ${response.statusCode}`);
+  console.log(`  Content length: ${response.content.length} chars`);
+
+  // Pull the title out of the raw HTML
+  const titleMatch = response.content.match(/<title[^>]*>([^<]+)<\/title>/i);
+  const title = titleMatch ? titleMatch[1].trim() : "Unknown";
+  console.log(`  Page title: ${title}`);
+}
+
+// ---------------------------------------------------------------------------
+// 3. Sessions + Playwright — full cloud browser via CDP
+// ---------------------------------------------------------------------------
+
+async function demoBrowserSession(bb: Browserbase): Promise<void> {
+  console.log("\n" + "=".repeat(50));
+  console.log("3. BROWSER SESSION (Playwright + CDP)");
+  console.log("=".repeat(50));
+
+  // Create a session
+  console.log("Creating a Browserbase session...");
+  const session = await bb.sessions.create({});
+
+  console.log(`Session ID: ${session.id}`);
+  console.log(`Live view: https://browserbase.com/sessions/${session.id}`);
+
+  // Connect via CDP
+  console.log("Connecting to browser via CDP...");
+  const browser = await chromium.connectOverCDP(session.connectUrl);
+  const page = browser.contexts()[0]?.pages()[0];
+
+  if (!page) {
+    await browser.close();
+    throw new Error("No page found — session may have failed to start.");
+  }
+  console.log("Connected!");
+
+  try {
+    // Navigate to Wikipedia
+    console.log(`\nSearching Wikipedia for "${SEARCH_QUERY}"...`);
+    await page.goto("https://www.wikipedia.org/", {
+      waitUntil: "domcontentloaded",
+      timeout: 30000,
+    });
+
+    // Search
+    await page.fill('input[name="search"]', SEARCH_QUERY);
+    await page.click('button[type="submit"]');
+    await page.waitForLoadState("domcontentloaded");
+    await page.waitForSelector("h1", { state: "visible", timeout: 10000 });
+
+    // Extract content
+    const title = (await page.textContent("h1")) || "No title found";
+    const summary = await page
+      .locator("#mw-content-text p:not(.mw-empty-elt)")
+      .first()
+      .textContent()
+      .then((text) => (text || "").trim());
+    const sections = await page
+      .locator("#mw-content-text .mw-heading2 h2")
+      .allTextContents()
+      .then((headings) => headings.map((h) => h.replace("[edit]", "").trim()).filter(Boolean));
+
+    console.log(`\n  Title: ${title}`);
+    console.log(`  Summary: ${summary}`);
+    console.log(`  Sections (${sections.length}):`);
+    for (const section of sections) {
+      console.log(`    - ${section}`);
+    }
+    console.log(`\n  Session replay: https://browserbase.com/sessions/${session.id}`);
+  } finally {
+    await browser.close();
+    console.log("  Browser closed.");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  console.log("=".repeat(50));
+  console.log("GETTING STARTED WITH BROWSERBASE");
+  console.log("=".repeat(50));
+  console.log("Demos: Search API, Fetch API, and Browser Sessions\n");
+
+  const bb = new Browserbase({ apiKey: getApiKey() });
+
+  await demoSearchApi(bb);
+  await demoFetchApi(bb);
+  await demoBrowserSession(bb);
+
+  console.log("\n" + "=".repeat(50));
+  console.log("ALL DEMOS COMPLETE!");
+  console.log("=".repeat(50));
+}
+
+main().catch((error) => {
+  console.error("Error:", error.message);
+  console.error("\nTroubleshooting:");
+  console.error("  1. Check your .env file has BROWSERBASE_API_KEY");
+  console.error("  2. Verify your API key at https://browserbase.com/overview");
+  console.error("  3. View session logs at https://browserbase.com/sessions");
+  console.error("Docs: https://docs.browserbase.com");
+  process.exit(1);
+});

--- a/typescript/getting-started-with-browserbase/package.json
+++ b/typescript/getting-started-with-browserbase/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "getting-started-with-browserbase",
+  "version": "1.0.0",
+  "description": "Browserbase + Playwright: Getting Started — connect to a cloud browser, navigate, and extract data",
+  "type": "module",
+  "main": "index.ts",
+  "scripts": {
+    "start": "tsx index.ts",
+    "dev": "tsx watch index.ts"
+  },
+  "dependencies": {
+    "@browserbasehq/sdk": "^2.8.0",
+    "dotenv": "^16.4.5",
+    "playwright-core": "^1.50.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "tsx": "^4.16.0",
+    "typescript": "^5.5.0"
+  }
+}


### PR DESCRIPTION
### Why
  We needed a simple "getting started" template that shows new users how to
  use Browserbase with just an API key.

### What
  - New `getting-started-with-browserbase` template in both TypeScript and
  Python
  - Demos all three Browserbase capabilities in one script:
    1. **Search API** — web search without a browser
    2. **Fetch API** — lightweight HTTP fetch through Browserbase infra
    3. **Sessions + Playwright** — full cloud browser via CDP
  - `BROWSERBASE_PROJECT_ID` is optional (inferred from API key per current
  docs)
  - Only requires `BROWSERBASE_API_KEY` to run — lowest barrier to entry
  - README follows existing template style with all required sections

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new example templates and docs only, with no changes to production runtime logic. Risk is limited to dependency/template maintenance and developer experience issues if SDK APIs drift.
> 
> **Overview**
> Adds a new **`getting-started-with-browserbase` template** in both Python and TypeScript that demonstrates Browserbase’s three core flows in a single runnable script: `search.web`, `fetch_api/fetchAPI.create`, and `sessions.create` + Playwright CDP automation.
> 
> Includes `.env.example` files documenting `BROWSERBASE_API_KEY` (with optional `BROWSERBASE_PROJECT_ID`), quickstart/expected output READMEs, and minimal project setup via `pyproject.toml` (Python) and `package.json` (TypeScript).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fce95af39b313334ad60a24698e0e70cd06a9a41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->