### PR TITLE
Add Selenium TypeScript quickstart template

### DIFF
--- a/typescript/selenium/quickstart-selenium/.env.example
+++ b/typescript/selenium/quickstart-selenium/.env.example
@@ -1,0 +1,6 @@
+# Browserbase Configuration
+# Get your API key from: https://www.browserbase.com/settings
+BROWSERBASE_API_KEY=your_browserbase_api_key
+
+# Optional — inferred from your API key if not provided
+# BROWSERBASE_PROJECT_ID=your_browserbase_project_id

--- a/typescript/selenium/quickstart-selenium/README.md
+++ b/typescript/selenium/quickstart-selenium/README.md
@@ -50,21 +50,21 @@
 - Timeout waiting for element: increase the `until` timeout (default 10000ms) for slow-loading pages
 - Click intercepted: another element (cookie banner, overlay) may be covering the target — close it first or use `driver.wait()` to wait for it to disappear
 - Stale element reference: if the page reloads between finding and clicking an element, re-locate it with a fresh `driver.wait()` call
-- Find more information on your Browserbase dashboard → https://www.browserbase.com/sign-in
+- Find more information on your Browserbase dashboard -> https://www.browserbase.com/sign-in
 
 ## USE CASES
 
-- Getting started with Browserbase and Selenium in TypeScript
-- Migrating existing Selenium scripts to the cloud
-- Cloud browser automation without managing infrastructure
-- Cross-browser testing with Selenium Grid compatibility
+• Getting started with Browserbase and Selenium in TypeScript
+• Migrating existing Selenium scripts to the cloud
+• Cloud browser automation without managing infrastructure
+• Cross-browser testing with Selenium Grid compatibility
 
 ## NEXT STEPS
 
-- Add AI extraction: swap in Stagehand for AI-powered `act()`, `extract()`, and `observe()`
-- Enable proxies: pass `proxies: true` in `bb.sessions.create()` for residential proxy support
-- Enable stealth mode: add `browserSettings: { advancedStealth: true, solveCaptchas: true }` to bypass bot detection
-- Run in parallel: create multiple sessions for concurrent browser automation
+• Add AI extraction: swap in Stagehand for AI-powered `act()`, `extract()`, and `observe()`
+• Enable proxies: pass `proxies: true` in `bb.sessions.create()` for residential proxy support
+• Enable stealth mode: add `browserSettings: { advancedStealth: true, solveCaptchas: true }` to bypass bot detection
+• Run in parallel: create multiple sessions for concurrent browser automation
 
 ## HELPFUL RESOURCES
 

