### PR TITLE
[STG-1716] Update templates to use model gateway (remove model API keys)

### DIFF
--- a/go/hackernews/main.go
+++ b/go/hackernews/main.go
@@ -16,7 +16,6 @@ func main() {
 	client := stagehand.NewClient(
 		option.WithBrowserbaseAPIKey(os.Getenv("BROWSERBASE_API_KEY")),
 		option.WithBrowserbaseProjectID(os.Getenv("BROWSERBASE_PROJECT_ID")),
-		option.WithModelAPIKey(os.Getenv("MODEL_API_KEY")),
 	)
 
 	ctx := context.Background()
@@ -139,7 +138,7 @@ func main() {
 			Model: stagehand.ModelConfigUnionParam{
 				OfModelConfigModelConfigObject: &stagehand.ModelConfigModelConfigObjectParam{
 					ModelName: "openai/gpt-4o-mini",
-					APIKey:    stagehand.String(os.Getenv("MODEL_API_KEY")),
+		
 				},
 			},
 			Cua: stagehand.Bool(false),

--- a/python/amazon-global-price-comparison/.env.example
+++ b/python/amazon-global-price-comparison/.env.example
@@ -1,7 +1,3 @@
 # Browserbase credentials - get these from https://www.browserbase.com/settings
 BROWSERBASE_API_KEY=your_browserbase_api_key
 BROWSERBASE_PROJECT_ID=your_browserbase_project_id
-
-# Model API key for Stagehand AI capabilities
-# Use Google API key for Gemini models, or OpenAI API key for GPT models
-MODEL_API_KEY=your_model_api_key

--- a/python/amazon-global-price-comparison/main.py
+++ b/python/amazon-global-price-comparison/main.py
@@ -128,7 +128,6 @@ async def get_products_for_country(
     client = AsyncStagehand(
         browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
-        model_api_key=os.environ.get("MODEL_API_KEY"),
     )
 
     try:

--- a/python/amazon-product-scraping/.env.example
+++ b/python/amazon-product-scraping/.env.example
@@ -2,9 +2,3 @@
 # Get these from https://www.browserbase.com/settings
 BROWSERBASE_PROJECT_ID=your-browserbase-project-id
 BROWSERBASE_API_KEY=your-browserbase-api-key
-
-# Model API key (required - use one of these)
-# For Google Gemini models
-MODEL_API_KEY=your-google-api-key
-# Or alternatively:
-# GOOGLE_API_KEY=your-google-api-key

--- a/python/amazon-product-scraping/main.py
+++ b/python/amazon-product-scraping/main.py
@@ -66,12 +66,11 @@ async def main():
     """
     print("Starting Amazon Product Scraping...")
 
-    # Initialize AsyncStagehand client (v3 BYOB architecture)
-    # Uses environment variables: BROWSERBASE_API_KEY, BROWSERBASE_PROJECT_ID, MODEL_API_KEY
+    # Initialize AsyncStagehand client (v3 API)
+    # Uses environment variables: BROWSERBASE_API_KEY, BROWSERBASE_PROJECT_ID
     client = AsyncStagehand(
         browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
-        model_api_key=os.environ.get("MODEL_API_KEY") or os.environ.get("GOOGLE_API_KEY"),
     )
 
     # Start a Stagehand session with the specified model

--- a/python/basic-caching/main.py
+++ b/python/basic-caching/main.py
@@ -116,7 +116,7 @@ def run_without_cache():
     client = Stagehand(
         browserbase_api_key=os.getenv("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.getenv("BROWSERBASE_PROJECT_ID"),
-        model_api_key=os.getenv("GOOGLE_API_KEY"),
+
     )
 
     start_response = client.sessions.start(model_name="google/gemini-2.5-flash")
@@ -170,7 +170,7 @@ def run_with_cache():
     client = Stagehand(
         browserbase_api_key=os.getenv("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.getenv("BROWSERBASE_PROJECT_ID"),
-        model_api_key=os.getenv("GOOGLE_API_KEY"),
+
     )
 
     start_response = client.sessions.start(model_name="google/gemini-2.5-flash")

--- a/python/basic-recaptcha/main.py
+++ b/python/basic-recaptcha/main.py
@@ -32,7 +32,7 @@ def main():
     client = Stagehand(
         browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
-        model_api_key=os.environ.get("GOOGLE_API_KEY"),
+
     )
 
     try:

--- a/python/browserbase-reducto/main.py
+++ b/python/browserbase-reducto/main.py
@@ -258,7 +258,7 @@ async def main():
     client = AsyncStagehand(
         browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
-        model_api_key=os.environ.get("GOOGLE_API_KEY"),
+
     )
 
     # Start a Stagehand session (returns a response with session_id)

--- a/python/cartesia-form-filling/.env.example
+++ b/python/cartesia-form-filling/.env.example
@@ -1,10 +1,3 @@
-# Gemini API Key for language model (default)
-GEMINI_API_KEY=your_gemini_api_key_here
-
 # Browserbase API key and Project ID
 BROWSERBASE_API_KEY=your_browserbase_api_key_here
 BROWSERBASE_PROJECT_ID=your_browserbase_project_id_here
-
-# Optional: Model configuration
-# MODEL_NAME=google/gemini-2.0-flash-exp
-# MODEL_API_KEY=your_model_api_key_here

--- a/python/cartesia-form-filling/stagehand_form_filler.py
+++ b/python/cartesia-form-filling/stagehand_form_filler.py
@@ -148,7 +148,7 @@ class StagehandFormFiller:
             self.client = AsyncStagehand(
                 browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
                 browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
-                model_api_key=os.environ.get("GEMINI_API_KEY"),
+
             )
 
             self.session = await self.client.sessions.create(

--- a/python/company-value-prop-generator/main.py
+++ b/python/company-value-prop-generator/main.py
@@ -32,7 +32,7 @@ def generate_one_liner(domain: str) -> str:
     client = Stagehand(
         browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
-        model_api_key=os.environ.get("OPENAI_API_KEY"),
+
     )
 
     # Start a new session

--- a/python/context/main.py
+++ b/python/context/main.py
@@ -39,7 +39,7 @@ def create_session_context_id():
     client = Stagehand(
         browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
-        model_api_key=os.environ.get("OPENAI_API_KEY"),
+
     )
 
     # Connect Stagehand to the existing session (no new session created).
@@ -136,7 +136,7 @@ def main():
     client = Stagehand(
         browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
-        model_api_key=os.environ.get("OPENAI_API_KEY"),
+
     )
 
     try:

--- a/python/council-events/main.py
+++ b/python/council-events/main.py
@@ -37,7 +37,7 @@ def main():
     client = Stagehand(
         browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
-        model_api_key=os.environ.get("OPENAI_API_KEY"),
+
     )
 
     # Start a new session

--- a/python/download-financial-statements/main.py
+++ b/python/download-financial-statements/main.py
@@ -92,7 +92,7 @@ def main():
     client = Stagehand(
         browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
-        model_api_key=os.environ.get("GOOGLE_API_KEY"),
+
     )
 
     # Start a new session

--- a/python/exa-browserbase/.env.example
+++ b/python/exa-browserbase/.env.example
@@ -2,11 +2,5 @@
 BROWSERBASE_PROJECT_ID=your-browserbase-project-id
 BROWSERBASE_API_KEY=your-browserbase-api-key
 
-# LLM API key (any of these work)
-MODEL_API_KEY=your-model-api-key
-# Or use Google AI key aliases:
-# GOOGLE_API_KEY=your-google-api-key
-# GOOGLE_GENERATIVE_AI_API_KEY=your-google-api-key
-
 # Exa API key from https://dashboard.exa.ai/api-keys
 EXA_API_KEY=your-exa-api-key

--- a/python/exa-browserbase/main.py
+++ b/python/exa-browserbase/main.py
@@ -281,15 +281,9 @@ async def apply_to_job(careers_page: dict, index: int) -> dict:
     log_prefix = f"[{index + 1}/{num_companies}] {company_name}: "
     print(f"\n{log_prefix}Starting application...")
 
-    model_api_key = (
-        os.environ.get("MODEL_API_KEY")
-        or os.environ.get("GOOGLE_API_KEY")
-        or os.environ.get("GOOGLE_GENERATIVE_AI_API_KEY")
-    )
     client = AsyncStagehand(
         browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
-        model_api_key=model_api_key,
     )
 
     # Start session (proxies require Developer plan or higher)

--- a/python/extend-browserbase/.env.example
+++ b/python/extend-browserbase/.env.example
@@ -3,8 +3,5 @@
 BROWSERBASE_PROJECT_ID=your_browserbase_project_id
 BROWSERBASE_API_KEY=your_browserbase_api_key
 
-# Google API key for Gemini model (required for Stagehand)
-GOOGLE_API_KEY=your_google_api_key
-
 # Extend AI (optional – enables receipt parsing; omit to only download receipts)
 EXTEND_API_KEY=your_extend_api_key

--- a/python/extend-browserbase/main.py
+++ b/python/extend-browserbase/main.py
@@ -442,7 +442,6 @@ async def main() -> None:
 
     browserbase_api_key = os.environ.get("BROWSERBASE_API_KEY")
     browserbase_project_id = os.environ.get("BROWSERBASE_PROJECT_ID")
-    google_api_key = os.environ.get("GOOGLE_API_KEY")
 
     if not browserbase_api_key or not browserbase_project_id:
         raise ValueError("BROWSERBASE_API_KEY and BROWSERBASE_PROJECT_ID are required")
@@ -450,11 +449,10 @@ async def main() -> None:
     # Initialize Browserbase SDK for session management and download retrieval
     bb = Browserbase(api_key=browserbase_api_key)
 
-    # Initialize AsyncStagehand client (v3 BYOB architecture)
+    # Initialize AsyncStagehand client (v3 API)
     client = AsyncStagehand(
         browserbase_api_key=browserbase_api_key,
         browserbase_project_id=browserbase_project_id,
-        model_api_key=google_api_key,
     )
 
     # Start a Stagehand session (returns a response with session_id)

--- a/python/form-filling/main.py
+++ b/python/form-filling/main.py
@@ -29,7 +29,7 @@ def main():
     client = Stagehand(
         browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
-        model_api_key=os.environ.get("OPENAI_API_KEY"),
+
     )
 
     # Start a new session

--- a/python/gift-finder/main.py
+++ b/python/gift-finder/main.py
@@ -256,7 +256,7 @@ def run_single_search(query: str, session_index: int) -> SearchResult:
     client = Stagehand(
         browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
-        model_api_key=os.environ.get("OPENAI_API_KEY"),
+
     )
 
     # Start a new session

--- a/python/google-trends/.env.example
+++ b/python/google-trends/.env.example
@@ -1,6 +1,3 @@
 # Browserbase credentials (required)
 BROWSERBASE_PROJECT_ID=your-browserbase-project-id
 BROWSERBASE_API_KEY=your-browserbase-api-key
-
-# Model API key (required)
-GOOGLE_API_KEY=your-google-api-key

--- a/python/google-trends/main.py
+++ b/python/google-trends/main.py
@@ -65,7 +65,7 @@ async def main():
     client = AsyncStagehand(
         browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
-        model_api_key=os.environ.get("GOOGLE_API_KEY"),
+
     )
 
     # Start a Stagehand session with Gemini model

--- a/python/image-url-download/.env.example
+++ b/python/image-url-download/.env.example
@@ -2,8 +2,5 @@
 BROWSERBASE_PROJECT_ID=your_browserbase_project_id
 BROWSERBASE_API_KEY=your_browserbase_api_key
 
-# Google API key for gemini-2.5-flash model
-GOOGLE_API_KEY=your_google_api_key
-
 # Optional: maximum number of images to download per run (default: 10)
 # MAX_IMAGES=10

--- a/python/image-url-download/main.py
+++ b/python/image-url-download/main.py
@@ -102,13 +102,11 @@ async def main():
     # credentials produce a clear error rather than a cryptic WebSocket failure.
     api_key = os.environ.get("BROWSERBASE_API_KEY")
     project_id = os.environ.get("BROWSERBASE_PROJECT_ID")
-    google_api_key = os.environ.get("GOOGLE_API_KEY")
     missing = [
         name
         for name, val in [
             ("BROWSERBASE_API_KEY", api_key),
             ("BROWSERBASE_PROJECT_ID", project_id),
-            ("GOOGLE_API_KEY", google_api_key),
         ]
         if not val
     ]
@@ -121,7 +119,6 @@ async def main():
     client = AsyncStagehand(
         browserbase_api_key=api_key,
         browserbase_project_id=project_id,
-        model_api_key=google_api_key,
     )
 
     # Start a new browser session.

--- a/python/job-application/main.py
+++ b/python/job-application/main.py
@@ -71,7 +71,7 @@ def apply_to_job(job_info: JobInfo):
     client = Stagehand(
         browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
-        model_api_key=os.environ.get("GOOGLE_GENERATIVE_AI_API_KEY"),
+
     )
 
     # Start a new session
@@ -205,7 +205,7 @@ def main():
     client = Stagehand(
         browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
-        model_api_key=os.environ.get("GOOGLE_GENERATIVE_AI_API_KEY"),
+
     )
 
     # Start a new session

--- a/python/license-verification/main.py
+++ b/python/license-verification/main.py
@@ -40,7 +40,7 @@ def main():
     client = Stagehand(
         browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
-        model_api_key=os.environ.get("OPENAI_API_KEY"),
+
     )
 
     # Start a new session

--- a/python/manual-mfa-with-contexts/main.py
+++ b/python/manual-mfa-with-contexts/main.py
@@ -41,7 +41,7 @@ def create_session_with_context():
     client = Stagehand(
         browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
-        model_api_key=os.environ.get("GOOGLE_GENERATIVE_AI_API_KEY"),
+
     )
 
     print(f"Watch live: https://browserbase.com/sessions/{session_id}")
@@ -151,7 +151,7 @@ def reuse_context(context_id: str):
     client = Stagehand(
         browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
-        model_api_key=os.environ.get("GOOGLE_GENERATIVE_AI_API_KEY"),
+
     )
 
     print(f"Watch live: https://browserbase.com/sessions/{session_id}")

--- a/python/mfa-handling/main.py
+++ b/python/mfa-handling/main.py
@@ -87,7 +87,7 @@ def main():
     client = Stagehand(
         browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
-        model_api_key=os.environ.get("OPENAI_API_KEY"),
+
     )
 
     # Start a new session
@@ -234,7 +234,7 @@ if __name__ == "__main__":
         print(f"Error in MFA handling: {err}")
         print("Common issues:")
         print("  - Check .env file has BROWSERBASE_PROJECT_ID and BROWSERBASE_API_KEY")
-        print("  - Check .env file has OPENAI_API_KEY (or set model_api_key for your chosen model)")
+        print("  - Verify your Browserbase plan supports the model gateway")
         print("  - TOTP code may have expired (try running again)")
         print("  - Page structure may have changed")
         print("Docs: https://docs.stagehand.dev/v3/first-steps/introduction")

--- a/python/nurse-verification/main.py
+++ b/python/nurse-verification/main.py
@@ -52,7 +52,7 @@ def main():
     client = Stagehand(
         browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
-        model_api_key=os.environ.get("OPENAI_API_KEY"),
+
     )
 
     # Start a new session

--- a/python/pickleball/main.py
+++ b/python/pickleball/main.py
@@ -399,7 +399,7 @@ def book_tennis_paddle_court():
     client = Stagehand(
         browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
-        model_api_key=os.environ.get("OPENAI_API_KEY"),
+
     )
 
     # Start a new session

--- a/python/polymarket-research/main.py
+++ b/python/polymarket-research/main.py
@@ -34,7 +34,7 @@ def main():
     client = Stagehand(
         browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
-        model_api_key=os.environ.get("OPENAI_API_KEY"),
+
     )
 
     # Start a new session

--- a/python/proxies-weather/main.py
+++ b/python/proxies-weather/main.py
@@ -43,13 +43,6 @@ def get_weather_for_location(geolocation: GeolocationConfig) -> WeatherResult:
     city_name = geolocation.city.replace("_", " ")
     print(f"\n=== Getting weather for {city_name}, {geolocation.country} ===")
 
-    model_api_key = os.environ.get("MODEL_API_KEY") or os.environ.get("GOOGLE_API_KEY")
-    if not model_api_key:
-        raise ValueError(
-            "MODEL_API_KEY or GOOGLE_API_KEY environment variable is required. "
-            "Please set one in your .env file."
-        )
-
     # Build proxy configuration for geolocation routing
     proxy_config = {
         "type": "browserbase",
@@ -74,7 +67,7 @@ def get_weather_for_location(geolocation: GeolocationConfig) -> WeatherResult:
     client = Stagehand(
         browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
-        model_api_key=model_api_key,
+
     )
 
     try:

--- a/python/proxies/main.py
+++ b/python/proxies/main.py
@@ -81,7 +81,7 @@ def test_session(session_function, session_name: str):
     client = Stagehand(
         browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
-        model_api_key=os.environ.get("OPENAI_API_KEY"),
+
     )
 
     try:

--- a/python/sec-filing-research/.env.example
+++ b/python/sec-filing-research/.env.example
@@ -2,8 +2,3 @@
 # Get these from https://www.browserbase.com/settings
 BROWSERBASE_PROJECT_ID=your-browserbase-project-id
 BROWSERBASE_API_KEY=your-browserbase-api-key
-
-# Model API key (required)
-# For Gemini: your Google API key
-# For OpenAI: your OpenAI API key
-MODEL_API_KEY=your-model-api-key

--- a/python/sec-filing-research/main.py
+++ b/python/sec-filing-research/main.py
@@ -73,12 +73,10 @@ async def main():
     print(f"Retrieving {NUM_FILINGS} most recent filings\n")
 
     # Initialize AsyncStagehand client (v3 architecture)
-    # Uses environment variables: BROWSERBASE_API_KEY, BROWSERBASE_PROJECT_ID, MODEL_API_KEY
+    # Uses environment variables: BROWSERBASE_API_KEY, BROWSERBASE_PROJECT_ID
     client = AsyncStagehand(
         browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
-        model_api_key=os.environ.get("MODEL_API_KEY")
-        or os.environ.get("GOOGLE_GENERATIVE_AI_API_KEY"),
     )
 
     # Start a new browser session

--- a/python/smart-fetch-scraper/.env.example
+++ b/python/smart-fetch-scraper/.env.example
@@ -1,8 +1,3 @@
 # Browserbase Configuration
 BROWSERBASE_PROJECT_ID=your_browserbase_project_id
 BROWSERBASE_API_KEY=your_browserbase_api_key
-
-# Google API key for gemini-2.5-flash model (used in browser fallback)
-MODEL_API_KEY=your_google_api_key
-# Or alternatively:
-# GOOGLE_API_KEY=your_google_api_key

--- a/python/smart-fetch-scraper/main.py
+++ b/python/smart-fetch-scraper/main.py
@@ -156,7 +156,6 @@ async def extract_with_browser(url: str) -> dict:
     client = AsyncStagehand(
         browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
-        model_api_key=os.environ.get("MODEL_API_KEY") or os.environ.get("GOOGLE_API_KEY"),
     )
 
     # Start session

--- a/python/website-link-tester/main.py
+++ b/python/website-link-tester/main.py
@@ -100,7 +100,7 @@ def collect_links_from_homepage() -> list[dict]:
     client = Stagehand(
         browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
-        model_api_key=os.environ.get("GOOGLE_API_KEY"),
+
     )
 
     # Start a new session
@@ -192,7 +192,7 @@ def verify_single_link(link: dict) -> LinkVerificationResult:
     client = Stagehand(
         browserbase_api_key=os.environ.get("BROWSERBASE_API_KEY"),
         browserbase_project_id=os.environ.get("BROWSERBASE_PROJECT_ID"),
-        model_api_key=os.environ.get("GOOGLE_API_KEY"),
+
     )
 
     # Start a new session

--- a/typescript/amazon-product-scraping/.env.example
+++ b/typescript/amazon-product-scraping/.env.example
@@ -1,6 +1,3 @@
 # Browserbase Configuration
 BROWSERBASE_PROJECT_ID=your_browserbase_project_id
 BROWSERBASE_API_KEY=your_browserbase_api_key
-
-# Google API key for gemini-2.5-flash model
-GOOGLE_API_KEY=your_google_api_key

--- a/typescript/amazon-product-scraping/index.ts
+++ b/typescript/amazon-product-scraping/index.ts
@@ -85,7 +85,7 @@ main().catch((err) => {
   console.error("Error in Amazon product scraping:", err);
   console.error("Common issues:");
   console.error("  - Check .env file has BROWSERBASE_PROJECT_ID and BROWSERBASE_API_KEY");
-  console.error("  - Verify GOOGLE_API_KEY is set for the model");
+  console.error("  - Verify your Browserbase plan supports the model gateway");
   console.error("  - Verify network connectivity");
   console.error("Docs: https://docs.stagehand.dev");
   process.exit(1);

--- a/typescript/basic-caching/index.ts
+++ b/typescript/basic-caching/index.ts
@@ -157,7 +157,7 @@ main().catch((err) => {
   console.error("Error in caching demo:", err);
   console.error("Common issues:");
   console.error("  - Check .env file has BROWSERBASE_PROJECT_ID and BROWSERBASE_API_KEY");
-  console.error("  - Verify GOOGLE_API_KEY is set for the model");
+  console.error("  - Verify your Browserbase plan supports the model gateway");
   console.error("Docs: https://docs.stagehand.dev/v3/first-steps/introduction");
   process.exit(1);
 });

--- a/typescript/browserbase-reducto/.env.example
+++ b/typescript/browserbase-reducto/.env.example
@@ -2,8 +2,5 @@
 BROWSERBASE_PROJECT_ID=your_browserbase_project_id
 BROWSERBASE_API_KEY=your_browserbase_api_key
 
-# Pass your preferred LLM API key (choose a model for your provider in the Stagehand constructor)
-GOOGLE_API_KEY="YOUR_GOOGLE_API_KEY"
-
 # Reducto Configuration
 REDUCTOAI_API_KEY=your_reducto_api_key

--- a/typescript/company-value-prop-generator/index.ts
+++ b/typescript/company-value-prop-generator/index.ts
@@ -130,7 +130,7 @@ async function main() {
     const errorMessage = error instanceof Error ? error.message : String(error);
     console.error(`\n❌ Error: ${errorMessage}`);
     console.error("\nCommon issues:");
-    console.error("  - Check .env file has OPENAI_API_KEY set (required for LLM generation)");
+    console.error("  - Verify your Browserbase plan supports the model gateway");
     console.error(
       "  - Check .env file has BROWSERBASE_PROJECT_ID and BROWSERBASE_API_KEY set (required for browser automation)",
     );

--- a/typescript/council-events/index.ts
+++ b/typescript/council-events/index.ts
@@ -68,7 +68,7 @@ async function main() {
     // Provide helpful troubleshooting information
     console.error("\nCommon issues:");
     console.error("1. Check .env file has BROWSERBASE_PROJECT_ID and BROWSERBASE_API_KEY");
-    console.error("2. Verify OPENAI_API_KEY is set in environment");
+    console.error("2. Verify your Browserbase plan supports the model gateway");
     console.error("3. Ensure internet access and https://phila.legistar.com is accessible");
     console.error("4. Verify Browserbase account has sufficient credits");
     console.error("5. Check if the calendar page structure has changed");

--- a/typescript/dynamic-form-filling/index.ts
+++ b/typescript/dynamic-form-filling/index.ts
@@ -29,10 +29,7 @@ async function main() {
     // The agent will use semantic matching to select appropriate form options.
     const agent = stagehand.agent({
       cua: false,
-      model: {
-        modelName: "google/gemini-2.5-pro",
-        apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY,
-      },
+      model: "google/gemini-2.5-pro",
       systemPrompt: `You are filling out a trip planning form. 
     - When filling out fields, extract relevant information from the trip details provided
     - For fields with options (radio buttons, dropdowns, checkboxes), always choose the closest matching option from the available choices
@@ -79,7 +76,7 @@ main().catch((err) => {
   console.error("Error in dynamic form filling:", err);
   console.error("Common issues:");
   console.error("  - Check .env file has BROWSERBASE_PROJECT_ID and BROWSERBASE_API_KEY");
-  console.error("  - Verify GOOGLE_GENERATIVE_AI_API_KEY is set for the agent");
+  console.error("  - Verify your Browserbase plan supports the model gateway");
   console.error("  - Ensure the form URL is accessible and form fields are available");
   console.error("Docs: https://docs.stagehand.dev/v3/first-steps/introduction");
   process.exit(1);

--- a/typescript/exa-browserbase/index.ts
+++ b/typescript/exa-browserbase/index.ts
@@ -358,7 +358,7 @@ main().catch((err) => {
   console.error("Error in Exa + Browserbase job application:", err);
   console.error("Common issues:");
   console.error(
-    "  - Check .env file has BROWSERBASE_PROJECT_ID, BROWSERBASE_API_KEY, MODEL_API_KEY, and EXA_API_KEY",
+    "  - Check .env file has BROWSERBASE_PROJECT_ID, BROWSERBASE_API_KEY, and EXA_API_KEY",
   );
   console.error("  - Verify companies exist for the search query");
   console.error("  - Ensure careers pages are accessible");

--- a/typescript/extend-browserbase/.env.example
+++ b/typescript/extend-browserbase/.env.example
@@ -2,8 +2,5 @@
 BROWSERBASE_PROJECT_ID=your_browserbase_project_id
 BROWSERBASE_API_KEY=your_browserbase_api_key
 
-# Google API key for Gemini model (Stagehand)
-GOOGLE_API_KEY=your_google_api_key
-
 # Extend AI (optional – enables receipt parsing; omit to only download receipts)
 EXTEND_API_KEY=your_extend_api_key

--- a/typescript/extend-browserbase/index.ts
+++ b/typescript/extend-browserbase/index.ts
@@ -353,10 +353,7 @@ async function main(): Promise<void> {
     // 0 = errors only, 1 = info, 2 = debug
     // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
     // https://docs.stagehand.dev/configuration/logging
-    model: {
-      modelName: "google/gemini-2.5-flash",
-      apiKey: process.env.GOOGLE_API_KEY,
-    },
+    model: "google/gemini-2.5-flash",
   });
 
   let sessionId: string | undefined;
@@ -466,7 +463,7 @@ main().catch((err) => {
   console.error("Application error:", err);
   console.error("Common issues:");
   console.error(
-    "  - Check .env file has BROWSERBASE_PROJECT_ID, BROWSERBASE_API_KEY, and GOOGLE_API_KEY",
+    "  - Check .env file has BROWSERBASE_PROJECT_ID and BROWSERBASE_API_KEY",
   );
   console.error("  - Add EXTEND_API_KEY to .env to enable receipt parsing with Extend AI");
   console.error("  - Verify internet connection and expense portal accessibility");

--- a/typescript/gemini-3-flash/index.ts
+++ b/typescript/gemini-3-flash/index.ts
@@ -58,10 +58,7 @@ async function main() {
 
     // Create agent with Gemini 3 Flash for autonomous web browsing.
     const agent = stagehand.agent({
-      model: {
-        modelName: "google/gemini-3-flash-preview",
-        apiKey: process.env.GOOGLE_API_KEY,
-      },
+      model: "google/gemini-3-flash-preview",
       systemPrompt: `You are a helpful assistant that can use a web browser.
       You are currently on the following page: ${page.url()}.
       Do not ask follow up questions, the user will trust your judgement. If you are getting blocked on google, try another search engine.`,
@@ -92,7 +89,7 @@ main().catch((err) => {
   console.error("Error in Gemini 3 Flash agent example:", err);
   console.error("Common issues:");
   console.error("  - Check .env file has BROWSERBASE_PROJECT_ID and BROWSERBASE_API_KEY");
-  console.error("  - Verify GOOGLE_API_KEY is set for the agent");
+  console.error("  - Verify your Browserbase plan supports the model gateway");
   console.error("Docs: https://docs.stagehand.dev/v3/first-steps/introduction");
   process.exit(1);
 });

--- a/typescript/google-trends/.env.example
+++ b/typescript/google-trends/.env.example
@@ -1,6 +1,3 @@
 # Browserbase credentials (required)
 BROWSERBASE_PROJECT_ID=your-browserbase-project-id
 BROWSERBASE_API_KEY=your-browserbase-api-key
-
-# Model API key (required)
-GOOGLE_API_KEY=your-google-api-key

--- a/typescript/google-trends/index.ts
+++ b/typescript/google-trends/index.ts
@@ -88,7 +88,7 @@ async function main() {
     // Provide helpful troubleshooting information.
     console.error("\nCommon issues:");
     console.error("1. Check .env file has BROWSERBASE_PROJECT_ID and BROWSERBASE_API_KEY");
-    console.error("2. Verify GOOGLE_API_KEY is set in environment");
+    console.error("2. Verify your Browserbase plan supports the model gateway");
     console.error("3. Ensure country code is a valid 2-letter ISO code (US, GB, IN, DE, etc.)");
     console.error("4. Verify Browserbase account has sufficient credits");
     console.error("5. Check if Google Trends page structure has changed");

--- a/typescript/image-url-download/.env.example
+++ b/typescript/image-url-download/.env.example
@@ -2,8 +2,5 @@
 BROWSERBASE_PROJECT_ID=your_browserbase_project_id
 BROWSERBASE_API_KEY=your_browserbase_api_key
 
-# Google API key for gemini-2.5-flash model
-GOOGLE_API_KEY=your_google_api_key
-
 # Optional: maximum number of images to download per run (default: 10)
 # MAX_IMAGES=10

--- a/typescript/image-url-download/index.ts
+++ b/typescript/image-url-download/index.ts
@@ -201,7 +201,7 @@ main().catch((err) => {
   console.error("Error:", err);
   console.error("Common issues:");
   console.error("  - Check .env file has BROWSERBASE_PROJECT_ID and BROWSERBASE_API_KEY");
-  console.error("  - Ensure GOOGLE_API_KEY is set for the gemini-2.5-flash model");
+  console.error("  - Verify your Browserbase plan supports the model gateway");
   console.error("  - Verify the target URL is accessible");
   console.error("Docs: https://docs.stagehand.dev/v3/first-steps/introduction");
   process.exit(1);

--- a/typescript/job-application/index.ts
+++ b/typescript/job-application/index.ts
@@ -72,10 +72,7 @@ async function applyToJob(jobInfo: JobInfo, semaphore: () => Promise<void>, rele
   // Initialize Stagehand with Browserbase for cloud-based browser automation
   const stagehand = new Stagehand({
     env: "BROWSERBASE",
-    model: {
-      modelName: "google/gemini-2.5-flash",
-      apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY,
-    },
+    model: "google/gemini-2.5-flash",
   });
 
   try {
@@ -168,10 +165,7 @@ async function main() {
   // Initialize Stagehand with Browserbase for cloud-based browser automation
   const stagehand = new Stagehand({
     env: "BROWSERBASE",
-    model: {
-      modelName: "google/gemini-2.5-flash",
-      apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY,
-    },
+    model: "google/gemini-2.5-flash",
   });
 
   // Initialize browser session to start automation
@@ -223,7 +217,7 @@ main().catch((err) => {
   console.error("Error in job application automation:", err);
   console.error("Common issues:");
   console.error("  - Check .env file has BROWSERBASE_PROJECT_ID and BROWSERBASE_API_KEY");
-  console.error("  - Verify GOOGLE_GENERATIVE_AI_API_KEY is set");
+  console.error("  - Verify your Browserbase plan supports the model gateway");
   console.error("Docs: https://docs.stagehand.dev/v3/first-steps/introduction");
   process.exit(1);
 });

--- a/typescript/mfa-handling/index.ts
+++ b/typescript/mfa-handling/index.ts
@@ -63,10 +63,7 @@ async function main() {
     // 0 = errors only, 1 = info, 2 = debug
     // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
     // https://docs.stagehand.dev/configuration/logging
-    model: {
-      modelName: "google/gemini-2.5-flash",
-      apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY,
-    },
+    model: "google/gemini-2.5-flash",
   });
 
   try {

--- a/typescript/nurse-verification/index.ts
+++ b/typescript/nurse-verification/index.ts
@@ -85,7 +85,7 @@ async function main() {
     // Provide helpful troubleshooting information
     console.error("\nCommon issues:");
     console.error("1. Check .env file has BROWSERBASE_PROJECT_ID and BROWSERBASE_API_KEY");
-    console.error("2. Verify OPENAI_API_KEY is set in environment");
+    console.error("2. Verify your Browserbase plan supports the model gateway");
     console.error("3. Ensure internet access and license verification site is accessible");
     console.error("4. Verify Browserbase account has sufficient credits");
 

--- a/typescript/polymarket-research/index.ts
+++ b/typescript/polymarket-research/index.ts
@@ -74,7 +74,7 @@ async function main() {
     // Provide helpful troubleshooting information
     console.error("\nCommon issues:");
     console.error("1. Check .env file has BROWSERBASE_PROJECT_ID and BROWSERBASE_API_KEY");
-    console.error("2. Verify OPENAI_API_KEY is set in environment");
+    console.error("2. Verify your Browserbase plan supports the model gateway");
     console.error("3. Ensure internet access and https://polymarket.com is accessible");
     console.error("4. Verify Browserbase account has sufficient credits");
 

--- a/typescript/sec-filing-research/.env.example
+++ b/typescript/sec-filing-research/.env.example
@@ -2,6 +2,3 @@
 # Get these from https://www.browserbase.com/settings
 BROWSERBASE_PROJECT_ID=your-browserbase-project-id
 BROWSERBASE_API_KEY=your-browserbase-api-key
-
-# Google API key for Gemini model (required)
-GOOGLE_API_KEY=your-google-api-key

--- a/typescript/smart-fetch-scraper/.env.example
+++ b/typescript/smart-fetch-scraper/.env.example
@@ -1,6 +1,3 @@
 # Browserbase Configuration
 BROWSERBASE_PROJECT_ID=your_browserbase_project_id
 BROWSERBASE_API_KEY=your_browserbase_api_key
-
-# Google API key for gemini-2.5-flash model (used in browser fallback)
-GOOGLE_API_KEY=your_google_api_key

--- a/typescript/smart-fetch-scraper/index.ts
+++ b/typescript/smart-fetch-scraper/index.ts
@@ -209,7 +209,7 @@ main().catch((err) => {
   console.error("Error:", err);
   console.error("Common issues:");
   console.error("  - Check .env has BROWSERBASE_PROJECT_ID and BROWSERBASE_API_KEY");
-  console.error("  - Verify GOOGLE_API_KEY is set for the model (browser fallback)");
+  console.error("  - Verify your Browserbase plan supports the model gateway");
   console.error("  - Verify network connectivity");
   console.error("Docs: https://docs.stagehand.dev");
   process.exit(1);


### PR DESCRIPTION
## Summary

Updates all Stagehand templates (TypeScript, Python, Go) to use the Browserbase model gateway instead of requiring users to provide their own model API keys.

### Changes

**TypeScript templates (5 model config changes + 10 error message updates + 7 .env.example updates):**
- Converted `model: { modelName: "...", apiKey: process.env.XXX }` to `model: "..."` in: dynamic-form-filling, extend-browserbase, job-application (x2), mfa-handling, gemini-3-flash
- Updated error messages referencing model API keys in: amazon-product-scraping, basic-caching, company-value-prop-generator, council-events, exa-browserbase, google-trends, image-url-download, nurse-verification, polymarket-research, smart-fetch-scraper
- Removed model API key entries from .env.example files

**Python templates (28 files):**
- Removed `model_api_key=...` from all Stagehand constructors
- Removed model API key environment variable lookups and validation
- Updated error messages
- Cleaned up .env.example files

**Go template (1 file):**
- Removed `option.WithModelAPIKey()` from client constructor
- Removed `APIKey` from agent model config

### Skipped (intentionally)
- **CUA templates**: gemini-cua, microsoft-cua, business-lookup, company-address-finder (use CUA models)
- **Non-gateway providers**: cerebras-docs-checker (uses Cerebras, not supported by gateway)

### Notes
- All templates preserve their existing model choices (e.g., `google/gemini-2.5-flash`, `openai/gpt-4.1`)
- Only model API key references were removed — Browserbase API keys (`BROWSERBASE_API_KEY`, `BROWSERBASE_PROJECT_ID`) and other service API keys (EXA, Reducto, Extend) are preserved
- README updates not included — those reference model API keys in setup instructions and should be updated separately or as part of this review

Linear: https://linear.app/browserbase/issue/STG-1716/update-templates-to-use-model-gateway-remove-model-api-keys

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad updates across Go/Python/TypeScript templates remove per-provider `model_api_key` configuration and `.env` expectations, which may break users following older setup steps if their Browserbase plan/gateway access isn’t enabled.
> 
> **Overview**
> Updates Stagehand Go/Python/TypeScript templates to rely on the **Browserbase model gateway** instead of requiring user-supplied model API keys.
> 
> This removes `model_api_key`/`WithModelAPIKey` usage from clients and agent model configs, simplifies agent `model` settings to just a model name string in TS examples, and strips model-key entries from multiple `.env.example` files. Related troubleshooting output is updated to stop referencing provider keys and instead point users to ensuring their Browserbase plan supports the model gateway.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71e6cb73ca7da433f620858e34a540d82eb046f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->