### PR TITLE
feat(browser-agent): adding browser agent demo from docs to templates…

### DIFF
--- a/python/cartesia-form-filling/README.md
+++ b/python/cartesia-form-filling/README.md
@@ -32,6 +32,7 @@ Voice Call (Cartesia) → Form Filling Node → Records Answer
 ## Getting Started
 
 First things first, here is what you will need:
+
 - A [Cartesia](https://play.cartesia.ai/agents) account and API key
 - A [Gemini API Key](https://aistudio.google.com/apikey)
 - A [Browserbase API Key and Project ID](https://www.browserbase.com/overview)
@@ -53,11 +54,13 @@ Make sure to add the API keys in your `.env` file or to the API keys section in 
 ## Setup
 
 1. Install dependencies:
+
 ```bash
 pip install .
 ```
 
 2. Set up environment variables - create a `.env` file:
+
 ```bash
 GEMINI_API_KEY=your_gemini_api_key_here
 BROWSERBASE_API_KEY=your_browserbase_api_key_here
@@ -65,6 +68,7 @@ BROWSERBASE_PROJECT_ID=your_browserbase_project_id_here
 ```
 
 3. Run the agent:
+
 ```bash
 python main.py
 ```
@@ -72,18 +76,23 @@ python main.py
 ## Project Structure
 
 ### `main.py`
+
 Entry point for the voice agent. Handles call initialization with `VoiceAgentApp` class and orchestrates the conversation flow with form filling integration.
 
 ### `form_filling_node.py`
+
 ReasoningNode subclass customized for voice-optimized form filling. Integrates Stagehand browser automation and manages async form filling during conversation without blocking the voice flow. Provides status updates and error handling.
 
 ### `stagehand_form_filler.py`
+
 Browser automation manager that handles all web interactions. Opens and controls web forms, maps conversation data to form fields using AI, transforms voice answers to form-compatible formats, and handles form submission. Supports different field types (text, select, checkbox, etc.).
 
 ### `config.py`
+
 System configuration file including system prompts, model IDs, and temperature
 
 ### `config.toml`
+
 Your Cartesia Line agent id.
 
 ## Configuration
@@ -129,6 +138,7 @@ For detailed deployment instructions, see [how to deploy an agent from the Carte
 ## Testing
 
 Test with different scenarios:
+
 - Complete questionnaire flow
 - Interruptions and corrections
 - Various answer formats

--- a/python/playwright-mfa-handling/README.md
+++ b/python/playwright-mfa-handling/README.md
@@ -21,12 +21,12 @@
 
 This template uses **pure Playwright** for browser automation. The Stagehand v3 Python SDK uses a session-based API with **observe** (find actions) and **act** (execute an action) instead. Here's how they compare:
 
-| Task          | Stagehand v3 — natural language (you describe intent) | Playwright — specific selectors (you target exact elements)   |
-| ------------- | ------------------------------------------------------- | ------------------------------------------------------------- |
-| Fill email    | *"Find the email field and type the user's email"*       | `page.locator('input[type="email"]').fill(email)`              |
-| Fill password | *"Find the password field and enter the password"*      | `page.locator('input[type="password"]').fill(password)`       |
-| Click submit  | *"Click the submit or sign-in button"*                   | `page.locator('input[type="submit"]').click()`                |
-| Check result  | *"Did login succeed or fail? Return success and message"* | `page.locator('text="Login Success"').is_visible()`          |
+| Task          | Stagehand v3 — natural language (you describe intent)     | Playwright — specific selectors (you target exact elements) |
+| ------------- | --------------------------------------------------------- | ----------------------------------------------------------- |
+| Fill email    | _"Find the email field and type the user's email"_        | `page.locator('input[type="email"]').fill(email)`           |
+| Fill password | _"Find the password field and enter the password"_        | `page.locator('input[type="password"]').fill(password)`     |
+| Click submit  | _"Click the submit or sign-in button"_                    | `page.locator('input[type="submit"]').click()`              |
+| Check result  | _"Did login succeed or fail? Return success and message"_ | `page.locator('text="Login Success"').is_visible()`         |
 
 **Example - Filling the login form:**
 

--- a/typescript/agent-with-human-in-loop/README.md
+++ b/typescript/agent-with-human-in-loop/README.md
@@ -1,6 +1,7 @@
 # Stagehand + Browserbase: Human-in-the-Loop Agent
 
 ## AT A GLANCE
+
 - Goal: showcase how to build an AI agent that can pause and ask a human for input mid-task using Stagehand and Browserbase.
 - Interactive Agent Loop: the agent automates browser tasks but can request human guidance when it encounters decisions it can't make alone.
 - Live Browser View: watch the agent work in real-time through an embedded Browserbase session.
@@ -8,6 +9,7 @@
   Docs → https://docs.browserbase.com/features/sessions
 
 ## GLOSSARY
+
 - agent: an AI-driven Stagehand instance that autonomously performs browser actions and can invoke custom tools
   Docs → https://docs.stagehand.dev/basics/agent
 - askHuman: a custom agent tool that pauses execution and sends a question to the user, resuming once a response is provided
@@ -18,16 +20,18 @@
   Docs → https://docs.stagehand.dev/basics/observe
 
 ## QUICKSTART
- 1) cd agent-with-human-in-loop
- 2) npm install
- 3) Create a .env file and add your Browserbase credentials:
+
+1.  cd agent-with-human-in-loop
+2.  npm install
+3.  Create a .env file and add your Browserbase credentials:
     BROWSERBASE_API_KEY=your-api-key
     BROWSERBASE_PROJECT_ID=your-project-id
     ANTHROPIC_API_KEY=your-anthropic-api-key
- 5) npm run dev
- 6) Open http://localhost:3000 in your browser
+4.  npm run dev
+5.  Open http://localhost:3000 in your browser
 
 ## EXPECTED OUTPUT
