### PR TITLE
Sydshields/dash 1732 turn existing templates in js files

### DIFF
--- a/.github/workflows/playground-production.yml
+++ b/.github/workflows/playground-production.yml
@@ -18,5 +18,3 @@ permissions:
 jobs:
   playground-templates:
     uses: ./.github/workflows/playground.yml
-    with:
-      branch: production

--- a/.github/workflows/playground-test-production.yml
+++ b/.github/workflows/playground-test-production.yml
@@ -18,5 +18,3 @@ permissions:
 jobs:
   playground-templates:
     uses: ./.github/workflows/playground.yml
-    with:
-      branch: test-production

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -48,6 +48,6 @@ jobs:
           if git diff --staged --quiet; then
             echo "No javascript changes to commit."
           else
-            git commit -m "chore: regenerate playground javascript templates"
+            git commit --no-verify -m "chore: regenerate playground javascript templates"
             git push
           fi

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -8,11 +8,6 @@ name: Playground templates
 
 on:
   workflow_call:
-    inputs:
-      branch:
-        description: Target branch name (used only in log messages)
-        required: true
-        type: string
 
 permissions:
   contents: write


### PR DESCRIPTION
- tests the js build with --no-verify flag

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change; it just tweaks GitHub Actions workflow wiring and uses `--no-verify` when auto-committing generated `javascript/` output, which could let unexpected changes be committed if hooks previously enforced checks.
> 
> **Overview**
> Removes the `branch` input plumbing from the reusable `playground.yml` workflow and stops passing that input from the `production` and `test-production` trigger workflows.
> 
> Updates the push-only auto-commit step to run `git commit --no-verify`, ensuring generated `javascript/` template updates can be committed even if local hooks would fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e8538382867a2ec6f7aeaa2c91da3d98ed5e5fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->