### PR TITLE
Fix broken documentation links across templates

### DIFF
--- a/go/hackernews/README.md
+++ b/go/hackernews/README.md
@@ -10,15 +10,15 @@
 ## GLOSSARY
 
 - navigate: Load a web page in the browser session
-  Docs → https://docs.stagehand.dev/basics/navigate
+  Docs → https://docs.stagehand.dev/v3/references/page
 - observe: Analyze page elements and generate actionable steps based on natural language instructions
-  Docs → https://docs.stagehand.dev/basics/observe
+  Docs → https://docs.stagehand.dev/v3/basics/observe
 - act: Execute actions on web pages using natural language instructions
-  Docs → https://docs.stagehand.dev/basics/act
+  Docs → https://docs.stagehand.dev/v3/basics/act
 - extract: Extract structured data from pages using JSON schema definitions
-  Docs → https://docs.stagehand.dev/basics/extract
+  Docs → https://docs.stagehand.dev/v3/basics/extract
 - execute: Run an autonomous agent to complete multi-step tasks automatically
-  Docs → https://docs.stagehand.dev/basics/execute
+  Docs → https://docs.stagehand.dev/v3/basics/act
 
 ## QUICKSTART
 

--- a/python/amazon-product-scraping/README.md
+++ b/python/amazon-product-scraping/README.md
@@ -58,7 +58,7 @@
 ## HELPFUL RESOURCES
 
 📚 Stagehand Docs: https://docs.stagehand.dev
-📚 Python SDK: https://docs.stagehand.dev/reference/python/overview
+📚 Python SDK: https://docs.stagehand.dev/v3/sdk/python
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground
 🔧 Templates: https://www.browserbase.com/templates

--- a/python/browserbase-reducto/main.py
+++ b/python/browserbase-reducto/main.py
@@ -331,5 +331,5 @@ if __name__ == "__main__":
         )
         print("  - Verify internet connection and Apple website accessibility")
         print("  - Ensure sufficient timeout for slow-loading pages")
-        print("Docs: https://docs.stagehand.dev/reference/python/overview")
+        print("Docs: https://docs.stagehand.dev/v3/sdk/python")
         exit(1)

--- a/python/cerebras-docs-checker/main.py
+++ b/python/cerebras-docs-checker/main.py
@@ -982,5 +982,5 @@ if __name__ == "__main__":
         print("\nCommon issues:")
         print("  - Check .env file has CEREBRAS_API_KEY, BROWSERBASE_API_KEY, BROWSERBASE_PROJECT_ID")
         print("  - Ensure playwright is installed: playwright install chromium")
-        print("Docs: https://docs.stagehand.dev/reference/python/overview")
+        print("Docs: https://docs.stagehand.dev/v3/sdk/python")
         exit(1)

--- a/python/company-value-prop-generator/README.md
+++ b/python/company-value-prop-generator/README.md
@@ -6,12 +6,12 @@
 - Demonstrates Stagehand's `extract` method with Pydantic schemas to pull structured data from landing pages
 - Shows direct OpenAI API usage to transform extracted content with custom prompts
 - Includes placeholder page detection and validation logic to filter out non-functional sites
-- Docs → https://docs.browserbase.com/stagehand/extract
+- Docs → https://docs.stagehand.dev/v3/basics/extract
 
 ## GLOSSARY
 
 - Extract: Stagehand method that uses AI to pull structured data from pages using natural language instructions
-  Docs → https://docs.browserbase.com/stagehand/extract
+  Docs → https://docs.stagehand.dev/v3/basics/extract
 - Value Proposition: The core benefit or unique selling point a company communicates to customers
 
 ## QUICKSTART

--- a/python/council-events/README.md
+++ b/python/council-events/README.md
@@ -58,6 +58,6 @@
 📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground
-🔧 Templates: https://github.com/browserbase/stagehand/tree/main/examples
+🔧 Templates: https://www.browserbase.com/templates
 📧 Need help? support@browserbase.com
 💬 Discord: http://stagehand.dev/discord

--- a/python/form-filling/README.md
+++ b/python/form-filling/README.md
@@ -6,7 +6,7 @@
 - Smart Form Automation: dynamically fill contact forms with variable-driven data.
 - Field Detection: analyze page structure with `observe` before interacting with fields.
 - AI-Powered Interaction: leverage Stagehand to map inputs to the right fields reliably.
-  Docs → https://docs.browserbase.com/features/sessions
+  Docs → https://docs.browserbase.com/fundamentals/create-browser-session
 
 ## GLOSSARY
 

--- a/python/google-trends/main.py
+++ b/python/google-trends/main.py
@@ -165,5 +165,5 @@ if __name__ == "__main__":
         print("Common issues:")
         print("  - Check .env file has BROWSERBASE_PROJECT_ID and BROWSERBASE_API_KEY")
         print("  - Verify GOOGLE_API_KEY is set in environment")
-        print("Docs: https://docs.stagehand.dev/reference/python/overview")
+        print("Docs: https://docs.stagehand.dev/v3/sdk/python")
         exit(1)

--- a/python/pickleball/README.md
+++ b/python/pickleball/README.md
@@ -6,7 +6,7 @@
 - AI Integration: Stagehand for UI interaction and data extraction.
 - Browser Automation: automates login, filtering, court selection, and booking confirmation.
 - User Interaction: prompts for activity type, date, and time preferences with validation.
-  Docs → https://docs.browserbase.com/features/sessions
+  Docs → https://docs.browserbase.com/fundamentals/create-browser-session
 
 ## GLOSSARY
 
@@ -17,7 +17,7 @@
 - observe: plan actions and get selectors before executing
   Docs → https://docs.stagehand.dev/basics/observe
 - browser automation: automated interaction with web applications for booking systems