+
 - A form appears to enter an applicant's name and upload a resume
 - On submit, a Browserbase session starts and the live browser view loads
 - The agent navigates to a job application site and begins filling out the form
@@ -35,11 +39,13 @@
 - You type a response and the agent resumes with your input
 
 ## USE CASES
+
 • Assisted form filling: automate job applications, account signups, or onboarding flows where some fields require human judgment.
 • Approval workflows: let an agent prepare actions (purchases, submissions) but pause for human confirmation before committing.
 • Supervised data entry: automate repetitive browser data entry while letting a human handle edge cases or ambiguous inputs.
 
 ## HELPFUL RESOURCES
+
 📚 Stagehand Docs: https://docs.stagehand.dev
 📚 Stagehand Agent: https://docs.stagehand.dev/basics/agent
 🎮 Browserbase: https://www.browserbase.com

--- a/typescript/agent-with-human-in-loop/app/api/agent/respond/route.ts
+++ b/typescript/agent-with-human-in-loop/app/api/agent/respond/route.ts
@@ -8,19 +8,13 @@ export async function POST(req: Request) {
   const { id, response } = await req.json();
 
   if (!id || !response) {
-    return Response.json(
-      { error: "id and response are required" },
-      { status: 400 }
-    );
+    return Response.json({ error: "id and response are required" }, { status: 400 });
   }
 
   const resolved = resolveQuestion(id, response);
 
   if (!resolved) {
-    return Response.json(
-      { error: "No pending question for this session" },
-      { status: 400 }
-    );
+    return Response.json({ error: "No pending question for this session" }, { status: 400 });
   }
 
   return Response.json({ ok: true });

--- a/typescript/agent-with-human-in-loop/app/api/agent/route.ts
+++ b/typescript/agent-with-human-in-loop/app/api/agent/route.ts
@@ -13,7 +13,7 @@ export async function POST(req: Request) {
   if (!firstName || !lastName || !resumeBase64 || !resumeFileName) {
     return Response.json(
       { error: "firstName, lastName, resumeBase64, and resumeFileName are required" },
-      { status: 400 }
+      { status: 400 },
     );
   }
 

--- a/typescript/agent-with-human-in-loop/app/layout.tsx
+++ b/typescript/agent-with-human-in-loop/app/layout.tsx
@@ -24,10 +24,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html
-      lang="en"
-      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
-    >
+    <html lang="en" className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}>
       <body className="min-h-full flex flex-col">{children}</body>
     </html>
   );

