### PR TITLE
[CE-865] Add agent instructions to TypeScript templates

### DIFF
--- a/typescript/agent-with-human-in-loop/AGENTS.md
+++ b/typescript/agent-with-human-in-loop/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/agent-with-human-in-loop/CLAUDE.md
+++ b/typescript/agent-with-human-in-loop/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/amazon-global-price-comparison/AGENTS.md
+++ b/typescript/amazon-global-price-comparison/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/amazon-global-price-comparison/CLAUDE.md
+++ b/typescript/amazon-global-price-comparison/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/amazon-product-scraping/AGENTS.md
+++ b/typescript/amazon-product-scraping/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/amazon-product-scraping/CLAUDE.md
+++ b/typescript/amazon-product-scraping/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/basic-caching/AGENTS.md
+++ b/typescript/basic-caching/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/basic-caching/CLAUDE.md
+++ b/typescript/basic-caching/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/basic-recaptcha/AGENTS.md
+++ b/typescript/basic-recaptcha/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/basic-recaptcha/CLAUDE.md
+++ b/typescript/basic-recaptcha/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/browser-agent-demo/AGENTS.md
+++ b/typescript/browser-agent-demo/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/browser-agent-demo/CLAUDE.md
+++ b/typescript/browser-agent-demo/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/browserbase-reducto/AGENTS.md
+++ b/typescript/browserbase-reducto/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/browserbase-reducto/CLAUDE.md
+++ b/typescript/browserbase-reducto/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/business-lookup/AGENTS.md
+++ b/typescript/business-lookup/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/business-lookup/CLAUDE.md
+++ b/typescript/business-lookup/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/company-address-finder/AGENTS.md
+++ b/typescript/company-address-finder/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/company-address-finder/CLAUDE.md
+++ b/typescript/company-address-finder/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/company-value-prop-generator/AGENTS.md
+++ b/typescript/company-value-prop-generator/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/company-value-prop-generator/CLAUDE.md
+++ b/typescript/company-value-prop-generator/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/context/AGENTS.md
+++ b/typescript/context/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/context/CLAUDE.md
+++ b/typescript/context/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/council-events/AGENTS.md
+++ b/typescript/council-events/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/council-events/CLAUDE.md
+++ b/typescript/council-events/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/download-financial-statements/AGENTS.md
+++ b/typescript/download-financial-statements/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/download-financial-statements/CLAUDE.md
+++ b/typescript/download-financial-statements/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/dynamic-form-filling/AGENTS.md
+++ b/typescript/dynamic-form-filling/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/dynamic-form-filling/CLAUDE.md
+++ b/typescript/dynamic-form-filling/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/exa-browserbase/AGENTS.md
+++ b/typescript/exa-browserbase/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/exa-browserbase/CLAUDE.md
+++ b/typescript/exa-browserbase/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/extend-browserbase/AGENTS.md
+++ b/typescript/extend-browserbase/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/extend-browserbase/CLAUDE.md
+++ b/typescript/extend-browserbase/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/form-filling/AGENTS.md
+++ b/typescript/form-filling/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/form-filling/CLAUDE.md
+++ b/typescript/form-filling/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/gemini-3-flash/AGENTS.md
+++ b/typescript/gemini-3-flash/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/gemini-3-flash/CLAUDE.md
+++ b/typescript/gemini-3-flash/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/gemini-cua/AGENTS.md
+++ b/typescript/gemini-cua/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/gemini-cua/CLAUDE.md
+++ b/typescript/gemini-cua/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/getting-started-with-browserbase/AGENTS.md
+++ b/typescript/getting-started-with-browserbase/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/getting-started-with-browserbase/CLAUDE.md
+++ b/typescript/getting-started-with-browserbase/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/gift-finder/AGENTS.md
+++ b/typescript/gift-finder/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/gift-finder/CLAUDE.md
+++ b/typescript/gift-finder/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/google-trends/AGENTS.md
+++ b/typescript/google-trends/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/google-trends/CLAUDE.md
+++ b/typescript/google-trends/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/image-url-download/AGENTS.md
+++ b/typescript/image-url-download/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/image-url-download/CLAUDE.md
+++ b/typescript/image-url-download/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/job-application/AGENTS.md
+++ b/typescript/job-application/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/job-application/CLAUDE.md
+++ b/typescript/job-application/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/license-verification/AGENTS.md
+++ b/typescript/license-verification/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/license-verification/CLAUDE.md
+++ b/typescript/license-verification/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/manual-mfa-with-contexts/AGENTS.md
+++ b/typescript/manual-mfa-with-contexts/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/manual-mfa-with-contexts/CLAUDE.md
+++ b/typescript/manual-mfa-with-contexts/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/mfa-handling/AGENTS.md
+++ b/typescript/mfa-handling/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/mfa-handling/CLAUDE.md
+++ b/typescript/mfa-handling/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/microsoft-cua/AGENTS.md
+++ b/typescript/microsoft-cua/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/microsoft-cua/CLAUDE.md
+++ b/typescript/microsoft-cua/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/nurse-verification/AGENTS.md
+++ b/typescript/nurse-verification/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/nurse-verification/CLAUDE.md
+++ b/typescript/nurse-verification/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/pickleball/AGENTS.md
+++ b/typescript/pickleball/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/pickleball/CLAUDE.md
+++ b/typescript/pickleball/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/playwright-mfa-handling/AGENTS.md
+++ b/typescript/playwright-mfa-handling/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/playwright-mfa-handling/CLAUDE.md
+++ b/typescript/playwright-mfa-handling/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/playwright/basic-recaptcha/AGENTS.md
+++ b/typescript/playwright/basic-recaptcha/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/playwright/basic-recaptcha/CLAUDE.md
+++ b/typescript/playwright/basic-recaptcha/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/playwright/quickstart-playwright/AGENTS.md
+++ b/typescript/playwright/quickstart-playwright/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/playwright/quickstart-playwright/CLAUDE.md
+++ b/typescript/playwright/quickstart-playwright/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/polymarket-research/AGENTS.md
+++ b/typescript/polymarket-research/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/polymarket-research/CLAUDE.md
+++ b/typescript/polymarket-research/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/proxies-weather/AGENTS.md
+++ b/typescript/proxies-weather/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/proxies-weather/CLAUDE.md
+++ b/typescript/proxies-weather/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/proxies/AGENTS.md
+++ b/typescript/proxies/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/proxies/CLAUDE.md
+++ b/typescript/proxies/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/puppeteer/quickstart-puppeteer/AGENTS.md
+++ b/typescript/puppeteer/quickstart-puppeteer/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/puppeteer/quickstart-puppeteer/CLAUDE.md
+++ b/typescript/puppeteer/quickstart-puppeteer/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/sec-filing-research/AGENTS.md
+++ b/typescript/sec-filing-research/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/sec-filing-research/CLAUDE.md
+++ b/typescript/sec-filing-research/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/selenium/quickstart-selenium/AGENTS.md
+++ b/typescript/selenium/quickstart-selenium/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/selenium/quickstart-selenium/CLAUDE.md
+++ b/typescript/selenium/quickstart-selenium/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/smart-fetch-scraper/AGENTS.md
+++ b/typescript/smart-fetch-scraper/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/smart-fetch-scraper/CLAUDE.md
+++ b/typescript/smart-fetch-scraper/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/typescript/website-link-tester/AGENTS.md
+++ b/typescript/website-link-tester/AGENTS.md
@@ -1,0 +1,20 @@
+# Stagehand Project
+
+<!-- BEGIN:stagehand-agent-rules -->
+
+Before any Stagehand work, find and read the relevant doc in `node_modules/@browserbasehq/stagehand/dist/docs/`. The installed package docs are the source of truth for this project's Stagehand version.
+
+Useful starting points:
+
+- `node_modules/@browserbasehq/stagehand/dist/docs/index.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/first-steps/quickstart.md`
+- `node_modules/@browserbasehq/stagehand/dist/docs/v3/references/stagehand.md`
+
+Useful searches:
+
+```bash
+rg "stagehand\\.act|stagehand\\.extract|stagehand\\.observe|stagehand\\.agent" node_modules/@browserbasehq/stagehand/dist/docs
+rg "env:|model:|browserbaseSession" node_modules/@browserbasehq/stagehand/dist/docs
+```
+
+<!-- END:stagehand-agent-rules -->

--- a/typescript/website-link-tester/CLAUDE.md
+++ b/typescript/website-link-tester/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
Linear: https://linear.app/browserbase/issue/CE-865/bundle-stagehand-docs-and-ship-agentsmd

## Summary
- add AGENTS.md to every TypeScript template directory with a README
- add CLAUDE.md includes that point Claude to AGENTS.md

## Verification
- pnpm exec prettier --check "typescript/**/{AGENTS,CLAUDE}.md"
- node scripts/check-readme-template-index.mjs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds new markdown instruction files to template directories and does not change runtime code or dependencies.
> 
> **Overview**
> Standardizes agent guidance across the TypeScript template directories by adding a new `AGENTS.md` with Stagehand-specific instructions (including where to find versioned Stagehand docs and suggested ripgrep queries).
> 
> Adds a companion `CLAUDE.md` in each template that simply includes `@AGENTS.md`, ensuring Claude-based workflows pick up the shared instructions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a38f4c1d85470c17cc05981aa8b18ad1e66540b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->