-  Docs → https://docs.browserbase.com/features/sessions
+  Docs → https://docs.browserbase.com/fundamentals/create-browser-session
 - form validation: ensure user input meets booking system requirements
 
 ## QUICKSTART

--- a/python/playwright/basic-recaptcha/README.md
+++ b/python/playwright/basic-recaptcha/README.md
@@ -117,7 +117,7 @@ session = bb.sessions.create(
 ## HELPFUL RESOURCES
 
 - Browserbase Docs: https://docs.browserbase.com
-- Browserbase Python Integration: https://docs.browserbase.com/integrations/playwright/python
+- Browserbase Python Integration: https://docs.browserbase.com/introduction/playwright
 - Playwright Python Docs: https://playwright.dev/python/docs/intro
 - Browserbase Dashboard: https://www.browserbase.com
 - Playground: https://www.browserbase.com/playground

--- a/python/sec-filing-research/main.py
+++ b/python/sec-filing-research/main.py
@@ -203,5 +203,5 @@ if __name__ == "__main__":
         print("  - Verify MODEL_API_KEY is set (e.g. Google API key for Gemini)")
         print("  - Verify internet connection and SEC website accessibility")
         print("  - Ensure the search query is valid (company name, ticker, or CIK)")
-        print("Docs: https://docs.stagehand.dev/reference/python/overview")
+        print("Docs: https://docs.stagehand.dev/v3/sdk/python")
         exit(1)

--- a/python/website-link-tester/README.md
+++ b/python/website-link-tester/README.md
@@ -11,7 +11,7 @@
 ## GLOSSARY
 
 - **Stagehand (Python v2)**: Python client that wraps AI-powered browser automation on top of Browserbase.  
-  Docs → `https://docs.stagehand.dev/python`
+  Docs → `https://docs.stagehand.dev/v3/sdk/python`
 - **extract**: Extract structured data from web pages using natural language instructions and Pydantic models.  
   Docs → `https://docs.stagehand.dev/basics/extract`
 - **concurrent sessions**: Run multiple browser sessions at the same time for faster batch processing.  

--- a/typescript/company-value-prop-generator/README.md
+++ b/typescript/company-value-prop-generator/README.md
@@ -6,12 +6,12 @@
 - Demonstrates Stagehand's `extract` method with Zod schemas to pull structured data from landing pages
 - Shows direct LLM API usage via `stagehand.llmClient` to transform extracted content with custom prompts
 - Includes placeholder page detection and validation logic to filter out non-functional sites
-- Docs → https://docs.browserbase.com/stagehand/extract
+- Docs → https://docs.stagehand.dev/v3/basics/extract
 
 ## GLOSSARY
 
 - Extract: Stagehand method that uses AI to pull structured data from pages using natural language instructions
-  Docs → https://docs.browserbase.com/stagehand/extract
+  Docs → https://docs.stagehand.dev/v3/basics/extract
 - Value Proposition: The core benefit or unique selling point a company communicates to customers
 
 ## QUICKSTART

--- a/typescript/form-filling/README.md
+++ b/typescript/form-filling/README.md
@@ -6,7 +6,7 @@
 - Smart Form Automation: dynamically fill contact forms with variable-driven data.
 - Field Detection: analyze page structure with `observe` before interacting with fields.
 - AI-Powered Interaction: leverage Stagehand to map inputs to the right fields reliably.
-  Docs → https://docs.browserbase.com/features/sessions
+  Docs → https://docs.browserbase.com/fundamentals/create-browser-session
 
 ## GLOSSARY
 

--- a/typescript/pickleball/README.md
+++ b/typescript/pickleball/README.md
@@ -6,7 +6,7 @@
 - AI Integration: Stagehand for UI interaction and data extraction.
 - Browser Automation: automates login, filtering, court selection, and booking confirmation.
 - User Interaction: prompts for activity type, date, and time preferences with validation.
-  Docs → https://docs.browserbase.com/features/sessions
+  Docs → https://docs.browserbase.com/fundamentals/create-browser-session
 
 ## GLOSSARY
 
@@ -17,7 +17,7 @@
 - observe: plan actions and get selectors before executing
   Docs → https://docs.stagehand.dev/basics/observe
 - browser automation: automated interaction with web applications for booking systems
-  Docs → https://docs.browserbase.com/features/sessions
+  Docs → https://docs.browserbase.com/fundamentals/create-browser-session
 - form validation: ensure user input meets booking system requirements
 
 ## QUICKSTART


### PR DESCRIPTION
Replace 8 dead URLs with current equivalents:
- docs.browserbase.com/features/sessions → /fundamentals/create-browser-session
- docs.browserbase.com/integrations/playwright/python → /introduction/playwright
- docs.browserbase.com/stagehand/extract → docs.stagehand.dev/v3/basics/extract
- docs.stagehand.dev/basics/navigate → /v3/references/page
- docs.stagehand.dev/basics/execute → /v3/basics/act
- docs.stagehand.dev/python → /v3/sdk/python
- docs.stagehand.dev/reference/python/overview → /v3/sdk/python
- github.com/browserbase/stagehand/tree/main/examples → browserbase.com/templates

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to README/help output URLs and do not affect runtime logic. Main risk is minor—incorrect new links could still misdirect users.
> 
> **Overview**
> Updates documentation links across Go/Python/TypeScript templates to point at current Stagehand v3 SDK/basics pages and the newer Browserbase docs URLs.
> 
> Also replaces a few stale resource links (e.g., old GitHub templates path and Playwright integration URL) and updates several Python templates’ error output to print the new Stagehand Python SDK docs link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b08e4b39450efc7e5164c9a5db6278afd3bdc72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->