--- a/typescript/agent-with-human-in-loop/app/page.tsx
+++ b/typescript/agent-with-human-in-loop/app/page.tsx
@@ -17,9 +17,7 @@ export default function Home() {
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
   const [resumeFile, setResumeFile] = useState<File | null>(null);
-  const [phase, setPhase] = useState<
-    "form" | "running" | "waiting" | "complete" | "error"
-  >("form");
+  const [phase, setPhase] = useState<"form" | "running" | "waiting" | "complete" | "error">("form");
   const [debuggerUrl, setDebuggerUrl] = useState<string | null>(null);
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [currentQuestion, setCurrentQuestion] = useState("");
@@ -164,24 +162,19 @@ export default function Home() {
       <main className="flex-1 flex items-center justify-center p-8">
         <div className="w-full max-w-md space-y-6">
           <div className="space-y-2 text-center">
-            <h1 className="text-2xl font-bold tracking-tight">
-              Human-in-the-Loop Agent
-            </h1>
+            <h1 className="text-2xl font-bold tracking-tight">Human-in-the-Loop Agent</h1>
             <p className="text-sm text-neutral-400">
-              Fill out your first and last name, upload a resume (you can use
-              the <code className="text-neutral-300">template_resume.pdf</code>{" "}
-              file in the project root as an example), and click{" "}
-              <strong className="text-neutral-300">Start Agent</strong>. An AI
-              agent will apply to a job on your behalf — when it needs more
-              information, it will pause to ask you directly.
+              Fill out your first and last name, upload a resume (you can use the{" "}
+              <code className="text-neutral-300">template_resume.pdf</code> file in the project root
+              as an example), and click <strong className="text-neutral-300">Start Agent</strong>.
+              An AI agent will apply to a job on your behalf — when it needs more information, it
+              will pause to ask you directly.
             </p>
           </div>
 
           <div className="space-y-4">
             <div>
-              <label className="block text-sm font-medium mb-1">
-                First Name
-              </label>
+              <label className="block text-sm font-medium mb-1">First Name</label>
               <input
                 type="text"
                 value={firstName}
@@ -191,9 +184,7 @@ export default function Home() {
               />
             </div>
             <div>
-              <label className="block text-sm font-medium mb-1">
-                Last Name
-              </label>
+              <label className="block text-sm font-medium mb-1">Last Name</label>
               <input
                 type="text"
                 value={lastName}
@@ -203,9 +194,7 @@ export default function Home() {
               />
             </div>
             <div>
-              <label className="block text-sm font-medium mb-1">
-                Resume
-              </label>
+              <label className="block text-sm font-medium mb-1">Resume</label>
               <input
                 type="file"
                 accept=".pdf,.doc,.docx"
@@ -221,9 +210,7 @@ export default function Home() {
                 }}
                 className="w-full rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm file:mr-3 file:rounded file:border-0 file:bg-neutral-700 file:px-3 file:py-1 file:text-sm file:text-neutral-200 focus:outline-none focus:ring-2 focus:ring-blue-500"
               />
-              <p className="text-xs text-neutral-500 mt-1">
-                PDF, DOC, or DOCX up to 10MB
-              </p>
+              <p className="text-xs text-neutral-500 mt-1">PDF, DOC, or DOCX up to 10MB</p>
             </div>
             <button
               onClick={handleStart}
@@ -316,9 +303,7 @@ export default function Home() {
           {phase === "waiting" && (
             <div className="space-y-3">
               <div className="rounded-md bg-yellow-500/10 border border-yellow-500/30 p-3">
-                <p className="text-xs text-yellow-400 font-medium mb-1">
-                  Agent needs your help:
-                </p>
+                <p className="text-xs text-yellow-400 font-medium mb-1">Agent needs your help:</p>
                 <p className="text-sm text-yellow-200">{currentQuestion}</p>
               </div>
               <div className="flex gap-2">

--- a/typescript/agent-with-human-in-loop/lib/agent.ts
+++ b/typescript/agent-with-human-in-loop/lib/agent.ts
@@ -15,7 +15,7 @@ import { tmpdir } from "os";
 function sendEvent(
   writer: WritableStreamDefaultWriter<Uint8Array>,
   event: string,
-  data: Record<string, unknown>
+  data: Record<string, unknown>,
 ) {
   const encoder = new TextEncoder();
   const msg = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
@@ -110,9 +110,9 @@ of trying to click or interact with the file input directly.`,
             "Use this when you encounter form fields requiring personal info you don't have. " +
             "Be specific about what information you need.",
           inputSchema: z.object({
-            question: z.string().describe(
-              "The question to ask the human. Be specific about what info is needed."
-            ),
+            question: z
+              .string()
+              .describe("The question to ask the human. Be specific about what info is needed."),
           }),
           execute: async ({ question }) => {
             // Send question to the frontend via SSE
@@ -205,7 +205,12 @@ of trying to click or interact with the file input directly.`,
     });
   } finally {
     // Clean up temp resume file (in finally so it's removed even on error)
-    if (resumePath) try { unlinkSync(resumePath); } catch { /* ignore */ }
+    if (resumePath)
+      try {
+        unlinkSync(resumePath);
+      } catch {
+        /* ignore */
+      }
     await writer.close();
   }
 }

--- a/typescript/agent-with-human-in-loop/lib/session-store.ts
+++ b/typescript/agent-with-human-in-loop/lib/session-store.ts
@@ -39,11 +39,7 @@ export function getSession(id: string): SessionState | undefined {
   return sessions.get(id);
 }
 
-export function setQuestion(
-  id: string,
-  question: string,
-  resolver: (response: string) => void
-) {
+export function setQuestion(id: string, question: string, resolver: (response: string) => void) {
   const session = sessions.get(id);
   if (session) {
     session.status = "waiting_for_human";

--- a/typescript/browser-agent-demo/.env.example
+++ b/typescript/browser-agent-demo/.env.example
@@ -1,0 +1,2 @@
+# Your Browserbase API key (Yep that's it)
+BROWSERBASE_API_KEY=

--- a/typescript/browser-agent-demo/.gitignore
+++ b/typescript/browser-agent-demo/.gitignore
@@ -1,0 +1,18 @@
+# Dependencies
+node_modules/
+
+# Environment variables
+.env
+.env.local
+
+# TypeScript build info
+*.tsbuildinfo
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+npm-debug.log*
+pnpm-debug.log*

--- a/typescript/browser-agent-demo/README.md
+++ b/typescript/browser-agent-demo/README.md
@@ -70,6 +70,7 @@ Docs → https://docs.browserbase.com/features/functions
 📚 Stagehand Docs: https://docs.stagehand.dev
 📚 Search API: https://docs.browserbase.com/features/search
 📚 Fetch API: https://docs.browserbase.com/features/fetch
+📚 Implementation Docs: https://docs.browserbase.com/features/fetch
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground
 🔧 Templates: https://www.browserbase.com/templates

--- a/typescript/browser-agent-demo/README.md
+++ b/typescript/browser-agent-demo/README.md
@@ -1,0 +1,77 @@
+# Browser Agent Demo: Search, Fetch & Stagehand Agent on Browserbase
+
+## AT A GLANCE
+
+- **Goal**: build a browser agent that searches the web, fetches page content, and autonomously extracts information — all through one Browserbase API key.
+- **Pattern**: Search → Fetch → Stagehand Agent. Lightweight primitives (Search, Fetch) gather context cheaply before spinning up a full browser agent for interaction.
+- **Single API key**: the Model Gateway routes LLM requests through Browserbase — no separate OpenAI/Anthropic/Google keys needed.
+- **Full platform demo**: uses Browsers, Search API, Fetch API, Stagehand, and Model Gateway together.
+  Docs → https://docs.browserbase.com
+
+## GLOSSARY
+
+- **Search API**: search the web for structured results (titles, URLs, metadata) without a browser session.
+  Docs → https://docs.browserbase.com/features/search
+- **Fetch API**: fetch page content (HTML, status, headers) for token-efficient context — no browser needed.
+  Docs → https://docs.browserbase.com/features/fetch
+- **Stagehand**: the AI SDK for browser agents — act, extract, observe, and agent primitives.
+  Docs → https://docs.stagehand.dev
+- **agent()**: Stagehand primitive that gives a model full control of a headless browser via natural-language instructions.
+  Docs → https://docs.stagehand.dev/v3/basics/agent
+- **Model Gateway**: routes LLM requests through Browserbase with unified billing across OpenAI, Anthropic, and Google.
+  Docs → https://docs.browserbase.com/features/model-gateway
+- **Agent Identity**: built-in credential management and strategic partnerships for accessing any website.
+  Docs → https://docs.browserbase.com/features/agent-identity
+
+## QUICKSTART
+
+1. cd typescript/browser-agent-demo
+2. pnpm install
+3. cp .env.example .env
+4. Add BROWSERBASE_API_KEY to .env (get it from https://browserbase.com/settings)
+5. pnpm start
+
+## EXPECTED OUTPUT
+
+- Searches the web for "best coffee shops in San Francisco" and displays 5 structured results
+- Selects the top result and fetches its HTML content with status code, content type, and preview
+- Launches a Stagehand browser agent on Browserbase and prints the session replay URL
+- Navigates to the selected page and autonomously extracts the top 3 recommendations
+- Outputs the agent's structured findings and closes the session
+
+## COMMON PITFALLS
+
+- Missing API key: verify .env contains BROWSERBASE_API_KEY — this is the only required credential
+- No separate LLM keys needed: the Model Gateway handles model access through your Browserbase key
+- Search returns no results: try a different query string — some queries may return empty depending on availability
+- Agent timeout: increase `maxSteps` if the page is complex and the agent needs more interactions
+- Session not closing: the demo uses `try/finally` to ensure `stagehand.close()` runs — always clean up sessions
+- Find more information on your Browserbase dashboard -> https://www.browserbase.com/sign-in
+
+## USE CASES
+
+• Building research agents that search, evaluate, and extract from web pages
+• Token-efficient web browsing pipelines (cheap Search/Fetch before expensive browser sessions)
+• Autonomous data extraction from any website without writing selectors
+• Prototyping browser agents with the full Browserbase platform
+
+## NEXT STEPS
+
+• **Customize the query**: change the search query and agent instructions to extract different types of information
+• **Add multi-page navigation**: chain multiple `agent.execute()` calls to browse across several pages
+• **Deploy as a Function**: run the agent on Browserbase infrastructure with <5ms browser latency
+Docs → https://docs.browserbase.com/features/functions
+• **Enable stealth mode**: add `browserSettings: { advancedStealth: true, solveCaptchas: true }` for protected sites
+• **Switch models**: change `model` in the Stagehand constructor to use OpenAI or Google models via the Model Gateway
+
+## HELPFUL RESOURCES
+
+📚 Browserbase Docs: https://docs.browserbase.com
+📚 Stagehand Docs: https://docs.stagehand.dev
+📚 Search API: https://docs.browserbase.com/features/search
+📚 Fetch API: https://docs.browserbase.com/features/fetch
+🎮 Browserbase: https://www.browserbase.com
+💡 Try it out: https://www.browserbase.com/playground
+🔧 Templates: https://www.browserbase.com/templates
+📧 Need help? support@browserbase.com
+💬 Discord: http://stagehand.dev/discord

--- a/typescript/browser-agent-demo/index.ts
+++ b/typescript/browser-agent-demo/index.ts
@@ -1,0 +1,130 @@
+import { Browserbase } from "@browserbasehq/sdk";
+import { Stagehand } from "@browserbasehq/stagehand";
+import "dotenv/config";
+
+async function main() {
+  const apiKey = process.env.BROWSERBASE_API_KEY!;
+
+  if (!apiKey) {
+    throw new Error("Missing BROWSERBASE_API_KEY. Get one at https://browserbase.com/settings");
+  }
+
+  // One API key, everything your agent needs to browse the web.
+  // Docs: https://docs.browserbase.com
+  const bb = new Browserbase({ apiKey });
+
+  const query = "best coffee shops in San Francisco";
+
+  // ─── STEP 1: SEARCH ─────────────────────────────────────────────────────────
+  // Agents can quickly search the web for context without spinning up a browser.
+  // Returns structured results (titles, URLs, metadata) for token-efficient decisions.
+  // Docs: https://docs.browserbase.com/features/search
+
+  console.log(`\nSTEP 1: SEARCH`);
+  console.log(`   Searching for: "${query}"\n`);
+
+  const searchData = await bb.search.web({
+    query,
+    numResults: 5,
+  });
+
+  console.log(`   Found ${searchData.results.length} results:`);
+  for (const [i, result] of searchData.results.entries()) {
+    console.log(`   ${i + 1}. ${result.title}`);
+    console.log(`      ${result.url}`);
+    if (result.publishedDate) {
+      console.log(`      Published: ${result.publishedDate}`);
+    }
+  }
+
+  const topResult = searchData.results[0];
+  if (!topResult) {
+    throw new Error("No search results found. Try a different query.");
+  }
+
+  const targetUrl = topResult.url;
+  const targetTitle = topResult.title;
+  console.log(`\n   -> Selected top result: "${targetTitle}"\n`);
+
+  // ─── STEP 2: FETCH ──────────────────────────────────────────────────────────
+  // Fetch page content (HTML, status, headers) for quick, token-efficient context —
+  // no browser session needed. Use it for recon before sending an agent to interact.
+  // Docs: https://docs.browserbase.com/features/fetch
+
+  console.log(`STEP 2: FETCH`);
+  console.log(`   Fetching content from: ${targetUrl}\n`);
+
+  const fetchResult = await bb.fetchAPI.create({
+    url: targetUrl,
+    allowRedirects: true,
+  });
+
+  console.log(`   Status:         ${fetchResult.statusCode}`);
+  console.log(`   Content-Type:   ${fetchResult.contentType}`);
+  console.log(`   Content length: ${fetchResult.content.length} chars`);
+
+  const textPreview = fetchResult.content
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .substring(0, 300);
+  console.log(`   Preview:        ${textPreview}...`);
+  console.log();
+
+  // ─── STEP 3: STAGEHAND AGENT ────────────────────────────────────────────────
+  // Stagehand is the AI SDK for browser agents — act, extract, observe, and agent
+  // primitives that let agents browse and interact with the web like humans.
+  // Docs: https://docs.stagehand.dev | Agent: https://docs.stagehand.dev/v3/basics/agent
+
+  console.log(`STEP 3: STAGEHAND AGENT`);
+  console.log(`   Launching browser...\n`);
+
+  // env: "BROWSERBASE" runs on Browserbase's headless browser infrastructure with
+  // session replay, Agent Identity, and proxies built in.
+  // The Model Gateway routes LLM requests through Browserbase — one API key gives
+  // access to models from OpenAI, Anthropic, and Google with unified billing.
+  const stagehand = new Stagehand({
+    env: "BROWSERBASE",
+    model: "anthropic/claude-sonnet-4-6",
+  });
+
+  await stagehand.init();
+
+  try {
+    console.log(`   Session:  https://browserbase.com/sessions/${stagehand.browserbaseSessionID}`);
+    console.log(`   Navigating to: ${targetUrl}`);
+
+    const page = stagehand.context.pages()[0]!;
+    await page.goto(targetUrl);
+
+    console.log(`   Starting autonomous agent...\n`);
+
+    // stagehand.agent() creates a browser agent that can autonomously navigate, click,
+    // type, scroll, and extract data — driven by a natural-language instruction.
+    const agent = stagehand.agent({
+      systemPrompt:
+        "You are a helpful research assistant browsing the web. " +
+        "Extract factual information from pages. Be concise and structured.",
+    });
+
+    const agentResult = await agent.execute({
+      instruction:
+        `You're on a page about "${targetTitle}". ` +
+        `Extract the top 3 recommendations or key points from this page. ` +
+        `For each, include the name and a one-sentence summary of why it's notable.`,
+      maxSteps: 10,
+    });
+
+    console.log(`\n   ── Agent Result ──`);
+    console.log(agentResult);
+  } finally {
+    await stagehand.close();
+  }
+
+  console.log(`\nDone! Watch the session replay at the URL above to see what the agent did.`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/typescript/browser-agent-demo/package.json
+++ b/typescript/browser-agent-demo/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "browser-agent-demo",
+  "version": "1.0.0",
+  "description": "Browser Agent Demo - Build a full fledged browser agent using the Browserbase Platform",
+  "main": "index.js",
+  "scripts": {
+    "start": "npx tsx index.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "packageManager": "pnpm@9.15.0",
+  "type": "module",
+  "dependencies": {
+    "@browserbasehq/sdk": "^2.9.0",
+    "@browserbasehq/stagehand": "^3.2.0",
+    "dotenv": "^17.4.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.8.2"
+  }
+}

--- a/typescript/browser-agent-demo/tsconfig.json
+++ b/typescript/browser-agent-demo/tsconfig.json
@@ -1,0 +1,44 @@
+{
+  // Visit https://aka.ms/tsconfig to read more about this file
+  "compilerOptions": {
+    // File Layout
+    // "rootDir": "./src",
+    // "outDir": "./dist",
+
+    // Environment Settings
+    // See also https://aka.ms/tsconfig/module
+    "module": "nodenext",
+    "target": "esnext",
+    "types": [],
+    // For nodejs:
+    // "lib": ["esnext"],
+    // "types": ["node"],
+    // and npm install -D @types/node
+
+    // Other Outputs
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+
+    // Stricter Typechecking Options
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+
+    // Style Options
+    // "noImplicitReturns": true,
+    // "noImplicitOverride": true,
+    // "noUnusedLocals": true,
+    // "noUnusedParameters": true,
+    // "noFallthroughCasesInSwitch": true,
+    // "noPropertyAccessFromIndexSignature": true,
+
+    // Recommended Options
+    "strict": true,
+    "jsx": "react-jsx",
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "noUncheckedSideEffectImports": true,
+    "moduleDetection": "force",
+    "skipLibCheck": true
+  }
+}

--- a/typescript/exa-browserbase/index.ts
+++ b/typescript/exa-browserbase/index.ts
@@ -69,9 +69,7 @@ Your responsibilities:
 Think critically about each field and present the candidate in the best professional light.`;
 
 // Builds the instruction prompt for the agent based on available job description
-function buildAgentInstruction(
-  jobDescription: z.infer<typeof jobDescriptionSchema>,
-): string {
+function buildAgentInstruction(jobDescription: z.infer<typeof jobDescriptionSchema>): string {
   const hasJobDescription = jobDescription.jobTitle || jobDescription.fullDescription;
 
   if (hasJobDescription) {
@@ -120,10 +118,7 @@ async function uploadResume(stagehand: Stagehand, logPrefix: string = ""): Promi
   const mainPageInputs = await pwPage.locator('input[type="file"]').count();
 
   if (mainPageInputs > 0) {
-    await pwPage
-      .locator('input[type="file"]')
-      .first()
-      .setInputFiles(applicationDetails.resumePath);
+    await pwPage.locator('input[type="file"]').first().setInputFiles(applicationDetails.resumePath);
     console.log(`${logPrefix}Resume uploaded successfully from main page!`);
     return;
   }
@@ -159,10 +154,7 @@ interface ApplicationResult {
 }
 
 // Applies to a single job posting
-async function applyToJob(
-  careersPage: CareersPage,
-  index: number,
-): Promise<ApplicationResult> {
+async function applyToJob(careersPage: CareersPage, index: number): Promise<ApplicationResult> {
   const logPrefix = `[${index + 1}/${searchConfig.numCompanies}] ${careersPage.company}: `;
   console.log(`\n${logPrefix}Starting application...`);
 
@@ -342,7 +334,9 @@ async function main() {
   const successful = results.filter((r) => r.success);
   const failed = results.filter((r) => !r.success);
 
-  console.log(`\nTotal: ${results.length} | Success: ${successful.length} | Failed: ${failed.length}\n`);
+  console.log(
+    `\nTotal: ${results.length} | Success: ${successful.length} | Failed: ${failed.length}\n`,
+  );
 
   results.forEach((r, i) => {
     const status = r.success ? "[SUCCESS]" : "[FAILED]";

--- a/typescript/image-url-download/index.ts
+++ b/typescript/image-url-download/index.ts
@@ -97,8 +97,12 @@ async function main(): Promise<void> {
 
     // Deduplicate and filter out any empty/malformed URLs before applying the limit.
     const uniqueUrls = [...new Set(allUrls)].filter((u) => {
-      try { const { protocol } = new URL(u); return protocol === "https:" || protocol === "http:"; }
-      catch { return false; }
+      try {
+        const { protocol } = new URL(u);
+        return protocol === "https:" || protocol === "http:";
+      } catch {
+        return false;
+      }
     });
     console.log(`Found ${uniqueUrls.length} unique image URL(s)`);
 
@@ -147,7 +151,10 @@ async function main(): Promise<void> {
               reader.onload = () => {
                 const dataUrl = reader.result as string;
                 const comma = dataUrl.indexOf(",");
-                if (comma === -1) { resolve(null); return; }
+                if (comma === -1) {
+                  resolve(null);
+                  return;
+                }
                 const prefix = dataUrl.slice(0, comma); // e.g. "data:image/png;base64"
                 const base64 = dataUrl.slice(comma + 1);
                 const mimeMatch = prefix.match(/data:([^;]+)/);

--- a/typescript/manual-mfa-with-contexts/index.ts
+++ b/typescript/manual-mfa-with-contexts/index.ts
@@ -15,7 +15,7 @@ const bb = new Browserbase({
 async function createSessionWithContext() {
   console.log("Creating new Browserbase context...");
 
-  const context = await bb.createContext()
+  const context = await bb.createContext();
 
   console.log(`Context created: ${context.id}`);
   console.log("First session: Performing login with MFA...");

--- a/typescript/smart-fetch-scraper/README.md
+++ b/typescript/smart-fetch-scraper/README.md
@@ -29,11 +29,13 @@
 ## EXAMPLE URLS
 
 Fetch API fast-path (server-rendered, returns usable HTML directly):
+
 - `npm start https://news.ycombinator.com` — server-rendered, lightweight HTML
 - `npm start https://en.wikipedia.org/wiki/Web_scraping` — static content, no JS required
 - `npm start https://www.bbc.com/news` — server-rendered news page
 
 Browser fallback (JS-rendered, blocked, or low text density):
+
 - `npm start https://www.reddit.com` — returns a 403, triggers fallback
 - `npm start https://x.com` — returns an "Enable JavaScript" shell page
 - `npm start https://github.com/trending` — HTML is mostly inline scripts (3.6% text density), triggers fallback

--- a/typescript/smart-fetch-scraper/index.ts
+++ b/typescript/smart-fetch-scraper/index.ts
@@ -68,7 +68,10 @@ function needsBrowserFallback(content: string, statusCode: number): string | nul
   }
 
   // Low text density: strip all HTML tags and measure how much real text remains
-  const textOnly = content.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim();
+  const textOnly = content
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
   const density = textOnly.length / content.length;
   if (density < MIN_TEXT_DENSITY) {
     return `text density too low (${(density * 100).toFixed(1)}% < ${MIN_TEXT_DENSITY * 100}%)`;
@@ -90,7 +93,9 @@ async function tryFetchApi(url: string): Promise<{ content: string; statusCode: 
   try {
     const data = await bb.fetchAPI.create({ url, allowRedirects: true });
 
-    console.log(`[Fetch API] Got response: status=${data.statusCode}, length=${data.content.length} chars`);
+    console.log(
+      `[Fetch API] Got response: status=${data.statusCode}, length=${data.content.length} chars`,
+    );
 
     const fallbackReason = needsBrowserFallback(data.content, data.statusCode);
     if (fallbackReason) {
@@ -141,7 +146,9 @@ async function extractWithBrowser(url: string) {
 
   try {
     await stagehand.init();
-    console.log(`[Browser] Live View: https://browserbase.com/sessions/${stagehand.browserbaseSessionID}`);
+    console.log(
+      `[Browser] Live View: https://browserbase.com/sessions/${stagehand.browserbaseSessionID}`,
+    );
 
     const page = stagehand.context.pages()[0];
     await page.goto(url);


### PR DESCRIPTION
# Summary

adding browser agent demo from gtm demos, also ran eslint/prettier on entire project

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily adds a new standalone TypeScript demo template and applies formatting-only changes across existing examples, with no shared library or production logic changes.
> 
> **Overview**
> Adds a new `typescript/browser-agent-demo` template that demonstrates a **Search → Fetch → Stagehand agent** workflow using only `BROWSERBASE_API_KEY`, including runnable code (`index.ts`), `package.json`/`tsconfig.json`, and setup docs.
> 
> Separately applies repo-wide doc/code formatting touch-ups (README markdown/table cleanup and Prettier-style line wrapping) across several existing Python/TypeScript templates, without changing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d59c46b4a5d9a43374d96b1c910cdaa874652839. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->