--- a/typescript/selenium/quickstart-selenium/README.md
+++ b/typescript/selenium/quickstart-selenium/README.md
@@ -1,0 +1,76 @@
+# Quickstart: Selenium + Browserbase (TypeScript)
+
+## AT A GLANCE
+
+- Goal: connect to a cloud browser via Selenium and Browserbase, click interactive elements, navigate between pages, and extract page copy.
+- No AI required: uses Selenium WebDriver and the Browserbase SDK directly — no model API key needed.
+- Demonstrates core Selenium patterns: navigation, element clicking, waiting, and text extraction.
+- Minimal setup: one script, one API key, instant cloud browser.
+  Docs → https://docs.browserbase.com/introduction/selenium
+
+## GLOSSARY
+
+- Session: a full cloud browser instance you connect to via Selenium WebDriver.
+  Docs → https://docs.browserbase.com/introduction/getting-started
+- Signing Key: a per-session key used to authenticate Selenium HTTP requests to Browserbase.
+  Docs → https://docs.browserbase.com/introduction/selenium
+- Selenium WebDriver: browser automation library — `driver.get()`, `driver.findElement()`, etc.
+  Docs → https://www.selenium.dev/documentation/webdriver/
+- WebDriverWait (until): robust element waiting — waits for elements to be clickable/visible before interacting, avoids brittle `setTimeout()`.
+  Docs → https://www.selenium.dev/documentation/webdriver/waits/
+
+## QUICKSTART
+
+1. cd typescript/selenium/quickstart-selenium
+2. npm install
+3. cp .env.example .env
+4. Add BROWSERBASE_API_KEY to .env (get it from https://browserbase.com/settings)
+5. npm start
+
+## EXPECTED OUTPUT
+
+- Creates a Browserbase cloud browser session
+- Connects via HTTP using Selenium WebDriver with a custom signing key
+- Prints browser name and version
+- Prints a live debug URL
+- Navigates to https://www.sfmoma.org and prints the URL and title
+- Clicks the search button to open the search overlay, then closes it
+- Clicks the Membership link and navigates to the membership page
+- Extracts the heading and intro copy from the membership page
+- Closes the driver
+
+## COMMON PITFALLS
+
+- Missing API key: verify .env contains BROWSERBASE_API_KEY — this is the only required credential
+- Project ID confusion: BROWSERBASE_PROJECT_ID is optional — the API infers it from your API key
+- Custom HTTP agent: Selenium requires a custom `http.Agent` to inject the `x-bb-signing-key` header — this is handled in the template code
+- Selenium uses HTTP not WebSocket: unlike Playwright/Puppeteer, Selenium connects over HTTP via `seleniumRemoteUrl`
+- Session not closing: always call `driver.quit()` in a `finally` block to avoid leaked sessions
+- Element not found: if selectors change on the target site, inspect the page and update `By.css()` or `By.linkText()` values
+- Timeout waiting for element: increase the `until` timeout (default 10000ms) for slow-loading pages
+- Click intercepted: another element (cookie banner, overlay) may be covering the target — close it first or use `driver.wait()` to wait for it to disappear
+- Stale element reference: if the page reloads between finding and clicking an element, re-locate it with a fresh `driver.wait()` call
+- Find more information on your Browserbase dashboard → https://www.browserbase.com/sign-in
+
+## USE CASES
+
+- Getting started with Browserbase and Selenium in TypeScript
+- Migrating existing Selenium scripts to the cloud
+- Cloud browser automation without managing infrastructure
+- Cross-browser testing with Selenium Grid compatibility
+
+## NEXT STEPS
+
+- Add AI extraction: swap in Stagehand for AI-powered `act()`, `extract()`, and `observe()`
+- Enable proxies: pass `proxies: true` in `bb.sessions.create()` for residential proxy support
+- Enable stealth mode: add `browserSettings: { advancedStealth: true, solveCaptchas: true }` to bypass bot detection
+- Run in parallel: create multiple sessions for concurrent browser automation
+
+## HELPFUL RESOURCES
+
+📚 Browserbase Docs: https://docs.browserbase.com
+🎮 Browserbase: https://www.browserbase.com
+💡 Try it out: https://www.browserbase.com/playground
+🔧 Templates: https://www.browserbase.com/templates
+📧 Need help? support@browserbase.com
+💬 Discord: http://stagehand.dev/discord

--- a/typescript/selenium/quickstart-selenium/index.ts
+++ b/typescript/selenium/quickstart-selenium/index.ts
@@ -21,7 +21,7 @@ const bb = new Browserbase({
   apiKey: BROWSERBASE_API_KEY,
 });
 
-async function run(): Promise<void> {
+async function main(): Promise<void> {
   // Create a new Browserbase session and connect via Selenium
   const session = await bb.sessions.create();
 
@@ -100,4 +100,12 @@ async function run(): Promise<void> {
   }
 }
 
-run();
+main().catch((err) => {
+  console.error("Error in Selenium quickstart:", err);
+  console.error("Common issues:");
+  console.error("  - Check .env file has BROWSERBASE_API_KEY set");
+  console.error("  - Verify your API key is valid at https://browserbase.com");
+  console.error("  - Ensure network connectivity to Browserbase servers");
+  console.error("Docs: https://docs.browserbase.com/quickstart/selenium");
+  process.exit(1);
+});

--- a/typescript/selenium/quickstart-selenium/index.ts
+++ b/typescript/selenium/quickstart-selenium/index.ts
@@ -1,0 +1,104 @@
+// Selenium + Browserbase: Quickstart
+// See README.md for full documentation
+
+import http from "http";
+import { Builder, By, until, type WebDriver } from "selenium-webdriver";
+import { Options } from "selenium-webdriver/chrome.js";
+import Browserbase from "@browserbasehq/sdk";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+// ============= CONFIGURATION =============
+const BROWSERBASE_API_KEY: string = process.env.BROWSERBASE_API_KEY!;
+// =========================================
+
+if (!BROWSERBASE_API_KEY) {
+  throw new Error("BROWSERBASE_API_KEY is not set");
+}
+
+const bb = new Browserbase({
+  apiKey: BROWSERBASE_API_KEY,
+});
+
+async function run(): Promise<void> {
+  // Create a new Browserbase session and connect via Selenium
+  const session = await bb.sessions.create();
+
+  const customHttpAgent = new http.Agent({});
+  const originalAddRequest = (http.Agent.prototype as unknown as Record<string, unknown>)
+    .addRequest as (req: http.ClientRequest, options: http.RequestOptions) => void;
+
+  (customHttpAgent as unknown as Record<string, unknown>).addRequest = (
+    req: http.ClientRequest,
+    options: http.RequestOptions,
+  ): void => {
+    req.setHeader("x-bb-signing-key", session.signingKey);
+    originalAddRequest.call(customHttpAgent, req, options);
+  };
+
+  const driver: WebDriver = new Builder()
+    .forBrowser("chrome")
+    .setChromeOptions(new Options())
+    .usingHttpAgent(customHttpAgent)
+    .usingServer(session.seleniumRemoteUrl)
+    .build();
+
+  const caps = await driver.getCapabilities();
+  console.log(
+    `Connected to Browserbase ${caps.getBrowserName()} version ${caps.getBrowserVersion()}`,
+  );
+  console.log(`Live debug URL: https://browserbase.com/sessions/${session.id}`);
+
+  try {
+    // Navigate to the SFMOMA homepage
+    await driver.get("https://www.sfmoma.org");
+    const url: string = await driver.getCurrentUrl();
+    const title: string = await driver.getTitle();
+    console.log(`At URL: ${url} | Title: ${title}`);
+
+    const WAIT_TIMEOUT = 10_000;
+
+    // Click the search button to open the search overlay
+    const searchButton = await driver.wait(
+      until.elementLocated(By.css('button[aria-label="Open search"]')),
+      WAIT_TIMEOUT,
+    );
+    await driver.wait(until.elementIsEnabled(searchButton), WAIT_TIMEOUT);
+    await searchButton.click();
+    console.log("Clicked search button — search overlay opened");
+
+    // Close the search overlay
+    const closeButton = await driver.wait(
+      until.elementLocated(By.css('button[aria-label="Close search"]')),
+      WAIT_TIMEOUT,
+    );
+    await driver.wait(until.elementIsEnabled(closeButton), WAIT_TIMEOUT);
+    await closeButton.click();
+    console.log("Closed search overlay");
+
+    // Click the Membership link
+    const membershipLink = await driver.wait(
+      until.elementLocated(By.linkText("Membership")),
+      WAIT_TIMEOUT,
+    );
+    await driver.wait(until.elementIsEnabled(membershipLink), WAIT_TIMEOUT);
+    await membershipLink.click();
+    await driver.wait(until.urlContains("/membership"), WAIT_TIMEOUT);
+    const membershipUrl: string = await driver.getCurrentUrl();
+    const membershipTitle: string = await driver.getTitle();
+    console.log(`At URL: ${membershipUrl} | Title: ${membershipTitle}`);
+
+    // Extract copy from the membership page
+    const heading = await driver.wait(until.elementLocated(By.tagName("h1")), WAIT_TIMEOUT);
+    console.log(`Heading: ${await heading.getText()}`);
+
+    const intro = await driver.findElement(By.css("main p"));
+    console.log(`Intro: ${await intro.getText()}`);
+  } finally {
+    // Make sure to quit the driver so your session is ended!
+    await driver.quit();
+  }
+}
+
+run();

--- a/typescript/selenium/quickstart-selenium/index.ts
+++ b/typescript/selenium/quickstart-selenium/index.ts
@@ -44,13 +44,12 @@ async function run(): Promise<void> {
     .usingServer(session.seleniumRemoteUrl)
     .build();
 
-  const caps = await driver.getCapabilities();
-  console.log(
-    `Connected to Browserbase ${caps.getBrowserName()} version ${caps.getBrowserVersion()}`,
-  );
-  console.log(`Live debug URL: https://browserbase.com/sessions/${session.id}`);
-
   try {
+    const caps = await driver.getCapabilities();
+    console.log(
+      `Connected to Browserbase ${caps.getBrowserName()} version ${caps.getBrowserVersion()}`,
+    );
+    console.log(`Live debug URL: https://browserbase.com/sessions/${session.id}`);
     // Navigate to the SFMOMA homepage
     await driver.get("https://www.sfmoma.org");
     const url: string = await driver.getCurrentUrl();
@@ -93,7 +92,7 @@ async function run(): Promise<void> {
     const heading = await driver.wait(until.elementLocated(By.tagName("h1")), WAIT_TIMEOUT);
     console.log(`Heading: ${await heading.getText()}`);
 
-    const intro = await driver.findElement(By.css("main p"));
+    const intro = await driver.wait(until.elementLocated(By.css("main p")), WAIT_TIMEOUT);
     console.log(`Intro: ${await intro.getText()}`);
   } finally {
     // Make sure to quit the driver so your session is ended!

--- a/typescript/selenium/quickstart-selenium/package.json
+++ b/typescript/selenium/quickstart-selenium/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "quickstart-selenium",
+  "version": "1.0.0",
+  "description": "Clone this repository to get started with Selenium (TypeScript) and Browserbase.",
+  "type": "module",
+  "main": "index.ts",
+  "scripts": {
+    "start": "tsx index.ts",
+    "dev": "tsx watch index.ts"
+  },
+  "dependencies": {
+    "@browserbasehq/sdk": "^2.8.0",
+    "dotenv": "^16.4.5",
+    "selenium-webdriver": "^4.29.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "@types/selenium-webdriver": "^4.1.28",
+    "tsx": "^4.16.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/typescript/selenium/quickstart-selenium/tsconfig.json
+++ b/typescript/selenium/quickstart-selenium/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["*.ts"]
+}


### PR DESCRIPTION
## Summary                                                                                                                                  
  - Adds `typescript/selenium/quickstart-selenium/` — a TypeScript Selenium quickstart that mirrors the Python version
  (`python/selenium/quickstart-selenium/`)                                                                                                    
  - Navigates to SFMOMA, clicks interactive elements (search open/close, Membership link), and extracts page copy   

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a new, self-contained quickstart under `typescript/selenium/quickstart-selenium/` and doesn’t modify existing runtime code paths.
> 
> **Overview**
> Adds a new `typescript/selenium/quickstart-selenium/` template with a runnable TypeScript Selenium script that creates a Browserbase session, injects the per-session `x-bb-signing-key` via a custom `http.Agent`, and drives a short flow on `sfmoma.org` (open/close search, navigate to Membership, extract heading/intro text).
> 
> Includes supporting template assets (`README.md`, `.env.example`, `package.json`, `tsconfig.json`) to document setup and provide a minimal Node/TS build/run configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77dee2334faea7527203a60539f0f955a7731b7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->