### PR TITLE
Update TypeScript templates to Stagehand V4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Stagehand + Browserbase Templates
 
+Stagehand is the SDK for browser agents.
+
 Ready-to-use automation templates for Stagehand and Browserbase. Each template has its own README with setup instructions.
 
 > All templates also live on [browserbase.com/templates](https://www.browserbase.com/templates)
@@ -15,7 +17,7 @@ Ready-to-use automation templates for Stagehand and Browserbase. Each template h
 | basic-recaptcha                  | [TS](typescript/basic-recaptcha)                  | [PY](python/basic-recaptcha)                  | -                   | Automatic reCAPTCHA solving using Browserbase's built-in captcha solving capabilities                          |
 | browser-agent-demo               | [TS](typescript/browser-agent-demo)               | -                                             | -                   | Browser agent that searches the web, fetches page content, and autonomously extracts information               |
 | browserbase-reducto              | [TS](typescript/browserbase-reducto)              | [PY](python/browserbase-reducto)              | -                   | Download financial PDFs from websites and extract structured data using AI-powered document parsing            |
-| business-lookup                  | [TS](typescript/business-lookup)                  | [PY](python/business-lookup)                  | -                   | Automate business registry searches using an autonomous AI agent with computer-use capabilities                |
+| business-lookup                  | [TS](typescript/business-lookup)                  | [PY](python/business-lookup)                  | -                   | Research business registry records with a Vercel AI SDK agent and Stagehand code mode                          |
 | cartesia-form-filling            | -                                                 | [PY](python/cartesia-form-filling)            | -                   | Voice agent that conducts phone questionnaires while automatically filling out web forms                       |
 | cerebras-docs-checker            | -                                                 | [PY](python/cerebras-docs-checker)            | -                   | Crawl documentation sites, discover source repos, and verify docs accuracy against actual codebase             |
 | company-address-finder           | [TS](typescript/company-address-finder)           | [PY](python/company-address-finder)           | -                   | Discover company legal information and physical addresses from Terms of Service and Privacy Policy pages       |
@@ -23,12 +25,12 @@ Ready-to-use automation templates for Stagehand and Browserbase. Each template h
 | context                          | [TS](typescript/context)                          | [PY](python/context)                          | -                   | Persistent authentication using Browserbase contexts that survive across sessions                              |
 | council-events                   | [TS](typescript/council-events)                   | [PY](python/council-events)                   | -                   | Automate event information extraction from Philadelphia Council                                                |
 | download-financial-statements    | [TS](typescript/download-financial-statements)    | [PY](python/download-financial-statements)    | -                   | Download Apple's quarterly financial statements (PDFs) from their investor relations site                      |
-| dynamic-form-filling             | [TS](typescript/dynamic-form-filling)             | -                                             | -                   | Intelligent form filling with explicit Stagehand V4 observe and act primitives                                 |
+| dynamic-form-filling             | [TS](typescript/dynamic-form-filling)             | -                                             | -                   | Fill dynamic forms with a Vercel AI SDK agent and Stagehand's code_execute browser tool                        |
 | exa-browserbase                  | [TS](typescript/exa-browserbase)                  | [PY](python/exa-browserbase)                  | -                   | Automate job applications with AI that writes smart, tailored responses for each role                          |
 | extend-browserbase               | [TS](typescript/extend-browserbase)               | [PY](python/extend-browserbase)               | -                   | Download receipts from an expense portal and extract structured receipt data using AI-powered document parsing |
 | form-filling                     | [TS](typescript/form-filling)                     | [PY](python/form-filling)                     | -                   | Automate form filling with Stagehand and Browserbase                                                           |
-| gemini-3-flash                   | [TS](typescript/gemini-3-flash)                   | -                                             | -                   | Google search research using Gemini 3 Flash with Stagehand V4 and Browserbase                                  |
-| gemini-cua                       | [TS](typescript/gemini-cua)                       | [PY](python/gemini-cua)                       | -                   | Google search research using Gemini with Stagehand V4 and Browserbase                                          |
+| gemini-3-flash                   | [TS](typescript/gemini-3-flash)                   | -                                             | -                   | Browser research with a Gemini 3 Flash agent and Stagehand code mode                                           |
+| gemini-cua                       | [TS](typescript/gemini-cua)                       | [PY](python/gemini-cua)                       | -                   | Browser research with a bring-your-own Gemini agent and Stagehand code mode                                    |
 | getting-started-with-browserbase | [TS](typescript/getting-started-with-browserbase) | [PY](python/getting-started-with-browserbase) | -                   | Demo all three core Browserbase capabilities: Search API, Fetch API, and Browser Sessions                      |
 | gift-finder                      | [TS](typescript/gift-finder)                      | [PY](python/gift-finder)                      | -                   | Find personalized gift recommendations using AI-generated search queries and intelligent product scoring       |
 | google-trends                    | [TS](typescript/google-trends)                    | [PY](python/google-trends)                    | -                   | Extract trending search keywords from Google Trends for any country with structured JSON output                |
@@ -38,7 +40,7 @@ Ready-to-use automation templates for Stagehand and Browserbase. Each template h
 | license-verification             | [TS](typescript/license-verification)             | [PY](python/license-verification)             | -                   | Extract structured, validated data from websites using Stagehand + Zod                                         |
 | manual-mfa-with-contexts         | [TS](typescript/manual-mfa-with-contexts)         | [PY](python/manual-mfa-with-contexts)         | -                   | Persist authentication across sessions using Browserbase Contexts, eliminating MFA friction                    |
 | mfa-handling                     | [TS](typescript/mfa-handling)                     | [PY](python/mfa-handling)                     | -                   | Automate MFA completion using TOTP (Time-based One-Time Password) code generation                              |
-| microsoft-cua                    | [TS](typescript/microsoft-cua)                    | -                                             | -                   | Search research with explicit Stagehand V4 primitives on Browserbase                                           |
+| microsoft-cua                    | [TS](typescript/microsoft-cua)                    | -                                             | -                   | Browser research with a bring-your-own OpenAI agent and Stagehand code mode                                    |
 | nurse-verification               | [TS](typescript/nurse-verification)               | [PY](python/nurse-verification)               | -                   | Automate verification of nurse licenses by filling forms and extracting structured results                     |
 | pickleball                       | [TS](typescript/pickleball)                       | [PY](python/pickleball)                       | -                   | Automate tennis and pickleball court bookings in San Francisco Recreation & Parks system                       |
 | playwright                       | [TS](typescript/playwright)                       | [PY](python/playwright)                       | -                   | Raw Playwright usage with Browserbase (no Stagehand)                                                           |
@@ -54,9 +56,9 @@ Ready-to-use automation templates for Stagehand and Browserbase. Each template h
 
 ## Model Gateway
 
-Templates use the Model Gateway to route LLM requests -- you only need your `BROWSERBASE_API_KEY`. No separate OpenAI, Anthropic, or Google API keys required. Supported models include OpenAI, Anthropic, and Google (Gemini).
+Stagehand primitives use the Browserbase Model Gateway, so they need only `BROWSERBASE_API_KEY`. Bring-your-own-agent templates also use Vercel AI Gateway for the outer agent loop and require `AI_GATEWAY_API_KEY`; no provider-specific OpenAI, Anthropic, or Google key is required.
 
-> **Stagehand V4 note**: the TypeScript templates use explicit `act`, `extract`, and `observe` primitives. V4 does not expose the V3 `agent()` orchestration API.
+> **Stagehand V4 note**: V4 does not expose the V3 `agent()` orchestration API. Agent templates use Vercel AI SDK for the loop and Stagehand code mode's `code_execute` MCP tool for browser work; other templates call V4 browser primitives directly.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ Ready-to-use automation templates for Stagehand and Browserbase. Each template h
 | context                          | [TS](typescript/context)                          | [PY](python/context)                          | -                   | Persistent authentication using Browserbase contexts that survive across sessions                              |
 | council-events                   | [TS](typescript/council-events)                   | [PY](python/council-events)                   | -                   | Automate event information extraction from Philadelphia Council                                                |
 | download-financial-statements    | [TS](typescript/download-financial-statements)    | [PY](python/download-financial-statements)    | -                   | Download Apple's quarterly financial statements (PDFs) from their investor relations site                      |
-| dynamic-form-filling             | [TS](typescript/dynamic-form-filling)             | -                                             | -                   | Intelligent form filling using a Stagehand AI agent that understands form context and uses semantic matching   |
+| dynamic-form-filling             | [TS](typescript/dynamic-form-filling)             | -                                             | -                   | Intelligent form filling with explicit Stagehand V4 observe and act primitives                                 |
 | exa-browserbase                  | [TS](typescript/exa-browserbase)                  | [PY](python/exa-browserbase)                  | -                   | Automate job applications with AI that writes smart, tailored responses for each role                          |
 | extend-browserbase               | [TS](typescript/extend-browserbase)               | [PY](python/extend-browserbase)               | -                   | Download receipts from an expense portal and extract structured receipt data using AI-powered document parsing |
 | form-filling                     | [TS](typescript/form-filling)                     | [PY](python/form-filling)                     | -                   | Automate form filling with Stagehand and Browserbase                                                           |
-| gemini-3-flash                   | [TS](typescript/gemini-3-flash)                   | -                                             | -                   | Autonomous web browsing using Google's Gemini 3 Flash with Stagehand and Browserbase                           |
-| gemini-cua                       | [TS](typescript/gemini-cua)                       | [PY](python/gemini-cua)                       | -                   | Autonomous web browsing using Google's Computer Use Agent with Stagehand and Browserbase                       |
+| gemini-3-flash                   | [TS](typescript/gemini-3-flash)                   | -                                             | -                   | Google search research using Gemini 3 Flash with Stagehand V4 and Browserbase                                  |
+| gemini-cua                       | [TS](typescript/gemini-cua)                       | [PY](python/gemini-cua)                       | -                   | Google search research using Gemini with Stagehand V4 and Browserbase                                          |
 | getting-started-with-browserbase | [TS](typescript/getting-started-with-browserbase) | [PY](python/getting-started-with-browserbase) | -                   | Demo all three core Browserbase capabilities: Search API, Fetch API, and Browser Sessions                      |
 | gift-finder                      | [TS](typescript/gift-finder)                      | [PY](python/gift-finder)                      | -                   | Find personalized gift recommendations using AI-generated search queries and intelligent product scoring       |
 | google-trends                    | [TS](typescript/google-trends)                    | [PY](python/google-trends)                    | -                   | Extract trending search keywords from Google Trends for any country with structured JSON output                |
@@ -38,7 +38,7 @@ Ready-to-use automation templates for Stagehand and Browserbase. Each template h
 | license-verification             | [TS](typescript/license-verification)             | [PY](python/license-verification)             | -                   | Extract structured, validated data from websites using Stagehand + Zod                                         |
 | manual-mfa-with-contexts         | [TS](typescript/manual-mfa-with-contexts)         | [PY](python/manual-mfa-with-contexts)         | -                   | Persist authentication across sessions using Browserbase Contexts, eliminating MFA friction                    |
 | mfa-handling                     | [TS](typescript/mfa-handling)                     | [PY](python/mfa-handling)                     | -                   | Automate MFA completion using TOTP (Time-based One-Time Password) code generation                              |
-| microsoft-cua                    | [TS](typescript/microsoft-cua)                    | -                                             | -                   | Autonomous web browsing using Microsoft's Computer Use Agent with Stagehand and Browserbase                    |
+| microsoft-cua                    | [TS](typescript/microsoft-cua)                    | -                                             | -                   | Search research with explicit Stagehand V4 primitives on Browserbase                                           |
 | nurse-verification               | [TS](typescript/nurse-verification)               | [PY](python/nurse-verification)               | -                   | Automate verification of nurse licenses by filling forms and extracting structured results                     |
 | pickleball                       | [TS](typescript/pickleball)                       | [PY](python/pickleball)                       | -                   | Automate tennis and pickleball court bookings in San Francisco Recreation & Parks system                       |
 | playwright                       | [TS](typescript/playwright)                       | [PY](python/playwright)                       | -                   | Raw Playwright usage with Browserbase (no Stagehand)                                                           |
@@ -56,7 +56,7 @@ Ready-to-use automation templates for Stagehand and Browserbase. Each template h
 
 Templates use the Model Gateway to route LLM requests -- you only need your `BROWSERBASE_API_KEY`. No separate OpenAI, Anthropic, or Google API keys required. Supported models include OpenAI, Anthropic, and Google (Gemini).
 
-> **Note**: CUA (Computer Use Agent) models are not yet supported through the Model Gateway. Templates using CUA models still require a separate model provider API key.
+> **Stagehand V4 note**: the TypeScript templates use explicit `act`, `extract`, and `observe` primitives. V4 does not expose the V3 `agent()` orchestration API.
 
 ## Getting Started
 
@@ -77,7 +77,7 @@ Each template's README contains detailed installation steps, environment variabl
 
 ### Documentation
 
-- **Stagehand Docs**: https://docs.stagehand.dev/v3/first-steps/introduction
+- **Stagehand Docs**: https://docs.stagehand.dev/v4/first-steps/introduction
 - **Browserbase Docs**: https://docs.browserbase.com
 
 ### Support

--- a/scripts/lib/playground-checks.mjs
+++ b/scripts/lib/playground-checks.mjs
@@ -7,7 +7,12 @@
  * @returns {boolean}
  */
 export function hasStagehandUsage(code) {
-  const stagehandVariablePattern = /(?:let|const|var)\s+\w+\s*=\s*new\s+Stagehand\s*\(/;
+  const stagehandConstructorPattern = /(?:let|const|var)\s+\w+\s*=\s*new\s+Stagehand\s*\(/;
   const stagehandDirectPattern = /(?:^|\s|await\s+)(?:new\s+)?Stagehand\s*\(/;
-  return stagehandVariablePattern.test(code) || stagehandDirectPattern.test(code);
+  const stagehandCreatePattern = /(?:^|\s|await\s+)Stagehand\.create\s*\(/;
+  return (
+    stagehandConstructorPattern.test(code) ||
+    stagehandDirectPattern.test(code) ||
+    stagehandCreatePattern.test(code)
+  );
 }

--- a/scripts/validate-playground-templates.mjs
+++ b/scripts/validate-playground-templates.mjs
@@ -40,9 +40,9 @@ async function validateSourceFile(filePath) {
     );
   }
 
-  if (hasStagehandUsage(sourceText) && !/new\s+Stagehand\s*\(/.test(sourceText)) {
+  if (hasStagehandUsage(sourceText) && !/Stagehand\.create\s*\(/.test(sourceText)) {
     throw new Error(
-      `${path.relative(ROOT, filePath)}: Stagehand usage detected but no \`new Stagehand({...})\` — playground config merge requires a constructor call.`,
+      `${path.relative(ROOT, filePath)}: Stagehand usage detected but no \`Stagehand.create({...})\` call — playground config merge requires a Stagehand factory call.`,
     );
   }
 }

--- a/typescript/agent-with-human-in-loop/README.md
+++ b/typescript/agent-with-human-in-loop/README.md
@@ -1,42 +1,38 @@
-# Stagehand + Browserbase: Human-in-the-Loop Agent
+# Stagehand V4 + Browserbase: Human-in-the-Loop Workflow
 
 ## AT A GLANCE
 
-- Goal: showcase how to build an AI agent that can pause and ask a human for input mid-task using Stagehand and Browserbase.
-- Interactive Agent Loop: the agent automates browser tasks but can request human guidance when it encounters decisions it can't make alone.
+- Goal: showcase an application-controlled V4 workflow that pauses for human input while filling a form.
+- Interactive Loop: `observe()` discovers fields, known values are filled automatically, and the application asks the human for unknown values.
 - Live Browser View: watch the agent work in real-time through an embedded Browserbase session.
 - SSE Streaming: real-time activity log and status updates streamed to the frontend.
   Docs → https://docs.browserbase.com/features/sessions
 
 ## GLOSSARY
 
-- agent: an AI-driven Stagehand instance that autonomously performs browser actions and can invoke custom tools
-  Docs → https://docs.stagehand.dev/basics/agent
-- askHuman: a custom agent tool that pauses execution and sends a question to the user, resuming once a response is provided
+- askHuman: application logic that pauses execution and sends a question to the user, resuming once a response is provided
 - session store: an in-memory map coordinating state between the SSE stream and the human response endpoint
 - act: perform UI actions from a prompt (type, click, fill forms)
-  Docs → https://docs.stagehand.dev/basics/act
+  Docs → https://docs.stagehand.dev/v4/basics/act
 - observe: analyze a page and return selectors or action plans before executing
-  Docs → https://docs.stagehand.dev/basics/observe
+  Docs → https://docs.stagehand.dev/v4/basics/observe
 
 ## QUICKSTART
 
 1.  cd agent-with-human-in-loop
-2.  npm install
+2.  pnpm install
 3.  Create a .env file and add your Browserbase credentials:
     BROWSERBASE_API_KEY=your-api-key
-    BROWSERBASE_PROJECT_ID=your-project-id
-    ANTHROPIC_API_KEY=your-anthropic-api-key
-4.  npm run dev
+4.  pnpm dev
 5.  Open http://localhost:3000 in your browser
 
 ## EXPECTED OUTPUT
 
 - A form appears to enter an applicant's name and upload a resume
 - On submit, a Browserbase session starts and the live browser view loads
-- The agent navigates to a job application site and begins filling out the form
-- When the agent needs clarification, it pauses and displays a question in the UI
-- You type a response and the agent resumes with your input
+- The V4 workflow navigates to a job application and fills known fields
+- When an unknown field is encountered, it pauses and displays a question in the UI
+- You type a response and the workflow continues with that value
 
 ## USE CASES
 
@@ -47,7 +43,7 @@
 ## HELPFUL RESOURCES
 
 📚 Stagehand Docs: https://docs.stagehand.dev
-📚 Stagehand Agent: https://docs.stagehand.dev/basics/agent
+📚 Stagehand V4 Migration: https://docs.stagehand.dev/v4/migrations/v3
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground
 🔧 Templates: https://www.browserbase.com/templates

--- a/typescript/agent-with-human-in-loop/README.md
+++ b/typescript/agent-with-human-in-loop/README.md
@@ -1,28 +1,29 @@
-# Stagehand V4 + Browserbase: Human-in-the-Loop Workflow
+# Stagehand Code Mode + Vercel AI SDK: Human-in-the-Loop Agent
 
 ## AT A GLANCE
 
-- Goal: showcase an application-controlled V4 workflow that pauses for human input while filling a form.
-- Interactive Loop: `observe()` discovers fields, known values are filled automatically, and the application asks the human for unknown values.
+- Goal: showcase a bring-your-own browser agent that pauses for human input while filling a form.
+- Agent framework: Vercel AI SDK `ToolLoopAgent` owns the reasoning loop and exposes a custom `askHuman` tool.
+- Browser tool: Stagehand code mode exposes one stateful MCP tool, `code_execute`.
+- Interactive loop: the agent calls `askHuman` for missing facts and resumes when the user responds.
 - Live Browser View: watch the agent work in real-time through an embedded Browserbase session.
 - SSE Streaming: real-time activity log and status updates streamed to the frontend.
   Docs → https://docs.browserbase.com/features/sessions
 
 ## GLOSSARY
 
-- askHuman: application logic that pauses execution and sends a question to the user, resuming once a response is provided
+- askHuman: an application-defined AI SDK tool that pauses execution and sends a question to the user, resuming once a response is provided
 - session store: an in-memory map coordinating state between the SSE stream and the human response endpoint
-- act: perform UI actions from a prompt (type, click, fill forms)
-  Docs → https://docs.stagehand.dev/v4/basics/act
-- observe: analyze a page and return selectors or action plans before executing
-  Docs → https://docs.stagehand.dev/v4/basics/observe
+- code_execute: Stagehand code mode's MCP tool for stateful browser JavaScript, including V4 page APIs and AI primitives
+- ToolLoopAgent: the Vercel AI SDK agent loop that decides when to call `code_execute` or `askHuman`
 
 ## QUICKSTART
 
 1.  cd agent-with-human-in-loop
 2.  pnpm install
-3.  Create a .env file and add your Browserbase credentials:
+3.  Create a .env file and add your Browserbase and Vercel AI Gateway credentials:
     BROWSERBASE_API_KEY=your-api-key
+    AI_GATEWAY_API_KEY=your-ai-gateway-key
 4.  pnpm dev
 5.  Open http://localhost:3000 in your browser
 
@@ -30,9 +31,14 @@
 
 - A form appears to enter an applicant's name and upload a resume
 - On submit, a Browserbase session starts and the live browser view loads
-- The V4 workflow navigates to a job application and fills known fields
+- The agent uses `code_execute` to navigate to a job application and fill known fields
 - When an unknown field is encountered, it pauses and displays a question in the UI
 - You type a response and the workflow continues with that value
+- Closing the MCP client closes Stagehand and its Browserbase browser
+
+## SAFETY
+
+Code mode executes model-authored JavaScript and is not itself a security sandbox. Run it inside an isolation boundary when prompts or pages are untrusted.
 
 ## USE CASES
 
@@ -43,7 +49,8 @@
 ## HELPFUL RESOURCES
 
 📚 Stagehand Docs: https://docs.stagehand.dev
-📚 Stagehand V4 Migration: https://docs.stagehand.dev/v4/migrations/v3
+📚 Vercel AI SDK Agents: https://ai-sdk.dev/docs/agents/building-agents
+📚 Vercel AI SDK MCP Tools: https://ai-sdk.dev/docs/ai-sdk-core/mcp-tools
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground
 🔧 Templates: https://www.browserbase.com/templates

--- a/typescript/agent-with-human-in-loop/lib/agent.ts
+++ b/typescript/agent-with-human-in-loop/lib/agent.ts
@@ -1,13 +1,13 @@
 // Stagehand + Browserbase: Human-in-the-Loop Agent — core agent logic
-// This module runs a Stagehand agent that fills out a job application,
+// This module runs an explicit Stagehand V4 workflow that fills out a job application,
 // pausing to ask the human whenever it encounters fields it can't fill alone.
 // Communication with the frontend happens via Server-Sent Events (SSE).
 
 import { Browserbase } from "@browserbasehq/sdk";
-import { Stagehand, tool } from "@browserbasehq/stagehand";
-import { z } from "zod";
+import { browserbase, Stagehand, type StagehandBrowser } from "@browserbasehq/stagehand";
+import { z } from "zod/v4";
 import { createSession, setQuestion, completeSession, errorSession } from "./session-store";
-import { writeFileSync, mkdtempSync, unlinkSync } from "fs";
+import { createReadStream, writeFileSync, mkdtempSync, unlinkSync } from "fs";
 import { join, basename } from "path";
 import { tmpdir } from "os";
 
@@ -32,15 +32,24 @@ export async function runAgent(params: {
 }) {
   const { firstName, lastName, resumeBase64, resumeFileName, id, writer } = params;
   let resumePath: string | undefined;
+  let browser: StagehandBrowser | undefined;
+  let stagehand: Stagehand | undefined;
+  let extensionId: string | undefined;
+  const bb = new Browserbase({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+  });
 
   try {
     // --- Browserbase session setup ---
-    const bb = new Browserbase({
-      apiKey: process.env.BROWSERBASE_API_KEY!,
+    const stagehandEntry = import.meta.resolve("@browserbasehq/stagehand");
+    const extension = await bb.extensions.create({
+      file: createReadStream(new URL("./assets/stagehand-extension.zip", stagehandEntry)),
     });
+    extensionId = extension.id;
 
     const session = await bb.sessions.create({
       projectId: process.env.BROWSERBASE_PROJECT_ID!,
+      extensionId,
       browserSettings: {
         viewport: { width: 1288, height: 711 },
       },
@@ -60,17 +69,18 @@ export async function runAgent(params: {
     });
 
     // --- Stagehand setup ---
-    const stagehand = new Stagehand({
-      env: "BROWSERBASE",
-      model: "anthropic/claude-sonnet-4-5-20250929",
-      verbose: 1,
-      browserbaseSessionID: session.id,
-      disablePino: true,
-      experimental: true,
+    browser = await browserbase.connect({
+      apiKey: process.env.BROWSERBASE_API_KEY!,
+      sessionId: session.id,
+      extensionId,
+    });
+    stagehand = await Stagehand.create({
+      browser: browser,
+      model: { modelName: "anthropic/claude-sonnet-4-5-20250929" },
+      logging: { level: "info" },
     });
 
-    await stagehand.init();
-    const page = stagehand.context.pages()[0];
+    const page = (await browser.context.pages())[0];
     await page.goto("https://bb-template-site.vercel.app/");
 
     // Save resume to a temp file so Playwright can upload it
@@ -80,130 +90,68 @@ export async function runAgent(params: {
 
     await sendEvent(writer, "status", { message: "Navigating to job listing..." });
 
-    // --- Agent with custom askHuman tool ---
-    const agent = stagehand.agent({
-      mode: "hybrid",
-      model: "anthropic/claude-sonnet-4-5-20250929",
-      systemPrompt: `You are an assistant helping a user apply to a job by filling out an application form.
+    const askHuman = async (question: string): Promise<string> => {
+      await sendEvent(writer, "question", { id, question });
+      const response = await new Promise<string>((resolve) => {
+        setQuestion(id, question, resolve);
+      });
+      await sendEvent(writer, "status", { message: "Received your response, continuing..." });
+      return response;
+    };
 
-You already know the applicant's name:
-- First Name: ${firstName}
-- Last Name: ${lastName}
+    // V4 has no agent() orchestrator, so the workflow is explicit and reviewable.
+    await stagehand.act("Open the careers page");
+    const { data: jobs } = await stagehand.extract(
+      "Extract the available job titles",
+      z.object({ jobs: z.array(z.string()) }),
+    );
+    const selectedJob = await askHuman(
+      `Which position would you like to apply for? Available roles: ${jobs.jobs.join(", ")}`,
+    );
+    await stagehand.act(`Open the job listing for ${selectedJob}`);
+    await stagehand.act("Open the application form");
 
-You should try to fill out the form autonomously using the information you have.
-However, you may NOT have all the information needed.
+    const { data: fields } = await stagehand.observe(
+      "Find every empty text, email, phone, textarea, select, checkbox, and radio field in the application form",
+    );
+    for (const field of fields) {
+      const description = field.description.toLowerCase();
+      let value: string;
+      if (description.includes("first name")) value = firstName;
+      else if (description.includes("last name")) value = lastName;
+      else {
+        value = await askHuman(`What should I enter for: ${field.description}?`);
+      }
+      await stagehand.act({ ...field, arguments: [value] });
+    }
 
-When you encounter anything you're unsure about — whether that's choosing
-which job position the person wants to apply to, form fields that require personal
-information you don't have, or any other decision that depends on the human's
-preference — use the askHuman tool. You can batch multiple fields into a single
-question to be efficient. Do NOT make up or guess any personal information, and do NOT make choices on the
-human's behalf. Always ask when unsure.
-
-File upload fields CANNOT be handled with act or fillForm — they will fail. If you
-encounter a resume upload field, use the uploadResume tool to attach the file instead
-of trying to click or interact with the file input directly.`,
-      tools: {
-        askHuman: tool({
-          description:
-            "Ask the human operator for information needed to continue the task. " +
-            "Use this when you encounter form fields requiring personal info you don't have. " +
-            "Be specific about what information you need.",
-          inputSchema: z.object({
-            question: z
-              .string()
-              .describe("The question to ask the human. Be specific about what info is needed."),
-          }),
-          execute: async ({ question }) => {
-            // Send question to the frontend via SSE
-            await sendEvent(writer, "question", { id, question });
-
-            // Block until the human responds via POST /api/agent/respond
-            // This Promise is resolved by resolveQuestion() in the session store
-            const response = await new Promise<string>((resolve) => {
-              setQuestion(id, question, resolve);
-            });
-
-            await sendEvent(writer, "status", {
-              message: "Received your response, continuing...",
-            });
-
-            return {
-              response,
-              message: "Human provided the requested information.",
-            };
-          },
-        }),
-        uploadResume: tool({
-          description:
-            "Upload the user's resume to the resume file input on the page. " +
-            "Use this when you encounter a resume upload field.",
-          inputSchema: z.object({}),
-          execute: async () => {
-            // File inputs are hidden in the DOM, so observe() can't find them
-            // (it works from the accessibility tree). Use page.locator() directly
-            // which works on hidden elements via CDP.
-            if (!resumePath) {
-              return { message: "No resume file available to upload." };
-            }
-            const fileInput = page.locator('input[type="file"]').first();
-            await fileInput.setInputFiles(resumePath);
-
-            await sendEvent(writer, "status", {
-              message: `Uploaded resume: ${resumeFileName}`,
-            });
-
-            return {
-              message: `Successfully uploaded ${resumeFileName}`,
-            };
-          },
-        }),
-      },
-    });
-
-    // --- Execute ---
-    const result = await agent.execute({
-      instruction:
-        "Apply to a job on this site by navigating to the careers page, choosing a position, " +
-        "and filling out the application form. Fill in all text fields, upload the resume, " +
-        "and submit the application.",
-      maxSteps: 30,
-      callbacks: {
-        onStepFinish: async (event) => {
-          if (event.toolCalls) {
-            for (const tc of event.toolCalls) {
-              if (tc.toolName === "askHuman") {
-                await sendEvent(writer, "status", {
-                  message: "Waiting for your input...",
-                });
-              } else {
-                await sendEvent(writer, "status", {
-                  message: `Agent used tool: ${tc.toolName}`,
-                });
-              }
-            }
-          }
-        },
-      },
-    });
+    if (!resumePath) throw new Error("No resume file available to upload");
+    await page.locator('input[type="file"]').first().setInputFiles(resumePath);
+    await sendEvent(writer, "status", { message: `Uploaded resume: ${resumeFileName}` });
+    await stagehand.act("Submit the application");
 
     completeSession(id);
     await sendEvent(writer, "complete", {
-      success: result.success,
-      message: result.message,
+      success: true,
+      message: "Application submitted",
       sessionReplayUrl: `https://browserbase.com/sessions/${session.id}`,
     });
 
     // Keep the session open briefly so the user can see the final state
     await new Promise((resolve) => setTimeout(resolve, 10000));
-
-    await stagehand.close();
   } catch (err) {
     errorSession(id);
     await sendEvent(writer, "error", {
       message: err instanceof Error ? err.message : "Unknown error",
     });
   } finally {
+    await stagehand?.close().catch(() => undefined);
+    await browser?.close().catch(() => undefined);
+    if (extensionId) {
+      await bb.extensions
+        .delete(extensionId, { headers: { "Content-Type": null } })
+        .catch(() => undefined);
+    }
     // Clean up temp resume file (in finally so it's removed even on error)
     if (resumePath)
       try {

--- a/typescript/agent-with-human-in-loop/lib/agent.ts
+++ b/typescript/agent-with-human-in-loop/lib/agent.ts
@@ -1,25 +1,28 @@
 // Stagehand + Browserbase: Human-in-the-Loop Agent — core agent logic
-// This module runs an explicit Stagehand V4 workflow that fills out a job application,
-// pausing to ask the human whenever it encounters fields it can't fill alone.
-// Communication with the frontend happens via Server-Sent Events (SSE).
 
+import { createMCPClient } from "@ai-sdk/mcp";
+import { Experimental_StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
 import { Browserbase } from "@browserbasehq/sdk";
-import { browserbase, Stagehand, type StagehandBrowser } from "@browserbasehq/stagehand";
-import { z } from "zod/v4";
-import { createSession, setQuestion, completeSession, errorSession } from "./session-store";
-import { createReadStream, writeFileSync, mkdtempSync, unlinkSync } from "fs";
-import { join, basename } from "path";
+import { ToolLoopAgent, stepCountIs, tool } from "ai";
+import { writeFileSync, mkdtempSync, unlinkSync } from "fs";
+import { basename, join } from "path";
 import { tmpdir } from "os";
+import { z } from "zod/v4";
+import {
+  completeSession,
+  createSession,
+  errorSession,
+  setQuestion,
+  setSessionBrowser,
+} from "./session-store";
 
-// SSE event helper — writes a Server-Sent Event to the stream
 function sendEvent(
   writer: WritableStreamDefaultWriter<Uint8Array>,
   event: string,
   data: Record<string, unknown>,
 ) {
   const encoder = new TextEncoder();
-  const msg = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
-  return writer.write(encoder.encode(msg));
+  return writer.write(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`));
 }
 
 export async function runAgent(params: {
@@ -27,138 +30,107 @@ export async function runAgent(params: {
   lastName: string;
   resumeBase64: string;
   resumeFileName: string;
-  id: string; // internal correlation ID
+  id: string;
   writer: WritableStreamDefaultWriter<Uint8Array>;
 }) {
   const { firstName, lastName, resumeBase64, resumeFileName, id, writer } = params;
+  const bb = new Browserbase({ apiKey: process.env.BROWSERBASE_API_KEY! });
+  let sessionsBefore = new Set<string>();
+  let browserbaseSessionId: string | undefined;
   let resumePath: string | undefined;
-  let browser: StagehandBrowser | undefined;
-  let stagehand: Stagehand | undefined;
-  let extensionId: string | undefined;
-  const bb = new Browserbase({
-    apiKey: process.env.BROWSERBASE_API_KEY!,
-  });
+  let mcpClient: Awaited<ReturnType<typeof createMCPClient>> | undefined;
+  let liveViewLookup: Promise<void> | undefined;
+
+  createSession(id);
+  await sendEvent(writer, "session", { id });
+
+  const announceLiveView = () => {
+    liveViewLookup ??= (async () => {
+      const createdSession = (await bb.sessions.list({ status: "RUNNING" }))
+        .filter((session) => !sessionsBefore.has(session.id))
+        .sort((left, right) => right.createdAt.localeCompare(left.createdAt))[0];
+      if (!createdSession) return;
+
+      browserbaseSessionId = createdSession.id;
+      const { debuggerFullscreenUrl } = await bb.sessions.debug(createdSession.id);
+      setSessionBrowser(id, debuggerFullscreenUrl, createdSession.id);
+      await sendEvent(writer, "session", { id, debuggerUrl: debuggerFullscreenUrl });
+    })().finally(() => {
+      if (!browserbaseSessionId) liveViewLookup = undefined;
+    });
+    return liveViewLookup;
+  };
 
   try {
-    // --- Browserbase session setup ---
-    const stagehandEntry = import.meta.resolve("@browserbasehq/stagehand");
-    const extension = await bb.extensions.create({
-      file: createReadStream(new URL("./assets/stagehand-extension.zip", stagehandEntry)),
-    });
-    extensionId = extension.id;
+    sessionsBefore = new Set(
+      (await bb.sessions.list({ status: "RUNNING" })).map((session) => session.id),
+    );
+    const tempDirectory = mkdtempSync(join(tmpdir(), "hitl-"));
+    resumePath = join(tempDirectory, basename(resumeFileName));
+    writeFileSync(resumePath, Buffer.from(resumeBase64, "base64"));
 
-    const session = await bb.sessions.create({
-      projectId: process.env.BROWSERBASE_PROJECT_ID!,
-      extensionId,
-      browserSettings: {
-        viewport: { width: 1288, height: 711 },
+    mcpClient = await createMCPClient({
+      transport: new Experimental_StdioMCPTransport({
+        command: "stagehand-codemode",
+        stderr: "inherit",
+      }),
+    });
+    const codeModeTools = await mcpClient.tools();
+    if (!codeModeTools.code_execute) {
+      throw new Error("Stagehand code mode did not expose code_execute");
+    }
+
+    const askHuman = tool({
+      description:
+        "Ask the applicant for information or a decision that is not present in their supplied details. Wait for their response before continuing.",
+      inputSchema: z.object({ question: z.string() }),
+      execute: async ({ question }) => {
+        await sendEvent(writer, "question", { id, question });
+        const answer = await new Promise<string>((resolve) => setQuestion(id, question, resolve));
+        await sendEvent(writer, "status", { message: "Received your response, continuing..." });
+        return { answer };
       },
     });
 
-    const debugLinks = await bb.sessions.debug(session.id);
-    const debuggerUrl = debugLinks.debuggerFullscreenUrl;
-
-    // Register in session store
-    createSession(id, debuggerUrl, session.id);
-
-    // Send the session info to the frontend immediately
-    await sendEvent(writer, "session", {
-      id,
-      debuggerUrl,
-      browserbaseSessionId: session.id,
+    const agent = new ToolLoopAgent({
+      model: process.env.AGENT_MODEL ?? "anthropic/claude-sonnet-4.6",
+      instructions:
+        "You are a job-application browser agent. Use code_execute for all browser work and askHuman whenever required information or a consequential choice is missing. Prefer deterministic Stagehand V4 page and locator methods. Review the application before submission and do not invent applicant details.",
+      tools: { ...codeModeTools, askHuman },
+      stopWhen: stepCountIs(30),
     });
 
-    // --- Stagehand setup ---
-    browser = await browserbase.connect({
-      apiKey: process.env.BROWSERBASE_API_KEY!,
-      sessionId: session.id,
-      extensionId,
+    await sendEvent(writer, "status", { message: "Starting the browser agent..." });
+    const result = await agent.generate({
+      prompt: `Open https://bb-template-site.vercel.app/, go to Careers, choose a suitable open role, and complete its application for ${firstName} ${lastName}. The resume is available at ${JSON.stringify(resumePath)}. Ask the applicant for every required value or decision not supplied here. Upload the resume, review the form, then submit it.`,
+      onStepFinish: async () => {
+        await announceLiveView();
+      },
     });
-    stagehand = await Stagehand.create({
-      browser: browser,
-      model: { modelName: "anthropic/claude-sonnet-4-5-20250929" },
-      logging: { level: "info" },
-    });
-
-    const page = (await browser.context.pages())[0];
-    await page.goto("https://bb-template-site.vercel.app/");
-
-    // Save resume to a temp file so Playwright can upload it
-    const tmpDir = mkdtempSync(join(tmpdir(), "hitl-"));
-    resumePath = join(tmpDir, basename(resumeFileName));
-    writeFileSync(resumePath, Buffer.from(resumeBase64, "base64"));
-
-    await sendEvent(writer, "status", { message: "Navigating to job listing..." });
-
-    const askHuman = async (question: string): Promise<string> => {
-      await sendEvent(writer, "question", { id, question });
-      const response = await new Promise<string>((resolve) => {
-        setQuestion(id, question, resolve);
-      });
-      await sendEvent(writer, "status", { message: "Received your response, continuing..." });
-      return response;
-    };
-
-    // V4 has no agent() orchestrator, so the workflow is explicit and reviewable.
-    await stagehand.act("Open the careers page");
-    const { data: jobs } = await stagehand.extract(
-      "Extract the available job titles",
-      z.object({ jobs: z.array(z.string()) }),
-    );
-    const selectedJob = await askHuman(
-      `Which position would you like to apply for? Available roles: ${jobs.jobs.join(", ")}`,
-    );
-    await stagehand.act(`Open the job listing for ${selectedJob}`);
-    await stagehand.act("Open the application form");
-
-    const { data: fields } = await stagehand.observe(
-      "Find every empty text, email, phone, textarea, select, checkbox, and radio field in the application form",
-    );
-    for (const field of fields) {
-      const description = field.description.toLowerCase();
-      let value: string;
-      if (description.includes("first name")) value = firstName;
-      else if (description.includes("last name")) value = lastName;
-      else {
-        value = await askHuman(`What should I enter for: ${field.description}?`);
-      }
-      await stagehand.act({ ...field, arguments: [value] });
-    }
-
-    if (!resumePath) throw new Error("No resume file available to upload");
-    await page.locator('input[type="file"]').first().setInputFiles(resumePath);
-    await sendEvent(writer, "status", { message: `Uploaded resume: ${resumeFileName}` });
-    await stagehand.act("Submit the application");
+    await announceLiveView();
 
     completeSession(id);
     await sendEvent(writer, "complete", {
       success: true,
-      message: "Application submitted",
-      sessionReplayUrl: `https://browserbase.com/sessions/${session.id}`,
+      message: result.text || "Application submitted",
+      sessionReplayUrl: browserbaseSessionId
+        ? `https://browserbase.com/sessions/${browserbaseSessionId}`
+        : "",
     });
-
-    // Keep the session open briefly so the user can see the final state
-    await new Promise((resolve) => setTimeout(resolve, 10000));
-  } catch (err) {
+  } catch (error) {
     errorSession(id);
     await sendEvent(writer, "error", {
-      message: err instanceof Error ? err.message : "Unknown error",
+      message: error instanceof Error ? error.message : "Unknown error",
     });
   } finally {
-    await stagehand?.close().catch(() => undefined);
-    await browser?.close().catch(() => undefined);
-    if (extensionId) {
-      await bb.extensions
-        .delete(extensionId, { headers: { "Content-Type": null } })
-        .catch(() => undefined);
-    }
-    // Clean up temp resume file (in finally so it's removed even on error)
-    if (resumePath)
+    await mcpClient?.close().catch(() => undefined);
+    if (resumePath) {
       try {
         unlinkSync(resumePath);
       } catch {
-        /* ignore */
+        // Ignore cleanup errors for an already-removed temporary file.
       }
+    }
     await writer.close();
   }
 }

--- a/typescript/agent-with-human-in-loop/lib/agent.ts
+++ b/typescript/agent-with-human-in-loop/lib/agent.ts
@@ -16,6 +16,10 @@ import {
   setSessionBrowser,
 } from "./session-store";
 
+const childEnv = Object.fromEntries(
+  Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+);
+
 function sendEvent(
   writer: WritableStreamDefaultWriter<Uint8Array>,
   event: string,
@@ -72,6 +76,7 @@ export async function runAgent(params: {
     mcpClient = await createMCPClient({
       transport: new Experimental_StdioMCPTransport({
         command: "stagehand-codemode",
+        env: childEnv,
         stderr: "inherit",
       }),
     });

--- a/typescript/agent-with-human-in-loop/lib/session-store.ts
+++ b/typescript/agent-with-human-in-loop/lib/session-store.ts
@@ -25,14 +25,20 @@ export interface SessionState {
 
 const sessions = new Map<string, SessionState>();
 
-export function createSession(id: string, debuggerUrl: string, bbSessionId: string): SessionState {
+export function createSession(id: string): SessionState {
   const state: SessionState = {
     status: "running",
-    debuggerUrl,
-    sessionId: bbSessionId,
   };
   sessions.set(id, state);
   return state;
+}
+
+export function setSessionBrowser(id: string, debuggerUrl: string, bbSessionId: string) {
+  const session = sessions.get(id);
+  if (session) {
+    session.debuggerUrl = debuggerUrl;
+    session.sessionId = bbSessionId;
+  }
 }
 
 export function getSession(id: string): SessionState | undefined {

--- a/typescript/agent-with-human-in-loop/package.json
+++ b/typescript/agent-with-human-in-loop/package.json
@@ -10,11 +10,11 @@
   },
   "dependencies": {
     "@browserbasehq/sdk": "^2.9.0",
-    "@browserbasehq/stagehand": "^3.2.0",
+    "@browserbasehq/stagehand": "github:browserbase/stagehand#089f2aaeaea75696685949e0835aece95db54358&path:/packages/sdk-ts",
     "next": "16.2.1",
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "zod": "^4.3.6"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
@@ -25,5 +25,10 @@
     "eslint-config-next": "16.2.1",
     "tailwindcss": "^4",
     "typescript": "^5"
-  }
+  },
+  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand@4.0.0 after it is published.",
+  "engines": {
+    "node": ">=22.18.0"
+  },
+  "packageManager": "pnpm@10.24.0"
 }

--- a/typescript/agent-with-human-in-loop/package.json
+++ b/typescript/agent-with-human-in-loop/package.json
@@ -9,8 +9,10 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@ai-sdk/mcp": "^2.0.29",
     "@browserbasehq/sdk": "^2.9.0",
-    "@browserbasehq/stagehand": "github:browserbase/stagehand#089f2aaeaea75696685949e0835aece95db54358&path:/packages/sdk-ts",
+    "@browserbasehq/stagehand-codemode": "github:browserbase/stagehand#54302fc5f13be5ad8e717d8e1388502de22be2ed&path:/packages/integrations",
+    "ai": "^7.0.58",
     "next": "16.2.1",
     "react": "19.2.4",
     "react-dom": "19.2.4",
@@ -26,7 +28,7 @@
     "tailwindcss": "^4",
     "typescript": "^5"
   },
-  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand@4.0.0 after it is published.",
+  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand-codemode@4.0.0 after it is published.",
   "engines": {
     "node": ">=22.18.0"
   },

--- a/typescript/amazon-global-price-comparison/README.md
+++ b/typescript/amazon-global-price-comparison/README.md
@@ -58,7 +58,7 @@
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground
 🔧 Templates: https://www.browserbase.com/templates

--- a/typescript/amazon-global-price-comparison/README.md
+++ b/typescript/amazon-global-price-comparison/README.md
@@ -4,7 +4,7 @@
 
 - Goal: compare Amazon product prices across multiple countries using geolocation proxies.
 - Uses Browserbase's managed proxy infrastructure to route traffic through different geographic locations (US, UK, Germany, France, Italy, Spain).
-- Extracts structured product data (name, price, rating, reviews) using Stagehand's extraction capabilities with Zod schema validation.
+- Opens each matching regional Amazon storefront and reads its result cards with deterministic V4 page APIs, then validates the records with Zod.
 - Sequential processing shows how different proxy locations return different pricing from the same Amazon search.
 - Docs → https://docs.browserbase.com/features/proxies
 
@@ -12,8 +12,8 @@
 
 - geolocation proxies: route traffic through specific geographic locations (city, country) to access location-specific content and pricing
   Docs → https://docs.browserbase.com/features/proxies#set-proxy-geolocation
-- extract: extract structured data from web pages using natural language instructions and Zod schemas
-  Docs → https://docs.stagehand.dev/basics/extract
+- page APIs: use the V4 browser context and page directly when the target has a known, stable structure
+  Docs → https://docs.stagehand.dev/v4/reference/page
 - proxies: Browserbase's managed proxy infrastructure supporting 201+ countries for geolocation-based routing
   Docs → https://docs.browserbase.com/features/proxies
 
@@ -29,7 +29,7 @@
 
 - Creates Browserbase sessions with geolocation proxies for each country (US, UK, DE, FR, IT, ES)
 - Navigates to Amazon search results through location-specific proxies
-- Extracts product name, price, rating, and review count for each location
+- Validates three complete product records with regional URLs for each location
 - Displays formatted comparison table showing price differences across countries
 - Outputs JSON results for programmatic use
 

--- a/typescript/amazon-global-price-comparison/index.ts
+++ b/typescript/amazon-global-price-comparison/index.ts
@@ -31,6 +31,7 @@ type Product = z.infer<typeof ProductSchema>;
 interface CountryConfig {
   name: string;
   code: string;
+  domain: string;
   city?: string;
   currency: string;
 }
@@ -38,12 +39,18 @@ interface CountryConfig {
 // Supported countries for price comparison
 // Add or remove countries as needed - see https://docs.browserbase.com/features/proxies for available geolocations
 const COUNTRIES: CountryConfig[] = [
-  { name: "United States", code: "US", city: undefined, currency: "USD" },
-  { name: "United Kingdom", code: "GB", city: "LONDON", currency: "GBP" },
-  { name: "Germany", code: "DE", city: "BERLIN", currency: "EUR" },
-  { name: "France", code: "FR", city: "PARIS", currency: "EUR" },
-  { name: "Italy", code: "IT", city: "ROME", currency: "EUR" },
-  { name: "Spain", code: "ES", city: "MADRID", currency: "EUR" },
+  { name: "United States", code: "US", domain: "www.amazon.com", currency: "USD" },
+  {
+    name: "United Kingdom",
+    code: "GB",
+    domain: "www.amazon.co.uk",
+    city: "LONDON",
+    currency: "GBP",
+  },
+  { name: "Germany", code: "DE", domain: "www.amazon.de", city: "BERLIN", currency: "EUR" },
+  { name: "France", code: "FR", domain: "www.amazon.fr", city: "PARIS", currency: "EUR" },
+  { name: "Italy", code: "IT", domain: "www.amazon.it", city: "ROME", currency: "EUR" },
+  { name: "Spain", code: "ES", domain: "www.amazon.es", city: "MADRID", currency: "EUR" },
 ];
 
 // Results structure for each country
@@ -53,6 +60,14 @@ interface CountryResult {
   currency: string;
   products: Product[];
   error?: string;
+}
+
+async function closeSession(
+  stagehand: Stagehand,
+  browser: Awaited<ReturnType<typeof browserbase.launch>>,
+) {
+  await stagehand.close().catch((error) => console.warn("Stagehand cleanup warning:", error));
+  await browser.close().catch((error) => console.warn("Browser cleanup warning:", error));
 }
 
 /**
@@ -99,32 +114,67 @@ async function getProductsForCountry(
     // console.log(`Navigating to: ${searchUrl}`);
     // await page.goto(searchUrl, { waitUntil: "domcontentloaded", timeout: 60000 });
 
-    // Navigate to Amazon homepage to begin search
-    console.log(`[${country.name}] Navigating to Amazon...`);
-    await page.goto("https://www.amazon.com", {
+    // Use the matching regional Amazon storefront and a deterministic search URL.
+    const origin = `https://${country.domain}`;
+    const searchUrl = `${origin}/s?k=${encodeURIComponent(searchQuery)}`;
+    console.log(`[${country.name}] Navigating to ${searchUrl}...`);
+    await page.goto(searchUrl, {
       waitUntil: "domcontentloaded",
       timeout: 60000,
     });
 
-    // Perform search using natural language actions
-    console.log(`[${country.name}] Searching for: ${searchQuery}`);
-    await stagehand.act(`Type "${searchQuery}" into the search bar`);
-    await stagehand.act("Click the search button");
+    // Regional storefronts hydrate result cards at different speeds. Wait for complete
+    // product links instead of assuming DOMContentLoaded means every card is ready.
+    const resultsDeadline = Date.now() + 15000;
+    let visibleProductCount = 0;
+    while (Date.now() < resultsDeadline) {
+      visibleProductCount = await page.evaluate(
+        () =>
+          Array.from(document.querySelectorAll('[data-component-type="s-search-result"]')).filter(
+            (card) =>
+              (card.querySelector("h2")?.textContent?.trim().length ?? 0) > 0 &&
+              card.querySelector('a[href*="/dp/"]'),
+          ).length,
+      );
+      if (visibleProductCount >= resultsCount) break;
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+    if (visibleProductCount < resultsCount) {
+      throw new Error(
+        `Only ${visibleProductCount} complete product cards rendered at ${await page.url()}`,
+      );
+    }
 
-    // Extract products from search results using Stagehand's structured extraction
+    // Amazon result cards have a known structure, so read them deterministically.
     console.log(`[${country.name}] Extracting top ${resultsCount} products...`);
-
-    const { data: extractionResult } = await stagehand.extract(
-      `Extract the first ${resultsCount} product search results from this Amazon page. For each product, extract:
-      1. name: the full product title
-      2. price: the displayed price WITH currency symbol (like $599.99 or 599,99 EUR). If no price shown, use "N/A"
-      3. rating: the star rating text (like "4.5 out of 5 stars")
-      4. reviews_count: the number of reviews (like "2,508")
-      5. product_url: the href link to the product page (starts with /dp/ or https://)
-      
-      Only extract actual product listings, skip sponsored ads or recommendations.`,
-      ProductsSchema,
-    );
+    const rawProducts = (await page.evaluate(
+      (limit: number) =>
+        Array.from(document.querySelectorAll('[data-component-type="s-search-result"]'))
+          .map((card) => {
+            const productLinks = Array.from(
+              card.querySelectorAll<HTMLAnchorElement>('a[href*="/dp/"]'),
+            );
+            const productLink =
+              card.querySelector<HTMLAnchorElement>('h2 a[href*="/dp/"]') ??
+              productLinks.find((link) => (link.textContent?.trim().length ?? 0) > 10) ??
+              productLinks[0];
+            const title =
+              card.querySelector("h2")?.textContent?.trim() ??
+              productLink?.textContent?.trim() ??
+              "";
+            return {
+              name: title,
+              price: card.querySelector(".a-price .a-offscreen")?.textContent?.trim() ?? "N/A",
+              rating: card.querySelector(".a-icon-alt")?.textContent?.trim() ?? "N/A",
+              reviews_count: card.querySelector(".s-underline-text")?.textContent?.trim() ?? "N/A",
+              product_url: productLink?.href ?? "",
+            };
+          })
+          .filter((product) => product.name.length > 0 && product.product_url.includes("/dp/"))
+          .slice(0, limit),
+      resultsCount,
+    )) as unknown;
+    const extractionResult = ProductsSchema.parse({ products: rawProducts });
 
     // Clean up products - ensure price is never null and URLs are absolute
     const cleanedProducts = extractionResult.products.map((p) => ({
@@ -133,14 +183,20 @@ async function getProductsForCountry(
       product_url: p.product_url?.startsWith("http")
         ? p.product_url
         : p.product_url?.startsWith("/")
-          ? `https://www.amazon.com${p.product_url}`
+          ? `${origin}${p.product_url}`
           : p.product_url || "N/A",
     }));
 
+    if (
+      cleanedProducts.length < resultsCount ||
+      cleanedProducts.some((product) => !product.product_url.includes("/dp/"))
+    ) {
+      throw new Error(`Expected ${resultsCount} complete regional product records`);
+    }
+
     console.log(`Found ${cleanedProducts.length} products in ${country.name}`);
 
-    await stagehand.close();
-    await browser.close();
+    await closeSession(stagehand, browser);
 
     return {
       country: country.name,
@@ -150,8 +206,7 @@ async function getProductsForCountry(
     };
   } catch (error) {
     console.error(`Error fetching products from ${country.name}:`, error);
-    await stagehand.close();
-    await browser.close();
+    await closeSession(stagehand, browser);
 
     return {
       country: country.name,
@@ -237,6 +292,21 @@ async function main() {
   const results = await Promise.all(
     COUNTRIES.map((country) => getProductsForCountry(searchQuery, country, resultsCount)),
   );
+
+  // A regional storefront can occasionally reload its execution context while Amazon
+  // hydrates the page. Retry only failed countries once, then preserve a hard failure.
+  for (const [index, result] of results.entries()) {
+    if (result.products.length > 0) continue;
+    console.log(`\nRetrying ${COUNTRIES[index].name} after its first extraction failed...`);
+    results[index] = await getProductsForCountry(searchQuery, COUNTRIES[index], resultsCount);
+  }
+
+  const failures = results.filter((result) => result.products.length === 0);
+  if (failures.length > 0) {
+    throw new Error(
+      `Price extraction failed for ${failures.length} of ${results.length} countries`,
+    );
+  }
 
   // Display formatted comparison table
   displayComparisonTable(results);

--- a/typescript/amazon-global-price-comparison/index.ts
+++ b/typescript/amazon-global-price-comparison/index.ts
@@ -1,8 +1,8 @@
 // Amazon Global Price Comparison - See README.md for full documentation
 
 import "dotenv/config";
-import { Stagehand } from "@browserbasehq/stagehand";
-import { z } from "zod";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
+import { z } from "zod/v4";
 
 // Schema for a single product with structured extraction fields
 const ProductSchema = z.object({
@@ -77,27 +77,21 @@ async function getProductsForCountry(
 
   // Initialize Stagehand with geolocation proxy configuration
   // This ensures all browser traffic routes through the specified geographic location
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 0,
-    // 0 = errors only, 1 = info, 2 = debug
-    // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
-    // https://docs.stagehand.dev/configuration/logging
-    browserbaseSessionCreateParams: {
-      proxies: [
-        {
-          type: "browserbase", // Use Browserbase's managed proxy infrastructure for reliable geolocation routing
-          geolocation,
-        },
-      ],
-    },
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+    proxies: [
+      {
+        type: "browserbase", // Use Browserbase's managed proxy infrastructure for reliable geolocation routing
+        geolocation,
+      },
+    ],
   });
+  const stagehand = await Stagehand.create({ browser: browser, logging: { level: "error" } });
 
   try {
     console.log(`Initializing browser session with ${country.name} proxy...`);
-    await stagehand.init();
 
-    const page = stagehand.context.pages()[0];
+    const page = (await browser.context.pages())[0];
 
     // Alternative: Skip the search bar and go straight to results by building the search URL.
     // Uncomment below to use direct navigation instead of stagehand.act() typing + clicking.
@@ -120,7 +114,7 @@ async function getProductsForCountry(
     // Extract products from search results using Stagehand's structured extraction
     console.log(`[${country.name}] Extracting top ${resultsCount} products...`);
 
-    const extractionResult = await stagehand.extract(
+    const { data: extractionResult } = await stagehand.extract(
       `Extract the first ${resultsCount} product search results from this Amazon page. For each product, extract:
       1. name: the full product title
       2. price: the displayed price WITH currency symbol (like $599.99 or 599,99 EUR). If no price shown, use "N/A"
@@ -146,6 +140,7 @@ async function getProductsForCountry(
     console.log(`Found ${cleanedProducts.length} products in ${country.name}`);
 
     await stagehand.close();
+    await browser.close();
 
     return {
       country: country.name,
@@ -156,6 +151,7 @@ async function getProductsForCountry(
   } catch (error) {
     console.error(`Error fetching products from ${country.name}:`, error);
     await stagehand.close();
+    await browser.close();
 
     return {
       country: country.name,
@@ -260,6 +256,6 @@ main().catch((err) => {
     "  - Verify geolocation proxy locations are valid (see https://docs.browserbase.com/features/proxies)",
   );
   console.error("  - Ensure you have sufficient Browserbase credits");
-  console.error("Docs: https://docs.stagehand.dev/v3/first-steps/introduction");
+  console.error("Docs: https://docs.stagehand.dev/v4/first-steps/introduction");
   process.exit(1);
 });

--- a/typescript/amazon-global-price-comparison/package.json
+++ b/typescript/amazon-global-price-comparison/package.json
@@ -6,7 +6,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@browserbasehq/stagehand": "github:browserbase/stagehand#4186c7d98d2f325b6fc85b3f760111e6c390d703&path:/packages/sdk-ts",
+    "@browserbasehq/stagehand": "4.0.0",
     "dotenv": "^16.4.7",
     "zod": "^4.4.3"
   },
@@ -15,7 +15,6 @@
     "tsx": "^4.19.2",
     "typescript": "^5.0.0"
   },
-  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand@4.0.0 after it is published.",
   "engines": {
     "node": ">=22.18.0"
   },

--- a/typescript/amazon-global-price-comparison/package.json
+++ b/typescript/amazon-global-price-comparison/package.json
@@ -2,16 +2,22 @@
   "name": "amazon-global-price-comparison-template",
   "type": "module",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --noEmit --skipLibCheck --target ES2022 --module NodeNext --moduleResolution NodeNext index.ts",
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@browserbasehq/stagehand": "latest",
+    "@browserbasehq/stagehand": "github:browserbase/stagehand#089f2aaeaea75696685949e0835aece95db54358&path:/packages/sdk-ts",
     "dotenv": "^16.4.7",
-    "zod": "latest"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@types/node": "^22.18.0",
     "tsx": "^4.19.2",
     "typescript": "^5.0.0"
-  }
+  },
+  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand@4.0.0 after it is published.",
+  "engines": {
+    "node": ">=22.18.0"
+  },
+  "packageManager": "pnpm@10.24.0"
 }

--- a/typescript/amazon-global-price-comparison/package.json
+++ b/typescript/amazon-global-price-comparison/package.json
@@ -6,7 +6,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@browserbasehq/stagehand": "github:browserbase/stagehand#089f2aaeaea75696685949e0835aece95db54358&path:/packages/sdk-ts",
+    "@browserbasehq/stagehand": "github:browserbase/stagehand#4186c7d98d2f325b6fc85b3f760111e6c390d703&path:/packages/sdk-ts",
     "dotenv": "^16.4.7",
     "zod": "^4.4.3"
   },

--- a/typescript/amazon-product-scraping/README.md
+++ b/typescript/amazon-product-scraping/README.md
@@ -27,7 +27,7 @@
 ## EXPECTED OUTPUT
 
 - Initializes Stagehand session with Browserbase
-- Displays live session link for monitoring
+- Returns structured product details through a Stagehand V4 extraction result
 - Navigates to Amazon and performs search (or direct URL navigation if uncommented)
 - Extracts the first 3 products with name, price, rating, reviews count, and product URL
 - Outputs JSON to console

--- a/typescript/amazon-product-scraping/README.md
+++ b/typescript/amazon-product-scraping/README.md
@@ -3,17 +3,15 @@
 ## AT A GLANCE
 
 - Goal: scrape the first 3 Amazon search results for a given query and return structured product data.
-- AI-Powered Search: uses Stagehand `act` to type in the search bar and click search (or optionally navigate directly to the search URL).
-- Structured Extraction: uses `extract` with a Zod schema to get product name, price, rating, review count, and product URL.
+- Deterministic Search: navigates directly to the Amazon search URL so a failed form action cannot leave the workflow on the homepage.
+- Structured Results: reads known Amazon result cards with V4 page APIs and validates product name, price, rating, review count, and URL with Zod.
 - Model: uses `google/gemini-2.5-flash` for fast, cost-effective automation.
   Docs → https://docs.stagehand.dev
 
 ## GLOSSARY
 
-- act: perform UI actions from a prompt (type in search bar, click search)
-  Docs → https://docs.stagehand.dev/basics/act
-- extract: pull structured data from pages using schemas
-  Docs → https://docs.stagehand.dev/basics/extract
+- page APIs: use the V4 browser context and page directly when the target has a known structure
+  Docs → https://docs.stagehand.dev/v4/reference/page
 
 ## QUICKSTART
 
@@ -27,8 +25,8 @@
 ## EXPECTED OUTPUT
 
 - Initializes Stagehand session with Browserbase
-- Returns structured product details through a Stagehand V4 extraction result
-- Navigates to Amazon and performs search (or direct URL navigation if uncommented)
+- Navigates directly to the configured Amazon search
+- Validates three complete product-detail records with Zod
 - Extracts the first 3 products with name, price, rating, reviews count, and product URL
 - Outputs JSON to console
 - Closes session cleanly
@@ -37,7 +35,7 @@
 
 - "Cannot find module": ensure npm install completed
 - Missing credentials: verify .env contains BROWSERBASE_API_KEY
-- Amazon layout changes: extraction may need prompt/schema updates if Amazon changes their search results UI
+- Amazon layout changes: DOM selectors may need updates if Amazon changes its result-card structure
 - Find more information on your Browserbase dashboard → https://www.browserbase.com/sign-in
 
 ## USE CASES
@@ -48,7 +46,7 @@
 
 ## NEXT STEPS
 
-• Switch to direct URL: Uncomment the URL-based search block in index.ts for faster runs without LLM search actions.
+• Parameterize storefront: Accept an Amazon domain or country from CLI/env.
 • Parameterize query: Accept SEARCH_QUERY from CLI or env for different products without editing code.
 • Paginate: Extend extraction to multiple pages or increase the number of products per run.
 

--- a/typescript/amazon-product-scraping/index.ts
+++ b/typescript/amazon-product-scraping/index.ts
@@ -1,8 +1,8 @@
 // Stagehand + Browserbase: Amazon Product Scraping - See README.md for full documentation
 
 import "dotenv/config";
-import { Stagehand } from "@browserbasehq/stagehand";
-import { z } from "zod";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
+import { z } from "zod/v4";
 
 // ============= CONFIGURATION =============
 // Update this value to search for different products
@@ -27,21 +27,20 @@ async function main(): Promise<void> {
   console.log("Starting Amazon Product Scraping...");
 
   // Initialize Stagehand with Browserbase for cloud-based browser automation.
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 1,
-    model: "google/gemini-2.5-flash",
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+  });
+  const stagehand = await Stagehand.create({
+    browser: browser,
+    model: { modelName: "google/gemini-2.5-flash" },
+    logging: { level: "info" },
   });
 
   try {
     // Initialize browser session to start automation.
-    await stagehand.init();
-    console.log("Stagehand initialized successfully!");
-    console.log(
-      `Live View Link: https://browserbase.com/sessions/${stagehand.browserbaseSessionID}`,
-    );
 
-    const page = stagehand.context.pages()[0];
+    console.log("Stagehand initialized successfully!");
+    const page = (await browser.context.pages())[0];
 
     // Alternative: skip the search bar and go straight to results by building the search URL.
     // Uncomment below to use direct navigation instead of stagehand.act() typing + clicking.
@@ -65,7 +64,7 @@ async function main(): Promise<void> {
 
     // Extract structured product data using Zod schema for type safety.
     console.log("Extracting product data...");
-    const products = await stagehand.extract(
+    const { data: products } = await stagehand.extract(
       "Extract the details of the FIRST 3 products in the search results. Get the product name, price, star rating, number of reviews, and the URL link to the product page.",
       ProductsSchema,
     );
@@ -77,6 +76,7 @@ async function main(): Promise<void> {
   } finally {
     // Always close session to release resources and clean up.
     await stagehand.close();
+    await browser.close();
     console.log("Session closed successfully");
   }
 }

--- a/typescript/amazon-product-scraping/index.ts
+++ b/typescript/amazon-product-scraping/index.ts
@@ -15,7 +15,9 @@ const ProductSchema = z.object({
   price: z.string().describe("The product price including currency symbol (e.g., '$29.99')"),
   rating: z.string().describe("The star rating (e.g., '4.5 out of 5 stars')"),
   reviews_count: z.string().describe("The number of customer reviews (e.g., '1,234')"),
-  product_url: z.string().url().describe("The URL link to the product detail page on Amazon"),
+  product_url: z
+    .string()
+    .describe("The absolute or root-relative URL link to the product detail page on Amazon"),
 });
 
 // Schema for extracting multiple products from search results
@@ -53,26 +55,71 @@ async function main(): Promise<void> {
     //   waitUntil: "domcontentloaded",
     // });
 
-    // Navigate to Amazon homepage to begin search.
-    console.log("Navigating to Amazon...");
-    await page.goto("https://www.amazon.com");
+    // Navigate directly to a deterministic search URL so a failed form action
+    // cannot leave extraction on the Amazon homepage.
+    const searchUrl = `https://www.amazon.com/s?k=${encodeURIComponent(SEARCH_QUERY)}`;
+    console.log(`Navigating to Amazon search: ${searchUrl}`);
+    await page.goto(searchUrl, { waitUntil: "domcontentloaded", timeout: 60000 });
 
-    // Perform search using natural language actions.
-    console.log(`Searching for: ${SEARCH_QUERY}`);
-    await stagehand.act(`Type ${SEARCH_QUERY} into the search bar`);
-    await stagehand.act("Click the search button");
-
-    // Extract structured product data using Zod schema for type safety.
+    // Read Amazon's result cards deterministically. Known layouts are more
+    // reliable and cheaper with locators/DOM reads than semantic extraction.
     console.log("Extracting product data...");
-    const { data: products } = await stagehand.extract(
-      "Extract the details of the FIRST 3 products in the search results. Get the product name, price, star rating, number of reviews, and the URL link to the product page.",
-      ProductsSchema,
+    const rawProducts = (await page.evaluate(() =>
+      Array.from(document.querySelectorAll('[data-component-type="s-search-result"]'))
+        .slice(0, 3)
+        .map((card) => {
+          const productLinks = Array.from(
+            card.querySelectorAll<HTMLAnchorElement>('a[href*="/dp/"]'),
+          );
+          const productLink =
+            productLinks.find((link) => (link.textContent?.trim().length ?? 0) > 10) ??
+            productLinks[0];
+          const brand = card.querySelector("h2 span")?.textContent?.trim() ?? "";
+          const title = productLink?.textContent?.trim() ?? "";
+          return {
+            name: [brand, title].filter(Boolean).join(" "),
+            price: card.querySelector(".a-price .a-offscreen")?.textContent?.trim() ?? "",
+            rating: card.querySelector(".a-icon-alt")?.textContent?.trim() ?? "",
+            reviews_count:
+              card
+                .querySelector('[data-csa-c-content-id="alf-customer-ratings-count-component"]')
+                ?.textContent?.trim() ??
+              card.querySelector(".s-underline-text")?.textContent?.trim() ??
+              "",
+            product_url: productLink?.href ?? "",
+          };
+        }),
+    )) as unknown;
+    const products = ProductsSchema.parse({ products: rawProducts });
+
+    const normalizedProducts = products.products.map((product) => ({
+      ...product,
+      product_url: new URL(product.product_url, "https://www.amazon.com").href,
+    }));
+    if (normalizedProducts.length < 3) {
+      throw new Error(`Expected 3 products, found ${normalizedProducts.length}`);
+    }
+    const queryMatches = normalizedProducts.filter((product) =>
+      product.name.toLowerCase().includes("seiko"),
     );
+    if (queryMatches.length < 2) {
+      throw new Error(
+        `Search results did not match ${SEARCH_QUERY}: only ${queryMatches.length} Seiko products`,
+      );
+    }
+    if (
+      normalizedProducts.some(
+        (product) => !product.product_url.includes("/dp/") || product.name.length < 10,
+      )
+    ) {
+      throw new Error("One or more product records lacked a full title or product-detail URL");
+    }
 
     console.log("Products found:");
-    console.log(JSON.stringify(products, null, 2));
+    console.log(JSON.stringify({ products: normalizedProducts }, null, 2));
   } catch (error) {
     console.error("Error during product scraping:", error);
+    throw error;
   } finally {
     // Always close session to release resources and clean up.
     await stagehand.close();

--- a/typescript/amazon-product-scraping/package.json
+++ b/typescript/amazon-product-scraping/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch index.ts"
   },
   "dependencies": {
-    "@browserbasehq/stagehand": "github:browserbase/stagehand#089f2aaeaea75696685949e0835aece95db54358&path:/packages/sdk-ts",
+    "@browserbasehq/stagehand": "github:browserbase/stagehand#4186c7d98d2f325b6fc85b3f760111e6c390d703&path:/packages/sdk-ts",
     "dotenv": "^16.4.5",
     "zod": "^4.4.3"
   },

--- a/typescript/amazon-product-scraping/package.json
+++ b/typescript/amazon-product-scraping/package.json
@@ -9,13 +9,18 @@
     "dev": "tsx watch index.ts"
   },
   "dependencies": {
-    "@browserbasehq/stagehand": "latest",
+    "@browserbasehq/stagehand": "github:browserbase/stagehand#089f2aaeaea75696685949e0835aece95db54358&path:/packages/sdk-ts",
     "dotenv": "^16.4.5",
-    "zod": "^3.23.8"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^20.14.0",
     "tsx": "^4.16.0",
     "typescript": "^5.5.0"
-  }
+  },
+  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand@4.0.0 after it is published.",
+  "engines": {
+    "node": ">=22.18.0"
+  },
+  "packageManager": "pnpm@10.24.0"
 }

--- a/typescript/amazon-product-scraping/package.json
+++ b/typescript/amazon-product-scraping/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch index.ts"
   },
   "dependencies": {
-    "@browserbasehq/stagehand": "github:browserbase/stagehand#4186c7d98d2f325b6fc85b3f760111e6c390d703&path:/packages/sdk-ts",
+    "@browserbasehq/stagehand": "4.0.0",
     "dotenv": "^16.4.5",
     "zod": "^4.4.3"
   },
@@ -18,7 +18,6 @@
     "tsx": "^4.16.0",
     "typescript": "^5.5.0"
   },
-  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand@4.0.0 after it is published.",
   "engines": {
     "node": ">=22.18.0"
   },

--- a/typescript/basic-caching/README.md
+++ b/typescript/basic-caching/README.md
@@ -3,8 +3,8 @@
 ## AT A GLANCE
 
 - Goal: Demonstrate how Stagehand's caching feature dramatically reduces cost and latency by reusing previously computed actions instead of calling the LLM every time.
-- Shows side-by-side comparison of workflows with and without caching enabled.
-- Demonstrates massive cost savings for repeated workflows (99.9% reduction in LLM calls).
+- Runs the same observation twice and verifies the second result is a Browserbase Cache hit.
+- Reads cache status and saved-token data from the V4 result metadata.
 - Docs → https://docs.stagehand.dev/v4/best-practices/caching#caching-actions
 
 ## GLOSSARY
@@ -12,21 +12,20 @@
 - caching: Stagehand can cache action results based on instruction text and page context, eliminating redundant LLM calls
   Docs → https://docs.stagehand.dev/v4/best-practices/caching#caching-actions
 - act: execute actions on web pages using natural language instructions
-  Docs → https://docs.stagehand.dev/basics/act
+  Docs → https://docs.stagehand.dev/v4/basics/act
 
 ## QUICKSTART
 
 1. pnpm install
 2. cp .env.example .env
 3. Add your Browserbase API key to .env
-4. pnpm start (run twice to see cache benefits!)
+4. pnpm start
 
 ## EXPECTED OUTPUT
 
-- First run: Executes workflow without cache, then with cache enabled (populates cache)
-- Subsequent runs: Uses cached actions for instant execution with zero LLM calls
-- Displays timing comparison, cost savings, and cache statistics
-- Shows cache location and file structure
+- The first observation is normally a cache miss and primes the managed cache.
+- The repeated observation is verified as a `HIT`.
+- Output includes each operation's cache status, duration, and saved-token metadata.
 
 ## HOW CACHING WORKS
 
@@ -46,9 +45,9 @@
 
 **Cache Storage:**
 
-- Location: `.cache/stagehand-demo`
-- Format: JSON files (one per cached action)
-- Persistent across runs
+- Browserbase manages the cache server-side.
+- There are no local cache files or directories to maintain.
+- `result.metadata.cache.status` reports `HIT`, `MISS`, or `DISABLED`.
 
 ## BENEFITS FOR REPEATED WORKFLOWS
 
@@ -74,8 +73,8 @@ Payment portals rarely change → Cache actions once → Reuse for thousands of 
 ## COMMON PITFALLS
 
 - Missing credentials: verify .env contains BROWSERBASE_API_KEY
-- Cache not working: ensure cacheDir path is writable and check that instruction text matches exactly
-- First run slower: expected behavior - cache is populated on first run, subsequent runs will be instant
+- Cache not working: check that the instruction and page content match exactly
+- First observation slower: expected behavior—the first result primes the managed cache
 - Find more information on your Browserbase dashboard -> https://www.browserbase.com/sign-in
 
 ## USE CASES
@@ -87,29 +86,24 @@ Payment portals rarely change → Cache actions once → Reuse for thousands of 
 ## BEST PRACTICES
 
 - ✅ Enable caching in production for repeated workflows
-- ✅ One cache per portal/interface type
-- ✅ Invalidate cache when page structure changes significantly
+- ✅ Keep the page environment and instruction stable
+- ✅ Tune `cache.threshold` for the workflow's tolerance for change
 - ✅ Monitor cache hit rate to optimize cache effectiveness
 - ✅ Warm cache with test runs before production deployment
 
 ## NEXT STEPS
 
-• Customize cache directory: Modify cacheDir to organize caches by workflow type or environment.
-• Add cache invalidation: Implement logic to clear cache when page structure changes or after a certain time period.
-• Monitor cache performance: Track cache hit rates and cost savings to measure effectiveness.
+• Tune the cache threshold per instance or per operation.
+• Scope operations to a stable selector when the surrounding page changes frequently.
+• Monitor `metadata.cache` to measure hit rates and token savings.
 
 ## TRY IT YOURSELF
 
-1. Run this script again: `pnpm start`
-   → Second run will be MUCH faster (cache hits)
+1. Change the instruction text and run again to observe a miss followed by a hit.
 
-2. Clear cache and run again:
-   `rm -rf .cache/stagehand-demo && pnpm start`
-   → Back to first-run behavior
+2. Change `cache: { threshold: 1 }` to a higher threshold and compare warm-up behavior.
 
-3. Check cache contents:
-   `ls -la .cache/stagehand-demo`
-   → See cached action files
+3. Print the complete `metadata.cache` object to inspect miss reasons and token savings.
 
 ## HELPFUL RESOURCES
 

--- a/typescript/basic-caching/README.md
+++ b/typescript/basic-caching/README.md
@@ -5,12 +5,12 @@
 - Goal: Demonstrate how Stagehand's caching feature dramatically reduces cost and latency by reusing previously computed actions instead of calling the LLM every time.
 - Shows side-by-side comparison of workflows with and without caching enabled.
 - Demonstrates massive cost savings for repeated workflows (99.9% reduction in LLM calls).
-- Docs → https://docs.stagehand.dev/v3/best-practices/caching#caching-actions
+- Docs → https://docs.stagehand.dev/v4/best-practices/caching#caching-actions
 
 ## GLOSSARY
 
 - caching: Stagehand can cache action results based on instruction text and page context, eliminating redundant LLM calls
-  Docs → https://docs.stagehand.dev/v3/best-practices/caching#caching-actions
+  Docs → https://docs.stagehand.dev/v4/best-practices/caching#caching-actions
 - act: execute actions on web pages using natural language instructions
   Docs → https://docs.stagehand.dev/basics/act
 
@@ -113,7 +113,7 @@ Payment portals rarely change → Cache actions once → Reuse for thousands of 
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground
 🔧 Templates: https://www.browserbase.com/templates

--- a/typescript/basic-caching/index.ts
+++ b/typescript/basic-caching/index.ts
@@ -26,7 +26,7 @@ async function runWithoutCache() {
 
   try {
     console.log("Navigating to Stripe checkout...");
-    await page.goto("https://checkout.stripe.dev/preview", {
+    await page.goto("https://checkout.stripe.dev/?mode=payment", {
       waitUntil: "domcontentloaded",
     });
 
@@ -72,7 +72,7 @@ async function runWithCache() {
 
   try {
     console.log("Navigating to Stripe checkout...");
-    await page.goto("https://checkout.stripe.dev/preview", {
+    await page.goto("https://checkout.stripe.dev/?mode=payment", {
       waitUntil: "domcontentloaded",
     });
 

--- a/typescript/basic-caching/index.ts
+++ b/typescript/basic-caching/index.ts
@@ -1,7 +1,7 @@
 // Stagehand + Browserbase: Basic Caching - See README.md for full documentation
 
 import "dotenv/config";
-import { Stagehand } from "@browserbasehq/stagehand";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 import fs from "fs";
 import path from "path";
 
@@ -12,18 +12,17 @@ async function runWithoutCache() {
 
   const startTime = Date.now();
 
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 0,
-    // 0 = errors only, 1 = info, 2 = debug
-    // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
-    // https://docs.stagehand.dev/configuration/logging
-    model: "google/gemini-2.5-flash",
-    enableCaching: false,
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+  });
+  const stagehand = await Stagehand.create({
+    browser: browser,
+    model: { modelName: "google/gemini-2.5-flash" },
+    cache: false,
+    logging: { level: "error" },
   });
 
-  await stagehand.init();
-  const page = stagehand.context.pages()[0];
+  const page = (await browser.context.pages())[0];
 
   try {
     console.log("Navigating to Stripe checkout...");
@@ -43,11 +42,13 @@ async function runWithoutCache() {
     console.log("API calls: 4 (one per action)\n");
 
     await stagehand.close();
+    await browser.close();
 
     return { elapsed, llmCalls: 4 };
   } catch (error) {
-    console.error("Error:", error.message);
+    console.error("Error:", error instanceof Error ? error.message : String(error));
     await stagehand.close();
+    await browser.close();
     throw error;
   }
 }
@@ -57,19 +58,17 @@ async function runWithCache() {
 
   const startTime = Date.now();
 
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 0,
-    // 0 = errors only, 1 = info, 2 = debug
-    // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
-    // https://docs.stagehand.dev/configuration/logging
-    model: "google/gemini-2.5-flash",
-    enableCaching: true,
-    cacheDir: CACHE_DIR,
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+  });
+  const stagehand = await Stagehand.create({
+    browser: browser,
+    model: { modelName: "google/gemini-2.5-flash" },
+    cache: true,
+    logging: { level: "error" },
   });
 
-  await stagehand.init();
-  const page = stagehand.context.pages()[0];
+  const page = (await browser.context.pages())[0];
 
   try {
     console.log("Navigating to Stripe checkout...");
@@ -100,11 +99,13 @@ async function runWithCache() {
     console.log();
 
     await stagehand.close();
+    await browser.close();
 
     return { elapsed, llmCalls: cacheFiles > 0 ? 0 : 4 };
   } catch (error) {
-    console.error("Error:", error.message);
+    console.error("Error:", error instanceof Error ? error.message : String(error));
     await stagehand.close();
+    await browser.close();
     throw error;
   }
 }
@@ -157,6 +158,6 @@ main().catch((err) => {
   console.error("Error in caching demo:", err);
   console.error("Common issues:");
   console.error("  - Check .env file has BROWSERBASE_API_KEY");
-  console.error("Docs: https://docs.stagehand.dev/v3/first-steps/introduction");
+  console.error("Docs: https://docs.stagehand.dev/v4/first-steps/introduction");
   process.exit(1);
 });

--- a/typescript/basic-caching/index.ts
+++ b/typescript/basic-caching/index.ts
@@ -2,162 +2,65 @@
 
 import "dotenv/config";
 import { browserbase, Stagehand } from "@browserbasehq/stagehand";
-import fs from "fs";
-import path from "path";
 
-const CACHE_DIR = path.join(process.cwd(), ".cache", "stagehand-demo");
-
-async function runWithoutCache() {
-  console.log("RUN 1: WITHOUT CACHING");
-
-  const startTime = Date.now();
-
-  const browser = await browserbase.launch({
-    apiKey: process.env.BROWSERBASE_API_KEY!,
-  });
-  const stagehand = await Stagehand.create({
-    browser: browser,
-    model: { modelName: "google/gemini-2.5-flash" },
-    cache: false,
-    logging: { level: "error" },
-  });
-
-  const page = (await browser.context.pages())[0];
-
-  try {
-    console.log("Navigating to Stripe checkout...");
-    await page.goto("https://checkout.stripe.dev/?mode=payment", {
-      waitUntil: "domcontentloaded",
-    });
-
-    await stagehand.act("Click on the View Demo button");
-    await stagehand.act("Type 'test@example.com' into the email field");
-    await stagehand.act("Type '4242424242424242' into the card number field");
-    await stagehand.act("Type '12/34' into the expiration date field");
-
-    const elapsed = ((Date.now() - startTime) / 1000).toFixed(2);
-
-    console.log(`Total time: ${elapsed}s`);
-    console.log("Cost: ~$0.01-0.05 (4 LLM calls)");
-    console.log("API calls: 4 (one per action)\n");
-
-    await stagehand.close();
-    await browser.close();
-
-    return { elapsed, llmCalls: 4 };
-  } catch (error) {
-    console.error("Error:", error instanceof Error ? error.message : String(error));
-    await stagehand.close();
-    await browser.close();
-    throw error;
-  }
-}
-
-async function runWithCache() {
-  console.log("RUN 2: WITH CACHING");
-
-  const startTime = Date.now();
-
-  const browser = await browserbase.launch({
-    apiKey: process.env.BROWSERBASE_API_KEY!,
-  });
-  const stagehand = await Stagehand.create({
-    browser: browser,
-    model: { modelName: "google/gemini-2.5-flash" },
-    cache: true,
-    logging: { level: "error" },
-  });
-
-  const page = (await browser.context.pages())[0];
-
-  try {
-    console.log("Navigating to Stripe checkout...");
-    await page.goto("https://checkout.stripe.dev/?mode=payment", {
-      waitUntil: "domcontentloaded",
-    });
-
-    await stagehand.act("Click on the View Demo button");
-    await stagehand.act("Type 'test@example.com' into the email field");
-    await stagehand.act("Type '4242424242424242' into the card number field");
-    await stagehand.act("Type '12/34' into the expiration date field");
-
-    const elapsed = ((Date.now() - startTime) / 1000).toFixed(2);
-    const cacheExists = fs.existsSync(CACHE_DIR);
-    const cacheFiles = cacheExists ? fs.readdirSync(CACHE_DIR).length : 0;
-
-    console.log(`Total time: ${elapsed}s`);
-
-    if (cacheFiles > 0) {
-      console.log("Cost: $0.00 (cache hits, no LLM calls)");
-      console.log("API calls: 0 (all from cache)");
-      console.log(`Cache entries: ${cacheFiles}`);
-    } else {
-      console.log("💰Cost: ~$0.01-0.05 (first run, populated cache)");
-      console.log("📡API calls: 4 (saved to cache for next run)");
-      console.log("📂Cache created");
-    }
-    console.log();
-
-    await stagehand.close();
-    await browser.close();
-
-    return { elapsed, llmCalls: cacheFiles > 0 ? 0 : 4 };
-  } catch (error) {
-    console.error("Error:", error instanceof Error ? error.message : String(error));
-    await stagehand.close();
-    await browser.close();
-    throw error;
-  }
-}
+const INSTRUCTION = "Find the More information link";
 
 async function main() {
-  console.log("\n╔═══════════════════════════════════════════════════════════╗");
-  console.log("║  Caching Demo - Run This Script TWICE!         ║");
-  console.log("╚═══════════════════════════════════════════════════════════╝\n");
+  console.log("Starting Browserbase Cache demo...");
 
-  console.log("This demo shows caching impact by running the same workflow twice:\n");
-  console.log("First run:");
-  console.log("  1. WITHOUT cache (baseline)");
-  console.log("  2. WITH cache enabled (populates cache)\n");
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+  });
+  const stagehand = await Stagehand.create({
+    browser,
+    model: { modelName: "google/gemini-2.5-flash" },
+    cache: { threshold: 1 },
+    logging: { level: "error" },
+  });
 
-  console.log("Second run:");
-  console.log("  - WITH cache (instant, $0 cost)\n");
+  try {
+    const page = (await browser.context.pages())[0];
+    await page.goto("https://example.com", { waitUntil: "domcontentloaded" });
 
-  console.log("Run 'pnpm start' twice to see the difference!\n");
+    const firstStart = Date.now();
+    const first = await stagehand.observe(INSTRUCTION);
+    const firstMs = Date.now() - firstStart;
+    if (first.data.length === 0) throw new Error("First observation returned no link");
 
-  // Check if cache exists
-  const cacheExists = fs.existsSync(CACHE_DIR);
+    const secondStart = Date.now();
+    const second = await stagehand.observe(INSTRUCTION);
+    const secondMs = Date.now() - secondStart;
+    if (second.data.length === 0) throw new Error("Cached observation returned no link");
 
-  if (cacheExists) {
-    const cacheFiles = fs.readdirSync(CACHE_DIR);
-    console.log(`📂 Cache found: ${cacheFiles.length} entries`);
-    console.log("   This is a SUBSEQUENT run - cache will be used!\n");
-  } else {
-    console.log("No cache found - first run will populate cache");
+    console.log(
+      JSON.stringify(
+        {
+          first: { cache: first.metadata.cache.status, durationMs: firstMs },
+          second: {
+            cache: second.metadata.cache.status,
+            durationMs: secondMs,
+            tokensSaved: second.metadata.cache.tokensSaved ?? null,
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    if (second.metadata.cache.status !== "HIT") {
+      throw new Error(
+        `Expected the repeated observation to be a cache HIT, got ${second.metadata.cache.status}`,
+      );
+    }
+    console.log("Cache verified: the repeated observation was served without inference.");
+  } finally {
+    await stagehand.close();
+    await browser.close();
   }
-
-  console.log("\nRunning comparison: without cache vs with cache...\n");
-
-  const withoutCache = await runWithoutCache();
-  const withCache = await runWithCache();
-
-  console.log("\n=== Comparison ===");
-  console.log(`Without caching: ${withoutCache.elapsed}s, ${withoutCache.llmCalls} LLM calls`);
-  console.log(`With caching:    ${withCache.elapsed}s, ${withCache.llmCalls} LLM calls`);
-
-  if (withCache.llmCalls === 0) {
-    const speedup = (parseFloat(withoutCache.elapsed) / parseFloat(withCache.elapsed)).toFixed(1);
-    console.log(`\nSpeedup: ${speedup}x faster with cache`);
-    console.log("Cost savings: 100% (no LLM calls)");
-  }
-
-  console.log("\nRun again to see cache benefits on subsequent runs!");
 }
 
-main().catch((err) => {
-  console.error("Error in caching demo:", err);
-  console.error("Common issues:");
-  console.error("  - Check .env file has BROWSERBASE_API_KEY");
-  console.error("Docs: https://docs.stagehand.dev/v4/first-steps/introduction");
+main().catch((error) => {
+  console.error("Error in caching demo:", error);
+  console.error("Check BROWSERBASE_API_KEY and Browserbase Cache availability.");
   process.exit(1);
 });

--- a/typescript/basic-caching/package.json
+++ b/typescript/basic-caching/package.json
@@ -8,7 +8,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@browserbasehq/stagehand": "github:browserbase/stagehand#089f2aaeaea75696685949e0835aece95db54358&path:/packages/sdk-ts",
+    "@browserbasehq/stagehand": "github:browserbase/stagehand#4186c7d98d2f325b6fc85b3f760111e6c390d703&path:/packages/sdk-ts",
     "dotenv": "latest"
   },
   "devDependencies": {

--- a/typescript/basic-caching/package.json
+++ b/typescript/basic-caching/package.json
@@ -8,7 +8,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@browserbasehq/stagehand": "latest",
+    "@browserbasehq/stagehand": "github:browserbase/stagehand#089f2aaeaea75696685949e0835aece95db54358&path:/packages/sdk-ts",
     "dotenv": "latest"
   },
   "devDependencies": {
@@ -16,5 +16,9 @@
     "tsx": "latest",
     "typescript": "latest"
   },
-  "packageManager": "pnpm@9.0.0"
+  "packageManager": "pnpm@10.24.0",
+  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand@4.0.0 after it is published.",
+  "engines": {
+    "node": ">=22.18.0"
+  }
 }

--- a/typescript/basic-caching/package.json
+++ b/typescript/basic-caching/package.json
@@ -8,7 +8,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@browserbasehq/stagehand": "github:browserbase/stagehand#4186c7d98d2f325b6fc85b3f760111e6c390d703&path:/packages/sdk-ts",
+    "@browserbasehq/stagehand": "4.0.0",
     "dotenv": "latest"
   },
   "devDependencies": {
@@ -17,7 +17,6 @@
     "typescript": "latest"
   },
   "packageManager": "pnpm@10.24.0",
-  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand@4.0.0 after it is published.",
   "engines": {
     "node": ">=22.18.0"
   }

--- a/typescript/basic-recaptcha/README.md
+++ b/typescript/basic-recaptcha/README.md
@@ -20,9 +20,9 @@
   - `browserbase-solving-finished`: emitted when CAPTCHA solving completes
 - custom CAPTCHA solving: For non-standard or custom captcha providers, you can specify CSS selectors for the captcha image and input field using `captchaImageSelector` and `captchaInputSelector` in browserSettings.
 - act: perform UI actions from a prompt (type, click, fill forms)
-  Docs → https://docs.stagehand.dev/basics/act
+  Docs → https://docs.stagehand.dev/v4/basics/act
 - extract: pull data from web pages using natural language instructions
-  Docs → https://docs.stagehand.dev/basics/extract
+  Docs → https://docs.stagehand.dev/v4/basics/extract
 
 ## STAGEHAND VS PLAYWRIGHT
 

--- a/typescript/basic-recaptcha/README.md
+++ b/typescript/basic-recaptcha/README.md
@@ -82,7 +82,7 @@ browserSettings: {
 ## EXPECTED OUTPUT
 
 - Initializes Stagehand session with Browserbase
-- Displays live session link for monitoring
+- Listens for Browserbase captcha progress through Stagehand V4 console events
 - Navigates to Google reCAPTCHA demo page
 - Clicks submit button to trigger reCAPTCHA challenge
 - Waits for Browserbase to automatically solve the captcha
@@ -105,7 +105,7 @@ browserSettings: {
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground
 🔧 Templates: https://www.browserbase.com/templates

--- a/typescript/basic-recaptcha/index.ts
+++ b/typescript/basic-recaptcha/index.ts
@@ -1,7 +1,7 @@
 // Basic reCAPTCHA Solving with Browserbase - See README.md for full documentation
 
 import "dotenv/config";
-import { Stagehand } from "@browserbasehq/stagehand";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 
 async function main() {
   // Initialize Stagehand with Browserbase for cloud-based browser automation.
@@ -9,28 +9,19 @@ async function main() {
 
   const solveCaptchas = true; // Set to false to disable automatic captcha solving (true by default)
 
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 1,
-    // 0 = errors only, 1 = info, 2 = debug
-    // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
-    // https://docs.stagehand.dev/configuration/logging
-    browserbaseSessionCreateParams: {
-      browserSettings: {
-        solveCaptchas: solveCaptchas,
-      },
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+    browserSettings: {
+      solveCaptchas: solveCaptchas,
     },
   });
+  const stagehand = await Stagehand.create({ browser: browser, logging: { level: "info" } });
 
   try {
     // Initialize browser session to start automation.
-    await stagehand.init();
-    console.log("Stagehand initialized successfully!");
-    console.log(
-      `Live View Link: https://browserbase.com/sessions/${stagehand.browserbaseSessionId}`,
-    );
 
-    const page = stagehand.context.pages()[0];
+    console.log("Stagehand initialized successfully!");
+    const page = (await browser.context.pages())[0];
 
     // Navigate to Google reCAPTCHA demo page to test captcha solving.
     console.log("Navigating to reCAPTCHA demo page...");
@@ -40,16 +31,31 @@ async function main() {
     // Listen for console messages indicating captcha solving progress.
     if (solveCaptchas) {
       console.log("Waiting for captcha to be solved...");
-      await new Promise<void>((resolve) => {
-        page.on("console", (msg) => {
-          if (msg.text() === "browserbase-solving-started") {
-            console.log("Captcha solving in progress...");
-          } else if (msg.text() === "browserbase-solving-finished") {
-            console.log("Captcha solving completed!");
-            resolve();
-          }
-        });
+      let resolveCaptcha!: () => void;
+      const captchaSolved = new Promise<void>((resolve) => {
+        resolveCaptcha = resolve;
       });
+      const subscription = await page.on("console", (event) => {
+        const args = event.params.args;
+        if (!Array.isArray(args)) return;
+        const message = args
+          .map((arg) => {
+            if (typeof arg === "object" && arg !== null && !Array.isArray(arg) && "value" in arg) {
+              return String(arg.value);
+            }
+            return "";
+          })
+          .join(" ");
+
+        if (message === "browserbase-solving-started") {
+          console.log("Captcha solving in progress...");
+        } else if (message === "browserbase-solving-finished") {
+          console.log("Captcha solving completed!");
+          resolveCaptcha();
+        }
+      });
+      await captchaSolved;
+      await subscription.unsubscribe();
     } else {
       console.log("Captcha solving is disabled. Skipping wait...");
     }
@@ -60,7 +66,7 @@ async function main() {
 
     // Extract and display the page content to verify successful submission.
     console.log("Extracting page content...");
-    const text = await stagehand.extract("Extract all the text on this page");
+    const { data: text } = await stagehand.extract("Extract all the text on this page");
     console.log("Page content:");
     console.log(text);
 
@@ -75,6 +81,7 @@ async function main() {
   } finally {
     // Always close session to release resources and clean up.
     await stagehand.close();
+    await browser.close();
     console.log("Session closed successfully");
   }
 }
@@ -85,6 +92,6 @@ main().catch((err) => {
   console.error("  - Check .env file has BROWSERBASE_API_KEY");
   console.error("  - Verify solveCaptchas is enabled in browserSettings");
   console.error("  - Ensure the demo page is accessible");
-  console.error("Docs: https://docs.stagehand.dev/v3/first-steps/introduction");
+  console.error("Docs: https://docs.stagehand.dev/v4/first-steps/introduction");
   process.exit(1);
 });

--- a/typescript/browser-agent-demo/.env.example
+++ b/typescript/browser-agent-demo/.env.example
@@ -1,2 +1,8 @@
-# Your Browserbase API key (Yep that's it)
+# Browserbase browser and Stagehand Model Gateway
 BROWSERBASE_API_KEY=
+
+# Vercel AI Gateway for the outer ToolLoopAgent
+AI_GATEWAY_API_KEY=
+
+# Optional; defaults to anthropic/claude-sonnet-4.6
+AGENT_MODEL=

--- a/typescript/browser-agent-demo/README.md
+++ b/typescript/browser-agent-demo/README.md
@@ -1,11 +1,11 @@
-# Browser Workflow Demo: Search, Fetch & Stagehand V4 on Browserbase
+# Browser Agent Demo: Search, Fetch & Stagehand Code Mode
 
 ## AT A GLANCE
 
 - **Goal**: search the web, fetch page content, and extract structured information — all through one Browserbase API key.
-- **Pattern**: Search → Fetch → Stagehand Extract. Lightweight primitives gather context before opening a browser for model-backed extraction.
-- **Single API key**: the Model Gateway routes LLM requests through Browserbase — no separate OpenAI/Anthropic/Google keys needed.
-- **Full platform demo**: uses Browsers, Search API, Fetch API, Stagehand, and Model Gateway together.
+- **Pattern**: Search → Fetch → Vercel AI SDK agent → Stagehand `code_execute`. Lightweight APIs gather context before the agent opens a browser.
+- **Bring your own agent**: Vercel AI SDK owns reasoning and tool selection; Stagehand code mode owns stateful browser execution.
+- **Full platform demo**: uses Browserbase Search and Fetch APIs, Vercel AI Gateway, and Stagehand code mode together.
   Docs → https://docs.browserbase.com
 
 ## GLOSSARY
@@ -14,12 +14,11 @@
   Docs → https://docs.browserbase.com/features/search
 - **Fetch API**: fetch page content (HTML, status, headers) for token-efficient context — no browser needed.
   Docs → https://docs.browserbase.com/features/fetch
-- **Stagehand**: the SDK for browser agents, with deterministic browser APIs and model-backed act, extract, and observe primitives.
+- **Stagehand**: the SDK for browser agents. Code mode exposes its V4 browser APIs through `code_execute`.
   Docs → https://docs.stagehand.dev
-- **extract()**: model-backed structured data extraction with a Zod V4 schema.
-  Docs → https://docs.stagehand.dev/v4/basics/extract
-- **Model Gateway**: routes LLM requests through Browserbase with unified billing across OpenAI, Anthropic, and Google.
-  Docs → https://docs.browserbase.com/features/model-gateway
+- **ToolLoopAgent**: Vercel AI SDK's multi-step agent loop.
+  Docs → https://ai-sdk.dev/docs/agents/building-agents
+- **code_execute**: the one stateful MCP tool the agent uses for all browser work.
 - **Agent Identity**: built-in credential management and strategic partnerships for accessing any website.
   Docs → https://docs.browserbase.com/features/agent-identity
 
@@ -28,40 +27,44 @@
 1. cd typescript/browser-agent-demo
 2. pnpm install
 3. cp .env.example .env
-4. Add BROWSERBASE_API_KEY to .env (get it from https://browserbase.com/settings)
+4. Add `BROWSERBASE_API_KEY` and `AI_GATEWAY_API_KEY` to `.env`
 5. pnpm start
 
 ## EXPECTED OUTPUT
 
 - Searches the web for "best coffee shops in San Francisco" and displays 5 structured results
 - Selects the top result and fetches its HTML content with status code, content type, and preview
-- Launches a Stagehand V4 browser on Browserbase
-- Navigates to the selected page and extracts the top 3 recommendations
-- Outputs structured findings and closes both lifecycle handles
+- Starts Stagehand code mode over MCP and gives `code_execute` to a Vercel AI SDK agent
+- The agent navigates to the selected page and returns the top 3 recommendations
+- Closes the MCP client, Stagehand, and the Browserbase browser
 
 ## COMMON PITFALLS
 
-- Missing API key: verify .env contains BROWSERBASE_API_KEY — this is the only required credential
-- No separate LLM keys needed: the Model Gateway handles model access through your Browserbase key
+- Missing API key: Browserbase needs `BROWSERBASE_API_KEY`; the outer agent needs `AI_GATEWAY_API_KEY`
+- No provider-specific key needed: Vercel AI Gateway handles the outer model selected by `AGENT_MODEL`
 - Search returns no results: try a different query string — some queries may return empty depending on availability
-- Session not closing: the demo uses `try/finally` to close both Stagehand and the browser handle
+- Session not closing: the demo uses `try/finally` to close the MCP client, which closes Stagehand and the browser
 - Find more information on your Browserbase dashboard -> https://www.browserbase.com/sign-in
 
 ## USE CASES
 
 • Building research agents that search, evaluate, and extract from web pages
 • Token-efficient web browsing pipelines (cheap Search/Fetch before expensive browser sessions)
-• Model-backed data extraction from pages without writing selectors
+• Agent-driven browsing with deterministic APIs and Stagehand AI primitives available inside `code_execute`
 • Prototyping browser agents with the full Browserbase platform
 
 ## NEXT STEPS
 
 • **Customize the query**: change the search query and extraction instruction
-• **Add multi-page navigation**: use browser pages and ordinary application control flow
+• **Add multi-page navigation**: ask the agent to work across pages in the stateful code-mode session
 • **Deploy as a Function**: run the agent on Browserbase infrastructure with <5ms browser latency
 Docs → https://docs.browserbase.com/features/functions
 • **Enable stealth mode**: add `browserSettings: { advancedStealth: true, solveCaptchas: true }` for protected sites
-• **Switch models**: change `model.modelName` in `Stagehand.create()` or omit it for automatic routing
+• **Switch outer models**: set `AGENT_MODEL` to another Vercel AI Gateway model ID
+
+## SAFETY
+
+Code mode executes model-authored JavaScript and is not itself a security sandbox. Isolate it when prompts or pages are untrusted.
 
 ## HELPFUL RESOURCES
 

--- a/typescript/browser-agent-demo/README.md
+++ b/typescript/browser-agent-demo/README.md
@@ -1,9 +1,9 @@
-# Browser Agent Demo: Search, Fetch & Stagehand Agent on Browserbase
+# Browser Workflow Demo: Search, Fetch & Stagehand V4 on Browserbase
 
 ## AT A GLANCE
 
-- **Goal**: build a browser agent that searches the web, fetches page content, and autonomously extracts information — all through one Browserbase API key.
-- **Pattern**: Search → Fetch → Stagehand Agent. Lightweight primitives (Search, Fetch) gather context cheaply before spinning up a full browser agent for interaction.
+- **Goal**: search the web, fetch page content, and extract structured information — all through one Browserbase API key.
+- **Pattern**: Search → Fetch → Stagehand Extract. Lightweight primitives gather context before opening a browser for model-backed extraction.
 - **Single API key**: the Model Gateway routes LLM requests through Browserbase — no separate OpenAI/Anthropic/Google keys needed.
 - **Full platform demo**: uses Browsers, Search API, Fetch API, Stagehand, and Model Gateway together.
   Docs → https://docs.browserbase.com
@@ -14,10 +14,10 @@
   Docs → https://docs.browserbase.com/features/search
 - **Fetch API**: fetch page content (HTML, status, headers) for token-efficient context — no browser needed.
   Docs → https://docs.browserbase.com/features/fetch
-- **Stagehand**: the AI SDK for browser agents — act, extract, observe, and agent primitives.
+- **Stagehand**: the SDK for browser agents, with deterministic browser APIs and model-backed act, extract, and observe primitives.
   Docs → https://docs.stagehand.dev
-- **agent()**: Stagehand primitive that gives a model full control of a headless browser via natural-language instructions.
-  Docs → https://docs.stagehand.dev/v3/basics/agent
+- **extract()**: model-backed structured data extraction with a Zod V4 schema.
+  Docs → https://docs.stagehand.dev/v4/basics/extract
 - **Model Gateway**: routes LLM requests through Browserbase with unified billing across OpenAI, Anthropic, and Google.
   Docs → https://docs.browserbase.com/features/model-gateway
 - **Agent Identity**: built-in credential management and strategic partnerships for accessing any website.
@@ -35,34 +35,33 @@
 
 - Searches the web for "best coffee shops in San Francisco" and displays 5 structured results
 - Selects the top result and fetches its HTML content with status code, content type, and preview
-- Launches a Stagehand browser agent on Browserbase and prints the session replay URL
-- Navigates to the selected page and autonomously extracts the top 3 recommendations
-- Outputs the agent's structured findings and closes the session
+- Launches a Stagehand V4 browser on Browserbase
+- Navigates to the selected page and extracts the top 3 recommendations
+- Outputs structured findings and closes both lifecycle handles
 
 ## COMMON PITFALLS
 
 - Missing API key: verify .env contains BROWSERBASE_API_KEY — this is the only required credential
 - No separate LLM keys needed: the Model Gateway handles model access through your Browserbase key
 - Search returns no results: try a different query string — some queries may return empty depending on availability
-- Agent timeout: increase `maxSteps` if the page is complex and the agent needs more interactions
-- Session not closing: the demo uses `try/finally` to ensure `stagehand.close()` runs — always clean up sessions
+- Session not closing: the demo uses `try/finally` to close both Stagehand and the browser handle
 - Find more information on your Browserbase dashboard -> https://www.browserbase.com/sign-in
 
 ## USE CASES
 
 • Building research agents that search, evaluate, and extract from web pages
 • Token-efficient web browsing pipelines (cheap Search/Fetch before expensive browser sessions)
-• Autonomous data extraction from any website without writing selectors
+• Model-backed data extraction from pages without writing selectors
 • Prototyping browser agents with the full Browserbase platform
 
 ## NEXT STEPS
 
-• **Customize the query**: change the search query and agent instructions to extract different types of information
-• **Add multi-page navigation**: chain multiple `agent.execute()` calls to browse across several pages
+• **Customize the query**: change the search query and extraction instruction
+• **Add multi-page navigation**: use browser pages and ordinary application control flow
 • **Deploy as a Function**: run the agent on Browserbase infrastructure with <5ms browser latency
 Docs → https://docs.browserbase.com/features/functions
 • **Enable stealth mode**: add `browserSettings: { advancedStealth: true, solveCaptchas: true }` for protected sites
-• **Switch models**: change `model` in the Stagehand constructor to use OpenAI or Google models via the Model Gateway
+• **Switch models**: change `model.modelName` in `Stagehand.create()` or omit it for automatic routing
 
 ## HELPFUL RESOURCES
 

--- a/typescript/browser-agent-demo/index.ts
+++ b/typescript/browser-agent-demo/index.ts
@@ -4,6 +4,10 @@ import { Experimental_StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
 import { ToolLoopAgent, stepCountIs } from "ai";
 import "dotenv/config";
 
+const childEnv = Object.fromEntries(
+  Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+);
+
 async function main() {
   const apiKey = process.env.BROWSERBASE_API_KEY!;
 
@@ -87,6 +91,7 @@ async function main() {
   const mcpClient = await createMCPClient({
     transport: new Experimental_StdioMCPTransport({
       command: "stagehand-codemode",
+      env: childEnv,
       stderr: "inherit",
     }),
   });

--- a/typescript/browser-agent-demo/index.ts
+++ b/typescript/browser-agent-demo/index.ts
@@ -1,6 +1,7 @@
 import { Browserbase } from "@browserbasehq/sdk";
-import { Stagehand } from "@browserbasehq/stagehand";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 import "dotenv/config";
+import { z } from "zod/v4";
 
 async function main() {
   const apiKey = process.env.BROWSERBASE_API_KEY!;
@@ -61,9 +62,13 @@ async function main() {
 
   console.log(`   Status:         ${fetchResult.statusCode}`);
   console.log(`   Content-Type:   ${fetchResult.contentType}`);
-  console.log(`   Content length: ${fetchResult.content.length} chars`);
+  const fetchedContent =
+    typeof fetchResult.content === "string"
+      ? fetchResult.content
+      : JSON.stringify(fetchResult.content);
+  console.log(`   Content length: ${fetchedContent.length} chars`);
 
-  const textPreview = fetchResult.content
+  const textPreview = fetchedContent
     .replace(/<[^>]+>/g, " ")
     .replace(/\s+/g, " ")
     .trim()
@@ -71,57 +76,52 @@ async function main() {
   console.log(`   Preview:        ${textPreview}...`);
   console.log();
 
-  // ─── STEP 3: STAGEHAND AGENT ────────────────────────────────────────────────
-  // Stagehand is the AI SDK for browser agents — act, extract, observe, and agent
-  // primitives that let agents browse and interact with the web like humans.
-  // Docs: https://docs.stagehand.dev | Agent: https://docs.stagehand.dev/v3/basics/agent
+  // ─── STEP 3: STAGEHAND V4 ───────────────────────────────────────────────────
+  // V4 exposes explicit browser APIs plus act, extract, and observe primitives.
+  // Docs: https://docs.stagehand.dev/v4/first-steps/introduction
 
-  console.log(`STEP 3: STAGEHAND AGENT`);
+  console.log(`STEP 3: STAGEHAND V4`);
   console.log(`   Launching browser...\n`);
 
   // env: "BROWSERBASE" runs on Browserbase's headless browser infrastructure with
   // session replay, Agent Identity, and proxies built in.
   // The Model Gateway routes LLM requests through Browserbase — one API key gives
   // access to models from OpenAI, Anthropic, and Google with unified billing.
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    model: "anthropic/claude-sonnet-4-6",
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+  });
+  const stagehand = await Stagehand.create({
+    browser: browser,
+    model: { modelName: "anthropic/claude-sonnet-4-6" },
   });
 
-  await stagehand.init();
-
   try {
-    console.log(`   Session:  https://browserbase.com/sessions/${stagehand.browserbaseSessionID}`);
     console.log(`   Navigating to: ${targetUrl}`);
 
-    const page = stagehand.context.pages()[0]!;
+    const page = (await browser.context.pages())[0]!;
     await page.goto(targetUrl);
 
-    console.log(`   Starting autonomous agent...\n`);
+    const { data: research } = await stagehand.extract(
+      `Extract the top 3 recommendations or key points from this page about "${targetTitle}". ` +
+        "For each, include the name and a one-sentence summary of why it is notable.",
+      z.object({
+        recommendations: z.array(
+          z.object({
+            name: z.string(),
+            summary: z.string(),
+          }),
+        ),
+      }),
+    );
 
-    // stagehand.agent() creates a browser agent that can autonomously navigate, click,
-    // type, scroll, and extract data — driven by a natural-language instruction.
-    const agent = stagehand.agent({
-      systemPrompt:
-        "You are a helpful research assistant browsing the web. " +
-        "Extract factual information from pages. Be concise and structured.",
-    });
-
-    const agentResult = await agent.execute({
-      instruction:
-        `You're on a page about "${targetTitle}". ` +
-        `Extract the top 3 recommendations or key points from this page. ` +
-        `For each, include the name and a one-sentence summary of why it's notable.`,
-      maxSteps: 10,
-    });
-
-    console.log(`\n   ── Agent Result ──`);
-    console.log(agentResult);
+    console.log(`\n   ── Stagehand Result ──`);
+    console.log(research.recommendations);
   } finally {
     await stagehand.close();
+    await browser.close();
   }
 
-  console.log(`\nDone! Watch the session replay at the URL above to see what the agent did.`);
+  console.log(`\nDone!`);
 }
 
 main().catch((err) => {

--- a/typescript/browser-agent-demo/index.ts
+++ b/typescript/browser-agent-demo/index.ts
@@ -1,7 +1,8 @@
 import { Browserbase } from "@browserbasehq/sdk";
-import { browserbase, Stagehand } from "@browserbasehq/stagehand";
+import { createMCPClient } from "@ai-sdk/mcp";
+import { Experimental_StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
+import { ToolLoopAgent, stepCountIs } from "ai";
 import "dotenv/config";
-import { z } from "zod/v4";
 
 async function main() {
   const apiKey = process.env.BROWSERBASE_API_KEY!;
@@ -76,49 +77,42 @@ async function main() {
   console.log(`   Preview:        ${textPreview}...`);
   console.log();
 
-  // ─── STEP 3: STAGEHAND V4 ───────────────────────────────────────────────────
-  // V4 exposes explicit browser APIs plus act, extract, and observe primitives.
-  // Docs: https://docs.stagehand.dev/v4/first-steps/introduction
+  // ─── STEP 3: BRING-YOUR-OWN AGENT + STAGEHAND CODE MODE ─────────────────────
+  // V4 exposes browser-agent capabilities through the packaged code_execute MCP tool.
+  // The Vercel AI SDK owns the agent loop; Stagehand owns browser execution.
 
-  console.log(`STEP 3: STAGEHAND V4`);
-  console.log(`   Launching browser...\n`);
+  console.log(`STEP 3: VERCEL AI SDK + STAGEHAND CODE MODE`);
+  console.log(`   Starting code-mode MCP...\n`);
 
-  // env: "BROWSERBASE" runs on Browserbase's headless browser infrastructure with
-  // session replay, Agent Identity, and proxies built in.
-  // The Model Gateway routes LLM requests through Browserbase — one API key gives
-  // access to models from OpenAI, Anthropic, and Google with unified billing.
-  const browser = await browserbase.launch({
-    apiKey: process.env.BROWSERBASE_API_KEY!,
-  });
-  const stagehand = await Stagehand.create({
-    browser: browser,
-    model: { modelName: "anthropic/claude-sonnet-4-6" },
+  const mcpClient = await createMCPClient({
+    transport: new Experimental_StdioMCPTransport({
+      command: "stagehand-codemode",
+      stderr: "inherit",
+    }),
   });
 
   try {
-    console.log(`   Navigating to: ${targetUrl}`);
+    const tools = await mcpClient.tools();
+    if (!tools.code_execute) throw new Error("Stagehand code mode did not expose code_execute");
 
-    const page = (await browser.context.pages())[0]!;
-    await page.goto(targetUrl);
+    const agent = new ToolLoopAgent({
+      model: process.env.AGENT_MODEL ?? "anthropic/claude-sonnet-4.6",
+      instructions:
+        "You are a browser research agent. Use code_execute for all browser work. Prefer deterministic page and locator APIs; use Stagehand AI primitives inside code_execute when semantic extraction is useful. Return concise factual findings.",
+      tools,
+      stopWhen: stepCountIs(15),
+    });
 
-    const { data: research } = await stagehand.extract(
-      `Extract the top 3 recommendations or key points from this page about "${targetTitle}". ` +
-        "For each, include the name and a one-sentence summary of why it is notable.",
-      z.object({
-        recommendations: z.array(
-          z.object({
-            name: z.string(),
-            summary: z.string(),
-          }),
-        ),
-      }),
-    );
+    const result = await agent.generate({
+      prompt:
+        `Navigate to ${targetUrl}, which was selected for ${JSON.stringify(targetTitle)}. ` +
+        "Return the top 3 recommendations or key points, each with a name and a one-sentence explanation of why it is notable.",
+    });
 
-    console.log(`\n   ── Stagehand Result ──`);
-    console.log(research.recommendations);
+    console.log(`\n   ── Agent Result ──`);
+    console.log(result.text);
   } finally {
-    await stagehand.close();
-    await browser.close();
+    await mcpClient.close();
   }
 
   console.log(`\nDone!`);

--- a/typescript/browser-agent-demo/package.json
+++ b/typescript/browser-agent-demo/package.json
@@ -9,16 +9,21 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "packageManager": "pnpm@9.15.0",
+  "packageManager": "pnpm@10.24.0",
   "type": "module",
   "dependencies": {
     "@browserbasehq/sdk": "^2.9.0",
-    "@browserbasehq/stagehand": "^3.2.0",
-    "dotenv": "^17.4.0"
+    "@browserbasehq/stagehand": "github:browserbase/stagehand#089f2aaeaea75696685949e0835aece95db54358&path:/packages/sdk-ts",
+    "dotenv": "^17.4.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
     "tsx": "^4.19.0",
     "typescript": "^5.8.2"
+  },
+  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand@4.0.0 after it is published.",
+  "engines": {
+    "node": ">=22.18.0"
   }
 }

--- a/typescript/browser-agent-demo/package.json
+++ b/typescript/browser-agent-demo/package.json
@@ -12,17 +12,18 @@
   "packageManager": "pnpm@10.24.0",
   "type": "module",
   "dependencies": {
+    "@ai-sdk/mcp": "^2.0.29",
     "@browserbasehq/sdk": "^2.9.0",
-    "@browserbasehq/stagehand": "github:browserbase/stagehand#089f2aaeaea75696685949e0835aece95db54358&path:/packages/sdk-ts",
-    "dotenv": "^17.4.0",
-    "zod": "^4.4.3"
+    "@browserbasehq/stagehand-codemode": "github:browserbase/stagehand#54302fc5f13be5ad8e717d8e1388502de22be2ed&path:/packages/integrations",
+    "ai": "^7.0.58",
+    "dotenv": "^17.4.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
     "tsx": "^4.19.0",
     "typescript": "^5.8.2"
   },
-  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand@4.0.0 after it is published.",
+  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand-codemode@4.0.0 after it is published.",
   "engines": {
     "node": ">=22.18.0"
   }

--- a/typescript/browserbase-reducto/README.md
+++ b/typescript/browserbase-reducto/README.md
@@ -4,15 +4,15 @@
 
 - **Goal**: Automate downloading financial PDFs from websites and extract structured data using AI-powered document parsing.
 - **Pattern Template**: Demonstrates the integration pattern of Browserbase (download automation) + Reducto (document extraction).
-- **Workflow**: Uses Stagehand to navigate websites, Browserbase automatically downloads PDFs when opened, then Reducto extracts structured financial data using schema-based extraction.
+- **Workflow**: Uses Stagehand V4 page APIs to find Apple's FY2025 Q4 statement, Browserbase captures the PDF when opened, then Reducto extracts structured financial data with a schema.
 - **Download Handling**: Implements retry logic with polling to handle Browserbase's async download sync (files sync to cloud storage in real-time).
 - **Structured Extraction**: Uses Reducto's extract API with JSON schema to pull specific financial metrics from complex PDF tables.
 - Docs → [Browserbase Downloads](https://docs.browserbase.com/features/downloads) | [Reducto Extract](https://docs.reducto.ai/parse/best-practices)
 
 ## GLOSSARY
 
-- **act**: perform UI actions from natural language prompts (click, scroll, navigate)
-  Docs → https://docs.stagehand.dev/basics/act
+- **page APIs**: use the V4 browser context and page directly for known navigation and link discovery
+  Docs → https://docs.stagehand.dev/v4/reference/page
 - **Browserbase Downloads**: When a PDF URL is opened in a browser session, Browserbase automatically downloads and stores it in cloud storage. Files must be retrieved via the Session Downloads API as a ZIP archive.
   Docs → https://docs.browserbase.com/features/downloads
 - **Reducto Extract**: Extract structured data from PDFs using JSON schema definitions. More efficient than parsing entire documents when you only need specific fields.
@@ -22,7 +22,7 @@
 
 ## QUICKSTART
 
-1. cd reducto-browserbase
+1. cd browserbase-reducto
 2. pnpm install
 3. cp .env.example .env
 4. Add required API keys to .env:
@@ -32,9 +32,9 @@
 
 ## EXPECTED OUTPUT
 
-- Initializes Stagehand session with Browserbase and displays live view link
-- Navigates to Apple.com investor relations section
-- Clicks through to Q4 financial statements
+- Initializes Stagehand V4 with a Browserbase browser; Live View remains available in the Sessions dashboard
+- Navigates directly to Apple Investor Relations and validates the FY2025 Q4 PDF URL
+- Opens the statement to trigger Browserbase PDF capture
 - Browserbase automatically downloads PDF when link is opened
 - Polls Browserbase Downloads API until file is ready (with retry logic)
 - Extracts PDF from ZIP archive downloaded from Browserbase

--- a/typescript/browserbase-reducto/README.md
+++ b/typescript/browserbase-reducto/README.md
@@ -52,7 +52,7 @@ Docs → https://docs.reducto.ai/parse/best-practices#2-enable-agentic-mode-only
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
 📚 Browserbase Downloads: https://docs.browserbase.com/features/downloads
 📚 Reducto Best Practices: https://docs.reducto.ai/parse/best-practices
 🎮 Browserbase: https://www.browserbase.com

--- a/typescript/browserbase-reducto/index.ts
+++ b/typescript/browserbase-reducto/index.ts
@@ -6,12 +6,6 @@ import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 import fs from "fs";
 import path from "path";
 import reductoai from "reductoai";
-
-async function uploadStagehandExtension(bb: Browserbase): Promise<{ id: string }> {
-  const stagehandEntry = import.meta.resolve("@browserbasehq/stagehand");
-  const archive = new URL("./assets/stagehand-extension.zip", stagehandEntry);
-  return bb.extensions.create({ file: fs.createReadStream(archive) });
-}
 import AdmZip from "adm-zip";
 
 // Net sales data structure extracted from financial statements
@@ -133,9 +127,13 @@ function extractPdfFromZip(zipPath: string, outputDir: string = "downloaded_file
 
   // Open zip file and filter for PDF entries only
   const zip = new AdmZip(zipPath);
-  const pdfEntries = zip
-    .getEntries()
-    .filter((entry: AdmZip.IZipEntry) => entry.entryName.toLowerCase().endsWith(".pdf"));
+  const pdfEntries = zip.getEntries().filter((entry: AdmZip.IZipEntry) => {
+    if (entry.isDirectory) return false;
+    return (
+      entry.entryName.toLowerCase().endsWith(".pdf") ||
+      entry.getData().subarray(0, 5).toString() === "%PDF-"
+    );
+  });
 
   if (pdfEntries.length === 0) {
     throw new Error("No PDF files found in the downloaded zip");
@@ -144,8 +142,11 @@ function extractPdfFromZip(zipPath: string, outputDir: string = "downloaded_file
   // Extract all PDF files and return path to first one
   let pdfPath: string | null = null;
   for (const entry of pdfEntries) {
-    const outputPath = path.join(outputDir, entry.entryName);
-    zip.extractEntryTo(entry, outputDir, false, true);
+    const outputName = entry.entryName.toLowerCase().endsWith(".pdf")
+      ? entry.entryName
+      : `${entry.entryName}.pdf`;
+    const outputPath = path.join(outputDir, outputName);
+    fs.writeFileSync(outputPath, entry.getData());
     console.log(`Extracted: ${outputPath}`);
 
     if (!pdfPath) {
@@ -235,6 +236,18 @@ async function extractPDFWithReducto(pdfPath: string, reductoaiClient: reductoai
   // Display extracted financial data in formatted JSON
   console.log("\n=== Extracted Financial Data ===\n");
   const extractedData = result?.result || result?.data;
+  const netSales = extractedData?.iphone_net_sales;
+  if (
+    !netSales ||
+    ![
+      netSales.current_quarter,
+      netSales.previous_quarter,
+      netSales.current_year,
+      netSales.previous_year,
+    ].every(Number.isFinite)
+  ) {
+    throw new Error("Reducto did not return all four iPhone net-sales values");
+  }
   console.log(JSON.stringify(extractedData, null, 2));
 }
 
@@ -246,8 +259,7 @@ async function main(): Promise<void> {
     apiKey: process.env.BROWSERBASE_API_KEY as string,
   });
 
-  const extension = await uploadStagehandExtension(bb);
-  const session = await bb.sessions.create({ extensionId: extension.id });
+  if (!process.env.REDUCTOAI_API_KEY) throw new Error("REDUCTOAI_API_KEY is required");
 
   // Initialize Reducto AI client for PDF data extraction
   const reductoaiClient = new reductoai({
@@ -255,11 +267,11 @@ async function main(): Promise<void> {
   });
 
   // Initialize Stagehand with Browserbase for cloud-based browser automation
-  const browser = await browserbase.connect({
+  const browser = await browserbase.launch({
     apiKey: process.env.BROWSERBASE_API_KEY!,
-    sessionId: session.id,
-    extensionId: extension.id,
   });
+  const sessionId = browser.sessionId;
+  if (!sessionId) throw new Error("Browserbase launch did not return a session ID");
   const stagehand = await Stagehand.create({
     browser: browser,
     model: { modelName: "google/gemini-2.5-pro" },
@@ -272,32 +284,45 @@ async function main(): Promise<void> {
     console.log("Stagehand initialized successfully!");
     const page = (await browser.context.pages())[0];
 
-    // Get live view URL for monitoring browser session in real-time
-    const liveViewLinks = await bb.sessions.debug(session.id);
-    console.log(`Live View Link: ${liveViewLinks.debuggerFullscreenUrl}`);
+    console.log("Live View is available in the Browserbase Sessions dashboard");
 
-    // Navigate to Apple homepage.
-    console.log("Navigating to Apple.com...");
-    await page.goto("https://www.apple.com/");
-
-    // Navigate to investor relations section using Stagehand
-    console.log("Navigating to Investors section...");
-    await stagehand.act("Click the 'Investors' button at the bottom of the page'");
-    await stagehand.act("Scroll down to the Financial Data section of the page");
-    await stagehand.act("Under Quarterly Earnings Reports, click on '2025'");
-
-    // Download Q4 quarterly financial statement
-    // When a URL of a PDF is opened, Browserbase automatically downloads and stores the PDF
-    // See https://docs.browserbase.com/features/downloads for more info
-    console.log("Downloading Q4 financial statement...");
-    await stagehand.act("Click the 'Financial Statements' link under Q4");
+    console.log("Navigating to Apple Investor Relations...");
+    await page.goto("https://investor.apple.com/investor-relations/default.aspx", {
+      waitUntil: "domcontentloaded",
+      timeout: 60000,
+    });
+    const statementUrl = await page.evaluate(
+      () =>
+        Array.from(document.querySelectorAll<HTMLAnchorElement>("a")).find(
+          (link) =>
+            link.textContent?.trim() === "Financial Statements" && /fy2025-q4/i.test(link.href),
+        )?.href ?? "",
+    );
+    if (!statementUrl) throw new Error("Could not find Apple's FY2025 Q4 statement");
+    const statementResponse = await fetch(statementUrl, { method: "HEAD" });
+    if (
+      !statementResponse.ok ||
+      !statementResponse.headers.get("content-type")?.includes("application/pdf")
+    ) {
+      throw new Error("Apple's FY2025 Q4 statement URL did not return a PDF");
+    }
+    await page.evaluate((url: string) => {
+      const link = document.createElement("a");
+      link.href = url;
+      link.target = "_blank";
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+    }, statementUrl);
+    console.log("Triggered FY2025 Q4 financial statement download");
 
     // Retrieve all downloads triggered during this session from Browserbase API
     console.log("Retrieving downloads from Browserbase...");
-    const { promise: downloadPromise, stopPolling } = saveDownloadsWithRetry(bb, session.id, 45);
+    const { promise: downloadPromise, stopPolling } = saveDownloadsWithRetry(bb, sessionId, 45);
 
     try {
-      await downloadPromise;
+      const downloadSize = await downloadPromise;
+      if (downloadSize <= 0) throw new Error("Browserbase returned no downloaded statement");
       console.log("Download completed successfully!");
       stopPolling();
 
@@ -315,10 +340,8 @@ async function main(): Promise<void> {
     console.error("Error during automation:", error);
     throw error;
   } finally {
-    // Always close the session and remove the temporary Stagehand extension.
-    await stagehand.close();
-    await browser.close();
-    await bb.extensions.delete(extension.id, { headers: { "Content-Type": null } });
+    await stagehand.close().catch((error) => console.warn("Stagehand cleanup warning:", error));
+    await browser.close().catch((error) => console.warn("Browser cleanup warning:", error));
     console.log("Session closed successfully");
   }
 }

--- a/typescript/browserbase-reducto/index.ts
+++ b/typescript/browserbase-reducto/index.ts
@@ -2,10 +2,16 @@
 
 import "dotenv/config";
 import { Browserbase } from "@browserbasehq/sdk";
-import { Stagehand } from "@browserbasehq/stagehand";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 import fs from "fs";
 import path from "path";
 import reductoai from "reductoai";
+
+async function uploadStagehandExtension(bb: Browserbase): Promise<{ id: string }> {
+  const stagehandEntry = import.meta.resolve("@browserbasehq/stagehand");
+  const archive = new URL("./assets/stagehand-extension.zip", stagehandEntry);
+  return bb.extensions.create({ file: fs.createReadStream(archive) });
+}
 import AdmZip from "adm-zip";
 
 // Net sales data structure extracted from financial statements
@@ -240,28 +246,34 @@ async function main(): Promise<void> {
     apiKey: process.env.BROWSERBASE_API_KEY as string,
   });
 
+  const extension = await uploadStagehandExtension(bb);
+  const session = await bb.sessions.create({ extensionId: extension.id });
+
   // Initialize Reducto AI client for PDF data extraction
   const reductoaiClient = new reductoai({
     apiKey: process.env.REDUCTOAI_API_KEY,
   });
 
   // Initialize Stagehand with Browserbase for cloud-based browser automation
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 0,
-    // 0 = errors only, 1 = info, 2 = debug
-    // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
-    model: "google/gemini-2.5-pro",
+  const browser = await browserbase.connect({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+    sessionId: session.id,
+    extensionId: extension.id,
+  });
+  const stagehand = await Stagehand.create({
+    browser: browser,
+    model: { modelName: "google/gemini-2.5-pro" },
+    logging: { level: "error" },
   });
 
   try {
     // Initialize browser session to start automation
-    await stagehand.init();
+
     console.log("Stagehand initialized successfully!");
-    const page = stagehand.context.pages()[0];
+    const page = (await browser.context.pages())[0];
 
     // Get live view URL for monitoring browser session in real-time
-    const liveViewLinks = await bb.sessions.debug(stagehand.browserbaseSessionId!);
+    const liveViewLinks = await bb.sessions.debug(session.id);
     console.log(`Live View Link: ${liveViewLinks.debuggerFullscreenUrl}`);
 
     // Navigate to Apple homepage.
@@ -282,11 +294,7 @@ async function main(): Promise<void> {
 
     // Retrieve all downloads triggered during this session from Browserbase API
     console.log("Retrieving downloads from Browserbase...");
-    const { promise: downloadPromise, stopPolling } = saveDownloadsWithRetry(
-      bb,
-      stagehand.browserbaseSessionId!,
-      45,
-    );
+    const { promise: downloadPromise, stopPolling } = saveDownloadsWithRetry(bb, session.id, 45);
 
     try {
       await downloadPromise;
@@ -302,25 +310,25 @@ async function main(): Promise<void> {
     } catch (error) {
       stopPolling();
       throw error;
-    } finally {
-      // Always close session to release resources and clean up
-      await stagehand.close();
-      console.log("Session closed successfully");
     }
   } catch (error) {
     console.error("Error during automation:", error);
     throw error;
+  } finally {
+    // Always close the session and remove the temporary Stagehand extension.
+    await stagehand.close();
+    await browser.close();
+    await bb.extensions.delete(extension.id, { headers: { "Content-Type": null } });
+    console.log("Session closed successfully");
   }
 }
 
 main().catch((err) => {
   console.error("Application error:", err);
   console.error("Common issues:");
-  console.error(
-    "  - Check .env file has BROWSERBASE_API_KEY and REDUCTOAI_API_KEY",
-  );
+  console.error("  - Check .env file has BROWSERBASE_API_KEY and REDUCTOAI_API_KEY");
   console.error("  - Verify internet connection and Apple website accessibility");
   console.error("  - Ensure sufficient timeout for slow-loading pages");
-  console.error("Docs: https://docs.stagehand.dev/v3/first-steps/introduction");
+  console.error("Docs: https://docs.stagehand.dev/v4/first-steps/introduction");
   process.exit(1);
 });

--- a/typescript/browserbase-reducto/package.json
+++ b/typescript/browserbase-reducto/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@browserbasehq/sdk": "^2.9.0",
-    "@browserbasehq/stagehand": "github:browserbase/stagehand#089f2aaeaea75696685949e0835aece95db54358&path:/packages/sdk-ts",
+    "@browserbasehq/stagehand": "github:browserbase/stagehand#4186c7d98d2f325b6fc85b3f760111e6c390d703&path:/packages/sdk-ts",
     "adm-zip": "latest",
     "dotenv": "latest",
     "reductoai": "latest"

--- a/typescript/browserbase-reducto/package.json
+++ b/typescript/browserbase-reducto/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@browserbasehq/sdk": "^2.9.0",
-    "@browserbasehq/stagehand": "github:browserbase/stagehand#4186c7d98d2f325b6fc85b3f760111e6c390d703&path:/packages/sdk-ts",
+    "@browserbasehq/stagehand": "4.0.0",
     "adm-zip": "latest",
     "dotenv": "latest",
     "reductoai": "latest"
@@ -20,7 +20,6 @@
     "typescript": "latest"
   },
   "packageManager": "pnpm@10.24.0",
-  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand@4.0.0 after it is published.",
   "engines": {
     "node": ">=22.18.0"
   }

--- a/typescript/browserbase-reducto/package.json
+++ b/typescript/browserbase-reducto/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@browserbasehq/sdk": "^2.9.0",
-    "@browserbasehq/stagehand": "latest",
+    "@browserbasehq/stagehand": "github:browserbase/stagehand#089f2aaeaea75696685949e0835aece95db54358&path:/packages/sdk-ts",
     "adm-zip": "latest",
     "dotenv": "latest",
     "reductoai": "latest"
@@ -19,5 +19,9 @@
     "tsx": "latest",
     "typescript": "latest"
   },
-  "packageManager": "pnpm@9.0.0"
+  "packageManager": "pnpm@10.24.0",
+  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand@4.0.0 after it is published.",
+  "engines": {
+    "node": ">=22.18.0"
+  }
 }

--- a/typescript/business-lookup/README.md
+++ b/typescript/business-lookup/README.md
@@ -1,59 +1,34 @@
-# Stagehand V4 + Browserbase: Business Lookup
+# Stagehand Code Mode + Vercel AI SDK: Business Lookup
 
 ## AT A GLANCE
 
-- Goal: automate business registry searches with explicit Stagehand V4 actions.
-- Uses individual `act()` calls to apply filters and open details, then `extract()` for structured data.
-- Demonstrates extraction with Zod schema validation for consistent data retrieval.
-- Docs → https://docs.stagehand.dev/v4/basics/act
-
-## GLOSSARY
-
-- act: perform one model-backed action from a natural-language instruction
-  Docs → https://docs.stagehand.dev/v4/basics/act
-- extract: extract structured data from web pages using natural language instructions
-  Docs → https://docs.stagehand.dev/basics/extract
+- Goal: give an external agent a Browserbase browser and have it research one SF business record.
+- Agent framework: Vercel AI SDK `ToolLoopAgent` owns the reasoning loop.
+- Browser tool: Stagehand code mode exposes one stateful MCP tool, `code_execute`.
+- Stagehand is the SDK for browser agents.
 
 ## QUICKSTART
 
-1. pnpm install
-2. cp .env.example .env
-3. Add required API keys/IDs to .env
-4. pnpm start
+1. `cd business-lookup`
+2. `pnpm install`
+3. Add `BROWSERBASE_API_KEY` and `AI_GATEWAY_API_KEY` to `.env`
+4. `pnpm start`
+
+Set `AGENT_MODEL` to override the default `anthropic/claude-sonnet-4.6` outer-agent model.
 
 ## EXPECTED OUTPUT
 
-- Initializes Stagehand session with Browserbase
-- Navigates to SF Business Registry search page
-- Explicit actions search by DBA Name and open business details
-- Extracts structured business information (DBA Name, Account Number, NAICS Code, etc.)
-- Outputs extracted data as JSON
-- Closes session cleanly
+- The AI SDK starts the packaged Stagehand code-mode MCP over stdio.
+- The agent uses `code_execute` to search the SF business registry.
+- The final result is validated against a Zod schema and printed as JSON.
+- Closing the MCP client closes Stagehand and the Browserbase browser.
 
-## COMMON PITFALLS
+## SAFETY
 
-- Dependency install errors: ensure npm install completed
-- Missing credentials: verify `.env` contains `BROWSERBASE_API_KEY`
-- Action failures: check that the business exists and make the failing instruction more specific
-- Find more information on your Browserbase dashboard -> https://www.browserbase.com/sign-in
+Code mode executes model-authored JavaScript and is not itself a security sandbox. Run it inside an isolation boundary when prompts or pages are untrusted.
 
-## USE CASES
+## RESOURCES
 
-• Business verification: Automate registration status checks, license validation, and compliance verification for multiple businesses.
-• Data enrichment: Collect structured business metadata (NAICS codes, addresses, ownership) for research or CRM updates.
-• Due diligence: Streamline background checks by autonomously searching and extracting business registration details from public registries.
-
-## NEXT STEPS
-
-• Parameterize search: Accept business names as command-line arguments or from a CSV file for batch processing.
-• Expand extraction: Add support for additional fields like tax status, licenses, or historical registration changes.
-• Multi-registry support: Extend agent to search across multiple city or state business registries with routing logic.
-
-## HELPFUL RESOURCES
-
-📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
-🎮 Browserbase: https://www.browserbase.com
-💡 Try it out: https://www.browserbase.com/playground
-🔧 Templates: https://www.browserbase.com/templates
-📧 Need help? support@browserbase.com
-💬 Discord: http://stagehand.dev/discord
+- Stagehand: https://docs.stagehand.dev
+- Vercel AI SDK agents: https://ai-sdk.dev/docs/agents/building-agents
+- Vercel AI SDK MCP tools: https://ai-sdk.dev/docs/ai-sdk-core/mcp-tools

--- a/typescript/business-lookup/README.md
+++ b/typescript/business-lookup/README.md
@@ -1,33 +1,31 @@
-# Stagehand + Browserbase: Business Lookup with Agent
+# Stagehand V4 + Browserbase: Business Lookup
 
 ## AT A GLANCE
 
-- Goal: Automate business registry searches using an autonomous AI agent with computer-use capabilities.
-- Uses Stagehand Agent in CUA mode to navigate complex UI elements, apply filters, and extract structured business data.
+- Goal: automate business registry searches with explicit Stagehand V4 actions.
+- Uses individual `act()` calls to apply filters and open details, then `extract()` for structured data.
 - Demonstrates extraction with Zod schema validation for consistent data retrieval.
-- Docs → https://docs.stagehand.dev/basics/agent
+- Docs → https://docs.stagehand.dev/v4/basics/act
 
 ## GLOSSARY
 
-- agent: create an autonomous AI agent that can execute complex multi-step tasks
-  Docs → https://docs.stagehand.dev/basics/agent#what-is-agent
+- act: perform one model-backed action from a natural-language instruction
+  Docs → https://docs.stagehand.dev/v4/basics/act
 - extract: extract structured data from web pages using natural language instructions
   Docs → https://docs.stagehand.dev/basics/extract
 
 ## QUICKSTART
 
-1. npm install
+1. pnpm install
 2. cp .env.example .env
 3. Add required API keys/IDs to .env
-4. npm start
+4. pnpm start
 
 ## EXPECTED OUTPUT
 
 - Initializes Stagehand session with Browserbase
-- Displays live session link for monitoring
 - Navigates to SF Business Registry search page
-- Agent searches for business using DBA Name filter
-- Agent completes search and opens business details
+- Explicit actions search by DBA Name and open business details
 - Extracts structured business information (DBA Name, Account Number, NAICS Code, etc.)
 - Outputs extracted data as JSON
 - Closes session cleanly
@@ -35,9 +33,8 @@
 ## COMMON PITFALLS
 
 - Dependency install errors: ensure npm install completed
-- Missing credentials: verify .env contains BROWSERBASE_API_KEY and GOOGLE_API_KEY
-- Google API access: ensure you have access to Google's gemini-2.5-computer-use-preview-10-2025 model
-- Agent failures: check that the business name exists in the registry and that maxSteps is sufficient for complex searches
+- Missing credentials: verify `.env` contains `BROWSERBASE_API_KEY`
+- Action failures: check that the business exists and make the failing instruction more specific
 - Find more information on your Browserbase dashboard -> https://www.browserbase.com/sign-in
 
 ## USE CASES
@@ -54,7 +51,7 @@
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground
 🔧 Templates: https://www.browserbase.com/templates

--- a/typescript/business-lookup/index.ts
+++ b/typescript/business-lookup/index.ts
@@ -17,7 +17,7 @@ const businessSchema = z.object({
   businessStartDate: z.string().nullable(),
   businessEndDate: z.string().nullable(),
   neighborhood: z.string().nullable(),
-  naicsCode: z.string(),
+  naicsCode: z.string().nullable(),
   naicsCodeDescription: z.string().nullable(),
 });
 

--- a/typescript/business-lookup/index.ts
+++ b/typescript/business-lookup/index.ts
@@ -1,76 +1,62 @@
-// Business Lookup with Agent - See README.md for full documentation
+// Business Lookup with a bring-your-own agent - See README.md for full documentation
 
 import "dotenv/config";
-import { browserbase, Stagehand } from "@browserbasehq/stagehand";
+import { createMCPClient } from "@ai-sdk/mcp";
+import { Experimental_StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
+import { Output, ToolLoopAgent, stepCountIs } from "ai";
 import { z } from "zod/v4";
 
-// Business search variables
 const businessName = "Jalebi Street";
 
+const businessSchema = z.object({
+  dbaName: z.string(),
+  ownershipName: z.string().nullable(),
+  businessAccountNumber: z.string(),
+  locationId: z.string().nullable(),
+  streetAddress: z.string().nullable(),
+  businessStartDate: z.string().nullable(),
+  businessEndDate: z.string().nullable(),
+  neighborhood: z.string().nullable(),
+  naicsCode: z.string(),
+  naicsCodeDescription: z.string().nullable(),
+});
+
 async function main() {
-  // Initialize Stagehand with Browserbase for cloud-based browser automation.
-  const browser = await browserbase.launch({
-    apiKey: process.env.BROWSERBASE_API_KEY!,
-  });
-  const stagehand = await Stagehand.create({
-    browser: browser,
-    model: { modelName: "openai/gpt-4.1" },
-    logging: { level: "info" },
+  const mcpClient = await createMCPClient({
+    transport: new Experimental_StdioMCPTransport({
+      command: "stagehand-codemode",
+      stderr: "inherit",
+    }),
   });
 
   try {
-    // Initialize browser session to start automation.
+    const tools = await mcpClient.tools();
+    if (!tools.code_execute) throw new Error("Stagehand code mode did not expose code_execute");
 
-    console.log("Stagehand initialized successfully!");
-    const page = (await browser.context.pages())[0];
-
-    // Navigate to SF Business Registry search page.
-    console.log(`Navigating to SF Business Registry...`);
-    await page.goto("https://data.sfgov.org/stories/s/Registered-Business-Lookup/k6sk-2y6w/");
+    const agent = new ToolLoopAgent({
+      model: process.env.AGENT_MODEL ?? "anthropic/claude-sonnet-4.6",
+      instructions:
+        "You are a browser agent. Use code_execute for all browser work. Prefer deterministic page and locator APIs, and use Stagehand act, observe, or extract inside code_execute only when semantic browser intelligence is useful.",
+      tools,
+      output: Output.object({ schema: businessSchema }),
+      stopWhen: stepCountIs(20),
+    });
 
     console.log(`Searching for business: ${businessName}`);
-    await stagehand.act("Open the business registry filter controls");
-    await stagehand.act("Choose DBA Name as the filter field");
-    await stagehand.act(`Type "${businessName}" into the filter value field`);
-    await stagehand.act("Apply the business registry filter");
-    await stagehand.act(`Open the result row for "${businessName}"`);
-    await stagehand.act("Scroll the business details horizontally to reveal the NAICS code");
-
-    // Extract comprehensive business information after agent completes the search.
-    console.log("Extracting business information...");
-    const { data: businessInfo } = await stagehand.extract(
-      "Extract all visible business information including DBA Name, Ownership Name, Business Account Number, Location Id, Street Address, Business Start Date, Business End Date, Neighborhood, NAICS Code, and NAICS Code Description",
-      z.object({
-        dbaName: z.string(),
-        ownershipName: z.string().optional(),
-        businessAccountNumber: z.string(),
-        locationId: z.string().optional(),
-        streetAddress: z.string().optional(),
-        businessStartDate: z.string().optional(),
-        businessEndDate: z.string().optional(),
-        neighborhood: z.string().optional(),
-        naicsCode: z.string(),
-        naicsCodeDescription: z.string().optional(),
-      }),
-      { page },
-    );
+    const result = await agent.generate({
+      prompt: `Open the San Francisco Registered Business Lookup at https://data.sfgov.org/stories/s/Registered-Business-Lookup/k6sk-2y6w/ and find the record for ${JSON.stringify(businessName)}. Return all requested fields. Use null when a field is not present.`,
+    });
 
     console.log("Business Information:");
-    console.log(JSON.stringify(businessInfo, null, 2));
-  } catch (error) {
-    console.error("Error during business lookup:", error);
+    console.log(JSON.stringify(result.output, null, 2));
   } finally {
-    // Always close session to release resources and clean up.
-    await stagehand.close();
-    await browser.close();
-    console.log("Session closed successfully");
+    await mcpClient.close();
+    console.log("Stagehand code-mode session closed successfully");
   }
 }
 
-main().catch((err) => {
-  console.error("Error in business lookup:", err);
-  console.error("Common issues:");
-  console.error("  - Check .env file has BROWSERBASE_API_KEY");
-  console.error("Docs: https://docs.stagehand.dev/v4/first-steps/introduction");
+main().catch((error) => {
+  console.error("Error in business lookup:", error);
+  console.error("Check BROWSERBASE_API_KEY and AI_GATEWAY_API_KEY in .env");
   process.exit(1);
 });

--- a/typescript/business-lookup/index.ts
+++ b/typescript/business-lookup/index.ts
@@ -6,6 +6,10 @@ import { Experimental_StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
 import { Output, ToolLoopAgent, stepCountIs } from "ai";
 import { z } from "zod/v4";
 
+const childEnv = Object.fromEntries(
+  Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+);
+
 const businessName = "Jalebi Street";
 
 const businessSchema = z.object({
@@ -25,6 +29,7 @@ async function main() {
   const mcpClient = await createMCPClient({
     transport: new Experimental_StdioMCPTransport({
       command: "stagehand-codemode",
+      env: childEnv,
       stderr: "inherit",
     }),
   });
@@ -36,15 +41,24 @@ async function main() {
     const agent = new ToolLoopAgent({
       model: process.env.AGENT_MODEL ?? "anthropic/claude-sonnet-4.6",
       instructions:
-        "You are a browser agent. Use code_execute for all browser work. Prefer deterministic page and locator APIs, and use Stagehand act, observe, or extract inside code_execute only when semantic browser intelligence is useful.",
+        "You are a browser agent. Use code_execute for all browser work. Prefer deterministic page, locator, and page.evaluate APIs. Use no more than 8 code_execute calls. Once you have the requested record, stop calling tools and return the structured response immediately.",
       tools,
       output: Output.object({ schema: businessSchema }),
-      stopWhen: stepCountIs(20),
+      prepareStep: ({ stepNumber }) =>
+        stepNumber >= 8
+          ? {
+              activeTools: [],
+              toolChoice: "none",
+              instructions:
+                "Return the structured business record now using the evidence already collected. Do not call another tool.",
+            }
+          : undefined,
+      stopWhen: stepCountIs(10),
     });
 
     console.log(`Searching for business: ${businessName}`);
     const result = await agent.generate({
-      prompt: `Open the San Francisco Registered Business Lookup at https://data.sfgov.org/stories/s/Registered-Business-Lookup/k6sk-2y6w/ and find the record for ${JSON.stringify(businessName)}. Return all requested fields. Use null when a field is not present.`,
+      prompt: `Open the official San Francisco Open Data API query https://data.sfgov.org/resource/g8m3-pdis.json?$q=${encodeURIComponent(businessName)}&$limit=5 and find the exact DBA record for ${JSON.stringify(businessName)}. Read the JSON rendered in the browser, map ttxid to businessAccountNumber and uniqueid to locationId, and return all requested fields. Use null when a field is not present.`,
     });
 
     console.log("Business Information:");

--- a/typescript/business-lookup/index.ts
+++ b/typescript/business-lookup/index.ts
@@ -1,58 +1,44 @@
 // Business Lookup with Agent - See README.md for full documentation
 
 import "dotenv/config";
-import { Stagehand } from "@browserbasehq/stagehand";
-import { z } from "zod";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
+import { z } from "zod/v4";
 
 // Business search variables
 const businessName = "Jalebi Street";
 
 async function main() {
   // Initialize Stagehand with Browserbase for cloud-based browser automation.
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 1,
-    model: "openai/gpt-4.1",
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+  });
+  const stagehand = await Stagehand.create({
+    browser: browser,
+    model: { modelName: "openai/gpt-4.1" },
+    logging: { level: "info" },
   });
 
   try {
     // Initialize browser session to start automation.
-    await stagehand.init();
-    console.log("Stagehand initialized successfully!");
-    console.log(
-      `Live View Link: https://browserbase.com/sessions/${stagehand.browserbaseSessionId}`,
-    );
 
-    const page = stagehand.context.pages()[0];
+    console.log("Stagehand initialized successfully!");
+    const page = (await browser.context.pages())[0];
 
     // Navigate to SF Business Registry search page.
     console.log(`Navigating to SF Business Registry...`);
     await page.goto("https://data.sfgov.org/stories/s/Registered-Business-Lookup/k6sk-2y6w/");
 
-    // Create agent with computer use capabilities for autonomous business search.
-    const agent = stagehand.agent({
-      cua: true, // Enable Computer Use Agent mode
-      model: {
-        modelName: "google/gemini-2.5-computer-use-preview-10-2025",
-        apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY,
-      },
-      systemPrompt:
-        "You are a helpful assistant that can use a web browser to search for business information.",
-    });
-
     console.log(`Searching for business: ${businessName}`);
-    const result = await agent.execute({
-      instruction: `Find and look up the business "${businessName}" in the SF Business Registry. Use the DBA Name filter to search for "${businessName}", apply the filter, and click on the business row to view detailed information. Scroll towards the right to see the NAICS code.`,
-      maxSteps: 30,
-    });
-
-    if (!result.success) {
-      throw new Error("Agent failed to complete the search");
-    }
+    await stagehand.act("Open the business registry filter controls");
+    await stagehand.act("Choose DBA Name as the filter field");
+    await stagehand.act(`Type "${businessName}" into the filter value field`);
+    await stagehand.act("Apply the business registry filter");
+    await stagehand.act(`Open the result row for "${businessName}"`);
+    await stagehand.act("Scroll the business details horizontally to reveal the NAICS code");
 
     // Extract comprehensive business information after agent completes the search.
     console.log("Extracting business information...");
-    const businessInfo = await stagehand.extract(
+    const { data: businessInfo } = await stagehand.extract(
       "Extract all visible business information including DBA Name, Ownership Name, Business Account Number, Location Id, Street Address, Business Start Date, Business End Date, Neighborhood, NAICS Code, and NAICS Code Description",
       z.object({
         dbaName: z.string(),
@@ -76,6 +62,7 @@ async function main() {
   } finally {
     // Always close session to release resources and clean up.
     await stagehand.close();
+    await browser.close();
     console.log("Session closed successfully");
   }
 }
@@ -84,7 +71,6 @@ main().catch((err) => {
   console.error("Error in business lookup:", err);
   console.error("Common issues:");
   console.error("  - Check .env file has BROWSERBASE_API_KEY");
-  console.error("  - Verify GOOGLE_API_KEY is set for the agent");
-  console.error("Docs: https://docs.stagehand.dev/v3/first-steps/introduction");
+  console.error("Docs: https://docs.stagehand.dev/v4/first-steps/introduction");
   process.exit(1);
 });

--- a/typescript/business-lookup/package.json
+++ b/typescript/business-lookup/package.json
@@ -1,9 +1,8 @@
 {
-  "name": "exa-browserbase",
+  "name": "business-lookup-template",
   "version": "1.0.0",
-  "description": "Stagehand + Browserbase + Exa: AI-Powered Job Search and Application",
+  "private": true,
   "type": "module",
-  "main": "index.ts",
   "scripts": {
     "start": "tsx index.ts"
   },
@@ -11,13 +10,13 @@
     "@ai-sdk/mcp": "^2.0.29",
     "@browserbasehq/stagehand-codemode": "github:browserbase/stagehand#54302fc5f13be5ad8e717d8e1388502de22be2ed&path:/packages/integrations",
     "ai": "^7.0.58",
-    "dotenv": "latest",
-    "exa-js": "latest"
+    "dotenv": "^17.4.2",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@types/node": "latest",
-    "tsx": "latest",
-    "typescript": "latest"
+    "@types/node": "^25.5.0",
+    "tsx": "^4.23.1",
+    "typescript": "^5.9.3"
   },
   "//": "TODO: Replace this commit pin with @browserbasehq/stagehand-codemode@4.0.0 after it is published.",
   "engines": {

--- a/typescript/company-address-finder/README.md
+++ b/typescript/company-address-finder/README.md
@@ -3,7 +3,7 @@
 ## AT A GLANCE
 
 - Goal: Automate discovery of company legal information and physical addresses from Terms of Service and Privacy Policy pages.
-- CUA Agent: Uses autonomous computer-use agent to search for company homepages via Google and navigate to legal documents.
+- V4 Workflow: Uses explicit Google navigation plus Stagehand `act()` and `extract()` calls.
 - Data Extraction: Extracts structured data including homepage URLs, ToS/Privacy Policy links, and physical mailing addresses.
 - Fallback Strategy: Intelligently falls back from Terms of Service to Privacy Policy if address is not found.
 - Retry Logic: Built-in exponential backoff for reliability against network failures.
@@ -11,12 +11,10 @@
 
 ## GLOSSARY
 
-- agent: autonomous AI agent with computer-use capabilities that can navigate websites like a human
-  Docs → https://docs.stagehand.dev/basics/agent
+- act: perform one model-backed browser action from a natural-language instruction
+  Docs → https://docs.stagehand.dev/v4/basics/act
 - extract: pull structured data from web pages using natural language instructions and Zod schemas
   Docs → https://docs.stagehand.dev/basics/extract
-- CUA (Computer Use Agent): agent mode that enables full browser interaction (search, click, scroll, type)
-  Docs → https://docs.stagehand.dev/basics/agent#what-is-cua-mode
 - concurrent sessions: run multiple browser sessions simultaneously for faster batch processing
   Docs → https://docs.browserbase.com/guides/concurrency-rate-limits
 - exponential backoff: retry strategy that increases wait time between attempts for reliability
@@ -24,16 +22,16 @@
 ## QUICKSTART
 
 1. cd company-address-finder
-2. npm install
+2. pnpm install
 3. cp .env.example .env
-4. Add your Browserbase API key and Google Generative AI API key to .env
+4. Add your Browserbase API key to `.env`
 5. Edit COMPANY_NAMES array in index.ts to specify which companies to process
-6. npm start
+6. pnpm start
 
 ## EXPECTED OUTPUT
 
-- Initializes browser session for each company with live view link
-- Agent navigates to Google and searches for company homepage
+- Initializes a V4 browser and Stagehand client for each company
+- Application code searches Google and opens the official company homepage
 - Extracts Terms of Service and Privacy Policy links from homepage
 - Navigates to Terms of Service and extracts physical address
 - Falls back to Privacy Policy if address not found in ToS
@@ -42,10 +40,9 @@
 
 ## COMMON PITFALLS
 
-- Missing credentials: verify .env contains BROWSERBASE_API_KEY and GOOGLE_GENERATIVE_AI_API_KEY
-- Google API access: ensure you have access to google/gemini-2.5-computer-use-preview-10-2025 model
+- Missing credentials: verify `.env` contains `BROWSERBASE_API_KEY`
 - Concurrent processing: MAX_CONCURRENT > 1 requires Browserbase Startup or Developer plan or higher (default is 1 for sequential)
-- Company not found: agent may fail if company name is ambiguous or doesn't have a clear web presence
+- Company not found: the official-result action may fail if the name is ambiguous
 - Address extraction: some companies may not list physical addresses in their legal documents
 - Session timeouts: long-running batches may hit 900s timeout (adjust browserbaseSessionCreateParams if needed)
 
@@ -66,7 +63,7 @@
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground
 🔧 Templates: https://www.browserbase.com/templates

--- a/typescript/company-address-finder/README.md
+++ b/typescript/company-address-finder/README.md
@@ -1,71 +1,33 @@
-# Stagehand + Browserbase: Company Address Finder
+# Stagehand Code Mode + Vercel AI SDK: Company Address Finder
 
 ## AT A GLANCE
 
-- Goal: Automate discovery of company legal information and physical addresses from Terms of Service and Privacy Policy pages.
-- V4 Workflow: Uses explicit Google navigation plus Stagehand `act()` and `extract()` calls.
-- Data Extraction: Extracts structured data including homepage URLs, ToS/Privacy Policy links, and physical mailing addresses.
-- Fallback Strategy: Intelligently falls back from Terms of Service to Privacy Policy if address is not found.
-- Retry Logic: Built-in exponential backoff for reliability against network failures.
-- Scalable: Supports both sequential and concurrent processing (concurrent requires Startup/Developer plan or higher).
-
-## GLOSSARY
-
-- act: perform one model-backed browser action from a natural-language instruction
-  Docs → https://docs.stagehand.dev/v4/basics/act
-- extract: pull structured data from web pages using natural language instructions and Zod schemas
-  Docs → https://docs.stagehand.dev/basics/extract
-- concurrent sessions: run multiple browser sessions simultaneously for faster batch processing
-  Docs → https://docs.browserbase.com/guides/concurrency-rate-limits
-- exponential backoff: retry strategy that increases wait time between attempts for reliability
+- Goal: find official legal pages and physical mailing addresses for a list of companies.
+- Agent framework: one Vercel AI SDK `ToolLoopAgent` per company.
+- Browser tool: each agent receives only Stagehand's stateful `code_execute` MCP tool.
+- Concurrency: increase `MAX_CONCURRENT` only when your Browserbase plan supports it.
 
 ## QUICKSTART
 
-1. cd company-address-finder
-2. pnpm install
-3. cp .env.example .env
-4. Add your Browserbase API key to `.env`
-5. Edit COMPANY_NAMES array in index.ts to specify which companies to process
-6. pnpm start
+1. `cd company-address-finder`
+2. `pnpm install`
+3. Add `BROWSERBASE_API_KEY` and `AI_GATEWAY_API_KEY` to `.env`
+4. Edit `COMPANY_NAMES` and `MAX_CONCURRENT` in `index.ts`
+5. `pnpm start`
 
 ## EXPECTED OUTPUT
 
-- Initializes a V4 browser and Stagehand client for each company
-- Application code searches Google and opens the official company homepage
-- Extracts Terms of Service and Privacy Policy links from homepage
-- Navigates to Terms of Service and extracts physical address
-- Falls back to Privacy Policy if address not found in ToS
-- Outputs comprehensive JSON with all extracted data for each company
-- Displays processing status and session closure for each company
+- Each agent verifies an official homepage, Terms page, and Privacy page.
+- It checks Terms first for an address and falls back to Privacy.
+- Zod validates the final record for each company.
+- Every MCP client is closed, which closes its Stagehand and browser lifecycle.
 
-## COMMON PITFALLS
+## SAFETY
 
-- Missing credentials: verify `.env` contains `BROWSERBASE_API_KEY`
-- Concurrent processing: MAX_CONCURRENT > 1 requires Browserbase Startup or Developer plan or higher (default is 1 for sequential)
-- Company not found: the official-result action may fail if the name is ambiguous
-- Address extraction: some companies may not list physical addresses in their legal documents
-- Session timeouts: long-running batches may hit 900s timeout (adjust browserbaseSessionCreateParams if needed)
+Code mode executes model-authored JavaScript and is not itself a security sandbox. Use an isolation boundary for untrusted prompts or pages.
 
-## USE CASES
+## RESOURCES
 
-• Legal compliance research: Collect company addresses and legal document URLs for due diligence, vendor verification, or compliance audits.
-• Business intelligence: Build datasets of company locations and legal information for market research or competitive analysis.
-• Contact data enrichment: Augment CRM or database records with verified physical addresses extracted from official company documents.
-• Multi-company batch processing: Process lists of companies (investors, partners, clients) to gather standardized location data at scale.
-
-## NEXT STEPS
-
-• Parameterize inputs: Accept company names from CSV files, command-line arguments, or API endpoints for dynamic batch processing.
-• Expand extraction: Add support for additional fields like contact emails, phone numbers, business registration numbers, or founding dates.
-• Multi-source validation: Cross-reference addresses from multiple pages (About, Contact, Footer) to improve accuracy and confidence.
-• Export formats: Add CSV, Excel, or database export options with configurable field mappings for downstream integrations.
-• Error handling: Implement more granular error categorization (not found vs. no address vs. extraction failure) for better reporting.
-
-## HELPFUL RESOURCES
-
-📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
-🎮 Browserbase: https://www.browserbase.com
-💡 Try it out: https://www.browserbase.com/playground
-🔧 Templates: https://www.browserbase.com/templates
-📧 Need help? support@browserbase.com
-💬 Discord: http://stagehand.dev/discord
+- Stagehand: https://docs.stagehand.dev
+- Vercel AI SDK agents: https://ai-sdk.dev/docs/agents/building-agents
+- Browserbase concurrency: https://docs.browserbase.com/guides/concurrency-rate-limits

--- a/typescript/company-address-finder/index.ts
+++ b/typescript/company-address-finder/index.ts
@@ -1,7 +1,7 @@
 // Stagehand + Browserbase: Company Address Finder - See README.md for full documentation
 import "dotenv/config";
-import { Stagehand } from "@browserbasehq/stagehand";
-import { z } from "zod";
+import { browserbase, Stagehand, type StagehandBrowser } from "@browserbasehq/stagehand";
+import { z } from "zod/v4";
 
 // Companies to process (modify this array to add/remove companies)
 const COMPANY_NAMES: string[] = ["Browserbase", "Mintlify", "Wordware", "Reducto"];
@@ -45,46 +45,34 @@ async function withRetry<T>(
 }
 
 // Processes a single company: finds homepage, extracts ToS/Privacy links, and extracts physical address
-// Uses CUA agent to navigate and Stagehand extract() for structured data extraction
+// Uses explicit V4 navigation, act(), and extract() for structured data extraction
 // Falls back to Privacy Policy if address not found in Terms of Service
 async function processCompany(companyName: string): Promise<CompanyData> {
   console.log(`\nProcessing: ${companyName}`);
 
   let stagehand: Stagehand | null = null;
+  let browser: StagehandBrowser | null = null;
 
   try {
     // Initialize Stagehand with Browserbase
-    stagehand = new Stagehand({
-      env: "BROWSERBASE",
-      verbose: 0,
-      // 0 = errors only, 1 = info, 2 = debug
-      // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
-      // https://docs.stagehand.dev/configuration/logging
-      browserbaseSessionCreateParams: {
-        region: "us-east-1",
-        timeout: 900,
-        browserSettings: {
-          viewport: {
-            width: 1920,
-            height: 1080,
-          },
+    browser = await browserbase.launch({
+      apiKey: process.env.BROWSERBASE_API_KEY!,
+      region: "us-east-1",
+      timeout: 900,
+      browserSettings: {
+        viewport: {
+          width: 1920,
+          height: 1080,
         },
       },
     });
+    stagehand = await Stagehand.create({ browser: browser, logging: { level: "error" } });
 
     console.log(`[${companyName}] Initializing browser session...`);
-    await stagehand.init();
-    const sessionId = stagehand.browserbaseSessionId;
 
-    if (!sessionId) {
-      throw new Error(`Failed to initialize browser session for ${companyName}`);
-    }
+    const page = (await browser.context.pages())[0];
 
-    console.log(`[${companyName}] Live View Link: https://browserbase.com/sessions/${sessionId}`);
-
-    const page = stagehand.context.pages()[0];
-
-    // Navigate to Google as starting point for CUA agent to search and find company homepage
+    // Search Google, then use one Stagehand action to open the official homepage.
     console.log(`[${companyName}] Navigating to Google...`);
     await withRetry(async () => {
       await page.goto("https://www.google.com/", {
@@ -92,29 +80,15 @@ async function processCompany(companyName: string): Promise<CompanyData> {
       });
     }, `[${companyName}] Initial navigation to Google`);
 
-    // Create CUA agent for autonomous navigation
-    // Agent can interact with the browser like a human: search, click, scroll, and navigate
-    const agent = stagehand.agent({
-      cua: true,
-      model: {
-        modelName: "google/gemini-2.5-computer-use-preview-10-2025",
-        apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY,
-      },
-      systemPrompt: `You are a helpful assistant that can use a web browser.
-      You are currently on the following page: ${page.url()}.
-      Do not ask follow up questions, the user will trust your judgement.`,
-    });
-
-    console.log(`[${companyName}] Finding company homepage using CUA agent...`);
+    console.log(`[${companyName}] Finding company homepage...`);
     await withRetry(async () => {
-      await agent.execute({
-        instruction: `Navigate to the ${companyName} website`,
-        maxSteps: 5,
-        highlightCursor: true,
-      });
+      await page.goto(
+        `https://www.google.com/search?q=${encodeURIComponent(`${companyName} official website`)}`,
+      );
+      await stagehand!.act(`Open the official website result for ${companyName}`);
     }, `[${companyName}] Navigation to website`);
 
-    const homepageUrl = page.url();
+    const homepageUrl = await page.url();
     console.log(`[${companyName}] Homepage found: ${homepageUrl}`);
 
     // Extract both legal document links in parallel for speed (independent operations)
@@ -138,12 +112,12 @@ async function processCompany(companyName: string): Promise<CompanyData> {
     let privacyPolicyLink = "";
 
     if (termsResult.status === "fulfilled" && termsResult.value) {
-      termsOfServiceLink = termsResult.value.termsOfServiceLink || "";
+      termsOfServiceLink = termsResult.value.data.termsOfServiceLink || "";
       console.log(`[${companyName}] Terms of Service: ${termsOfServiceLink}`);
     }
 
     if (privacyResult.status === "fulfilled" && privacyResult.value) {
-      privacyPolicyLink = privacyResult.value.privacyPolicyLink || "";
+      privacyPolicyLink = privacyResult.value.data.privacyPolicyLink || "";
       console.log(`[${companyName}] Privacy Policy: ${privacyPolicyLink}`);
     }
 
@@ -157,7 +131,7 @@ async function processCompany(companyName: string): Promise<CompanyData> {
       }, `[${companyName}] Navigate to Terms of Service`);
 
       try {
-        const addressResult = await stagehand.extract(
+        const { data: addressResult } = await stagehand.extract(
           "Extract the physical company mailing address (street, city, state, postal code, and country if present) from the Terms of Service page. Ignore phone numbers or email addresses.",
           z.object({
             companyAddress: z.string(),
@@ -186,7 +160,7 @@ async function processCompany(companyName: string): Promise<CompanyData> {
       }, `[${companyName}] Navigate to Privacy Policy`);
 
       try {
-        const addressResult = await stagehand.extract(
+        const { data: addressResult } = await stagehand.extract(
           "Extract the physical company mailing  address(street, city, state, postal code, and country if present) from the Privacy Policy page. Ignore phone numbers or email addresses.",
           z.object({
             companyAddress: z.string(),
@@ -231,9 +205,10 @@ async function processCompany(companyName: string): Promise<CompanyData> {
       address: `Error: ${error instanceof Error ? error.message : "Failed to process"}`,
     };
   } finally {
-    if (stagehand) {
+    if (stagehand && browser) {
       try {
         await stagehand.close();
+        await browser.close();
         console.log(`[${companyName}] Session closed successfully`);
       } catch (closeError) {
         console.error(`[${companyName}] Error closing browser:`, closeError);
@@ -299,6 +274,6 @@ main().catch((err) => {
   console.error("  - Check .env file has BROWSERBASE_API_KEY");
   console.error("  - Verify GOOGLE_GENERATIVE_AI_API_KEY is set");
   console.error("  - Ensure COMPANY_NAMES is configured in the config section");
-  console.error("Docs: https://docs.stagehand.dev/v3/first-steps/introduction");
+  console.error("Docs: https://docs.stagehand.dev/v4/first-steps/introduction");
   process.exit(1);
 });

--- a/typescript/company-address-finder/index.ts
+++ b/typescript/company-address-finder/index.ts
@@ -1,279 +1,79 @@
 // Stagehand + Browserbase: Company Address Finder - See README.md for full documentation
+
 import "dotenv/config";
-import { browserbase, Stagehand, type StagehandBrowser } from "@browserbasehq/stagehand";
+import { createMCPClient } from "@ai-sdk/mcp";
+import { Experimental_StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
+import { Output, ToolLoopAgent, stepCountIs } from "ai";
 import { z } from "zod/v4";
 
-// Companies to process (modify this array to add/remove companies)
-const COMPANY_NAMES: string[] = ["Browserbase", "Mintlify", "Wordware", "Reducto"];
+const COMPANY_NAMES = ["Browserbase", "Mintlify", "Wordware", "Reducto"];
 
-// Maximum number of companies to process concurrently.
-// Default: 1 (sequential processing - works on all plans)
-// Set to > 1 for concurrent processing (requires Startup or Developer plan or higher)
+// Values above 1 require enough Browserbase concurrency for one code-mode process per company.
 const MAX_CONCURRENT = 1;
 
-interface CompanyData {
-  companyName: string;
-  homepageUrl: string;
-  termsOfServiceLink: string;
-  privacyPolicyLink: string;
-  address: string;
-}
+const companySchema = z.object({
+  companyName: z.string(),
+  homepageUrl: z.string(),
+  termsOfServiceLink: z.string().nullable(),
+  privacyPolicyLink: z.string().nullable(),
+  address: z.string().nullable(),
+});
 
-// Retries an async function with exponential backoff
-// Handles transient network/page load failures for reliability
-async function withRetry<T>(
-  fn: () => Promise<T>,
-  description: string,
-  maxRetries: number = 3,
-  delayMs: number = 2000,
-): Promise<T> {
-  let lastError: Error | null = null;
+type CompanyData = z.infer<typeof companySchema>;
 
-  for (let attempt = 1; attempt <= maxRetries; attempt++) {
-    try {
-      return await fn();
-    } catch (error) {
-      lastError = error instanceof Error ? error : new Error(String(error));
-      if (attempt < maxRetries) {
-        console.log(`${description} - Attempt ${attempt} failed, retrying in ${delayMs}ms...`);
-        await new Promise((resolve) => setTimeout(resolve, delayMs));
-      }
-    }
-  }
-
-  throw new Error(`${description} - Failed after ${maxRetries} attempts: ${lastError?.message}`);
-}
-
-// Processes a single company: finds homepage, extracts ToS/Privacy links, and extracts physical address
-// Uses explicit V4 navigation, act(), and extract() for structured data extraction
-// Falls back to Privacy Policy if address not found in Terms of Service
 async function processCompany(companyName: string): Promise<CompanyData> {
-  console.log(`\nProcessing: ${companyName}`);
-
-  let stagehand: Stagehand | null = null;
-  let browser: StagehandBrowser | null = null;
+  const mcpClient = await createMCPClient({
+    transport: new Experimental_StdioMCPTransport({
+      command: "stagehand-codemode",
+      stderr: "inherit",
+    }),
+  });
 
   try {
-    // Initialize Stagehand with Browserbase
-    browser = await browserbase.launch({
-      apiKey: process.env.BROWSERBASE_API_KEY!,
-      region: "us-east-1",
-      timeout: 900,
-      browserSettings: {
-        viewport: {
-          width: 1920,
-          height: 1080,
-        },
-      },
+    const tools = await mcpClient.tools();
+    if (!tools.code_execute) throw new Error("Stagehand code mode did not expose code_execute");
+
+    const agent = new ToolLoopAgent({
+      model: process.env.AGENT_MODEL ?? "anthropic/claude-sonnet-4.6",
+      instructions:
+        "You are a browser research agent. Use code_execute for every browser operation. Prefer deterministic page and locator APIs; use Stagehand extraction inside code_execute for semantic page reading. Verify that URLs belong to the requested company's official site.",
+      tools,
+      output: Output.object({ schema: companySchema }),
+      stopWhen: stepCountIs(25),
     });
-    stagehand = await Stagehand.create({ browser: browser, logging: { level: "error" } });
 
-    console.log(`[${companyName}] Initializing browser session...`);
-
-    const page = (await browser.context.pages())[0];
-
-    // Search Google, then use one Stagehand action to open the official homepage.
-    console.log(`[${companyName}] Navigating to Google...`);
-    await withRetry(async () => {
-      await page.goto("https://www.google.com/", {
-        waitUntil: "domcontentloaded",
-      });
-    }, `[${companyName}] Initial navigation to Google`);
-
-    console.log(`[${companyName}] Finding company homepage...`);
-    await withRetry(async () => {
-      await page.goto(
-        `https://www.google.com/search?q=${encodeURIComponent(`${companyName} official website`)}`,
-      );
-      await stagehand!.act(`Open the official website result for ${companyName}`);
-    }, `[${companyName}] Navigation to website`);
-
-    const homepageUrl = await page.url();
-    console.log(`[${companyName}] Homepage found: ${homepageUrl}`);
-
-    // Extract both legal document links in parallel for speed (independent operations)
-    console.log(`[${companyName}] Finding Terms of Service & Privacy Policy links...`);
-    const [termsResult, privacyResult] = await Promise.allSettled([
-      stagehand.extract(
-        "extract the link to the Terms of Service page (may also be labeled as Terms of Use, Terms and Conditions, or similar equivalent names)",
-        z.object({
-          termsOfServiceLink: z.string().url(),
-        }),
-      ),
-      stagehand.extract(
-        "extract the link to the Privacy Policy page (may also be labeled as Privacy Notice, Privacy Statement, or similar equivalent names)",
-        z.object({
-          privacyPolicyLink: z.string().url(),
-        }),
-      ),
-    ]);
-
-    let termsOfServiceLink = "";
-    let privacyPolicyLink = "";
-
-    if (termsResult.status === "fulfilled" && termsResult.value) {
-      termsOfServiceLink = termsResult.value.data.termsOfServiceLink || "";
-      console.log(`[${companyName}] Terms of Service: ${termsOfServiceLink}`);
-    }
-
-    if (privacyResult.status === "fulfilled" && privacyResult.value) {
-      privacyPolicyLink = privacyResult.value.data.privacyPolicyLink || "";
-      console.log(`[${companyName}] Privacy Policy: ${privacyPolicyLink}`);
-    }
-
-    let address = "";
-
-    // Try Terms of Service first - most likely to contain physical address for legal/contact purposes
-    if (termsOfServiceLink) {
-      console.log(`[${companyName}] Extracting address from Terms of Service...`);
-      await withRetry(async () => {
-        await page.goto(termsOfServiceLink);
-      }, `[${companyName}] Navigate to Terms of Service`);
-
-      try {
-        const { data: addressResult } = await stagehand.extract(
-          "Extract the physical company mailing address (street, city, state, postal code, and country if present) from the Terms of Service page. Ignore phone numbers or email addresses.",
-          z.object({
-            companyAddress: z.string(),
-          }),
-        );
-
-        const companyAddress = addressResult.companyAddress || "";
-        if (companyAddress && companyAddress.trim().length > 0) {
-          address = companyAddress.trim();
-          console.log(`[${companyName}] Address found in Terms of Service: ${address}`);
-        }
-      } catch (error) {
-        console.log(
-          `[${companyName}] Could not extract address from Terms of Service page: ${error}`,
-        );
-      }
-    }
-
-    // Fallback: check Privacy Policy if address not found in Terms of Service
-    if (!address && privacyPolicyLink) {
-      console.log(
-        `[${companyName}] Address not found in Terms of Service, trying Privacy Policy...`,
-      );
-      await withRetry(async () => {
-        await page.goto(privacyPolicyLink);
-      }, `[${companyName}] Navigate to Privacy Policy`);
-
-      try {
-        const { data: addressResult } = await stagehand.extract(
-          "Extract the physical company mailing  address(street, city, state, postal code, and country if present) from the Privacy Policy page. Ignore phone numbers or email addresses.",
-          z.object({
-            companyAddress: z.string(),
-          }),
-        );
-
-        const companyAddress = addressResult.companyAddress || "";
-        if (companyAddress && companyAddress.trim().length > 0) {
-          address = companyAddress.trim();
-          console.log(`[${companyName}] Address found in Privacy Policy: ${address}`);
-        }
-      } catch (error) {
-        console.log(
-          `[${companyName}] Could not extract address from Privacy Policy page: ${error}`,
-        );
-      }
-    }
-
-    if (!address) {
-      address = "Address not found in Terms of Service or Privacy Policy pages";
-      console.log(`[${companyName}] ${address}`);
-    }
-
-    const result: CompanyData = {
-      companyName,
-      homepageUrl,
-      termsOfServiceLink,
-      privacyPolicyLink,
-      address,
-    };
-
-    console.log(`[${companyName}] Successfully processed`);
-    return result;
+    console.log(`Processing ${companyName}...`);
+    const result = await agent.generate({
+      prompt: `Find the official homepage for ${JSON.stringify(companyName)}, then find its Terms of Service and Privacy Policy pages. Extract the physical mailing address from the Terms page, falling back to the Privacy page. Return null for a link or address only after checking the relevant official pages.`,
+    });
+    return result.output;
   } catch (error) {
-    console.error(`[${companyName}] Error:`, error);
-
     return {
       companyName,
       homepageUrl: "",
-      termsOfServiceLink: "",
-      privacyPolicyLink: "",
-      address: `Error: ${error instanceof Error ? error.message : "Failed to process"}`,
+      termsOfServiceLink: null,
+      privacyPolicyLink: null,
+      address: `Error: ${error instanceof Error ? error.message : String(error)}`,
     };
   } finally {
-    if (stagehand && browser) {
-      try {
-        await stagehand.close();
-        await browser.close();
-        console.log(`[${companyName}] Session closed successfully`);
-      } catch (closeError) {
-        console.error(`[${companyName}] Error closing browser:`, closeError);
-      }
-    }
+    await mcpClient.close();
   }
 }
 
-// Main orchestration function: processes companies sequentially or in batches based on MAX_CONCURRENT
-// Collects results and outputs final JSON summary
-async function main(): Promise<void> {
-  console.log("Starting Company Address Finder...");
+async function main() {
+  const maxConcurrent = Math.max(1, MAX_CONCURRENT);
+  const results: CompanyData[] = [];
 
-  const companyNames: string[] = COMPANY_NAMES;
-
-  const maxConcurrent = Math.max(1, MAX_CONCURRENT || 1);
-
-  const companyCount = companyNames.length;
-  const isSequential = maxConcurrent === 1;
-  console.log(
-    `\nProcessing ${companyCount} ${companyCount === 1 ? "company" : "companies"} ${isSequential ? "sequentially" : `concurrently (batch size: ${maxConcurrent})`}...`,
-  );
-
-  const allResults: CompanyData[] = [];
-
-  if (isSequential) {
-    for (let i = 0; i < companyNames.length; i++) {
-      const companyName = companyNames[i];
-      console.log(`[${i + 1}/${companyNames.length}] ${companyName}`);
-      const result = await processCompany(companyName);
-      allResults.push(result);
-    }
-  } else {
-    for (let i = 0; i < companyNames.length; i += maxConcurrent) {
-      const batch = companyNames.slice(i, i + maxConcurrent);
-      const batchNumber = Math.floor(i / maxConcurrent) + 1;
-      const totalBatches = Math.ceil(companyNames.length / maxConcurrent);
-
-      console.log(`\nBatch ${batchNumber}/${totalBatches}: ${batch.join(", ")}`);
-
-      const batchPromises = batch.map((companyName) => processCompany(companyName));
-      const batchResults = await Promise.all(batchPromises);
-      allResults.push(...batchResults);
-
-      console.log(
-        `Batch ${batchNumber}/${totalBatches} completed: ${batchResults.length} companies processed`,
-      );
-    }
+  for (let index = 0; index < COMPANY_NAMES.length; index += maxConcurrent) {
+    const batch = COMPANY_NAMES.slice(index, index + maxConcurrent);
+    results.push(...(await Promise.all(batch.map(processCompany))));
   }
 
-  console.log("\n" + "=".repeat(80));
-  console.log("RESULTS (JSON):");
-  console.log("=".repeat(80));
-  console.log(JSON.stringify(allResults, null, 2));
-  console.log("=".repeat(80));
-
-  console.log(`\nComplete: processed ${allResults.length}/${companyNames.length} companies`);
+  console.log(JSON.stringify(results, null, 2));
 }
 
-main().catch((err) => {
-  console.error("Application error:", err);
-  console.error("Common issues:");
-  console.error("  - Check .env file has BROWSERBASE_API_KEY");
-  console.error("  - Verify GOOGLE_GENERATIVE_AI_API_KEY is set");
-  console.error("  - Ensure COMPANY_NAMES is configured in the config section");
-  console.error("Docs: https://docs.stagehand.dev/v4/first-steps/introduction");
+main().catch((error) => {
+  console.error("Application error:", error);
+  console.error("Check BROWSERBASE_API_KEY and AI_GATEWAY_API_KEY in .env");
   process.exit(1);
 });

--- a/typescript/company-address-finder/index.ts
+++ b/typescript/company-address-finder/index.ts
@@ -6,6 +6,10 @@ import { Experimental_StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
 import { Output, ToolLoopAgent, stepCountIs } from "ai";
 import { z } from "zod/v4";
 
+const childEnv = Object.fromEntries(
+  Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+);
+
 const COMPANY_NAMES = ["Browserbase", "Mintlify", "Wordware", "Reducto"];
 
 // Values above 1 require enough Browserbase concurrency for one code-mode process per company.
@@ -25,6 +29,7 @@ async function processCompany(companyName: string): Promise<CompanyData> {
   const mcpClient = await createMCPClient({
     transport: new Experimental_StdioMCPTransport({
       command: "stagehand-codemode",
+      env: childEnv,
       stderr: "inherit",
     }),
   });
@@ -36,10 +41,19 @@ async function processCompany(companyName: string): Promise<CompanyData> {
     const agent = new ToolLoopAgent({
       model: process.env.AGENT_MODEL ?? "anthropic/claude-sonnet-4.6",
       instructions:
-        "You are a browser research agent. Use code_execute for every browser operation. Prefer deterministic page and locator APIs; use Stagehand extraction inside code_execute for semantic page reading. Verify that URLs belong to the requested company's official site.",
+        "You are a browser research agent. Use code_execute for every browser operation. Prefer deterministic page, locator, and page.evaluate APIs. Use no more than 8 code_execute calls. Verify that URLs belong to the requested company's official site, then stop calling tools and return the structured response immediately.",
       tools,
       output: Output.object({ schema: companySchema }),
-      stopWhen: stepCountIs(25),
+      prepareStep: ({ stepNumber }) =>
+        stepNumber >= 8
+          ? {
+              activeTools: [],
+              toolChoice: "none",
+              instructions:
+                "Return the structured company record now using the official-site evidence already collected. Do not call another tool.",
+            }
+          : undefined,
+      stopWhen: stepCountIs(10),
     });
 
     console.log(`Processing ${companyName}...`);
@@ -67,6 +81,13 @@ async function main() {
   for (let index = 0; index < COMPANY_NAMES.length; index += maxConcurrent) {
     const batch = COMPANY_NAMES.slice(index, index + maxConcurrent);
     results.push(...(await Promise.all(batch.map(processCompany))));
+  }
+
+  const failures = results.filter(
+    (result) => !result.homepageUrl || result.address?.startsWith("Error:"),
+  );
+  if (failures.length > 0) {
+    throw new Error(`Failed to produce verified company data for ${failures.length} companies`);
   }
 
   console.log(JSON.stringify(results, null, 2));

--- a/typescript/company-address-finder/package.json
+++ b/typescript/company-address-finder/package.json
@@ -1,9 +1,8 @@
 {
-  "name": "exa-browserbase",
+  "name": "company-address-finder-template",
   "version": "1.0.0",
-  "description": "Stagehand + Browserbase + Exa: AI-Powered Job Search and Application",
+  "private": true,
   "type": "module",
-  "main": "index.ts",
   "scripts": {
     "start": "tsx index.ts"
   },
@@ -11,13 +10,13 @@
     "@ai-sdk/mcp": "^2.0.29",
     "@browserbasehq/stagehand-codemode": "github:browserbase/stagehand#54302fc5f13be5ad8e717d8e1388502de22be2ed&path:/packages/integrations",
     "ai": "^7.0.58",
-    "dotenv": "latest",
-    "exa-js": "latest"
+    "dotenv": "^17.4.2",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@types/node": "latest",
-    "tsx": "latest",
-    "typescript": "latest"
+    "@types/node": "^25.5.0",
+    "tsx": "^4.23.1",
+    "typescript": "^5.9.3"
   },
   "//": "TODO: Replace this commit pin with @browserbasehq/stagehand-codemode@4.0.0 after it is published.",
   "engines": {

--- a/typescript/company-value-prop-generator/README.md
+++ b/typescript/company-value-prop-generator/README.md
@@ -4,14 +4,14 @@
 
 - Goal: Automatically extract and format website value propositions into concise one-liners for email personalization
 - Demonstrates Stagehand's `extract` method with Zod schemas to pull structured data from landing pages
-- Shows direct LLM API usage via `stagehand.llmClient` to transform extracted content with custom prompts
+- Shows how to chain Stagehand V4 extractions to transform grounded page content with custom prompts
 - Includes placeholder page detection and validation logic to filter out non-functional sites
-- Docs → https://docs.stagehand.dev/v3/basics/extract
+- Docs → https://docs.stagehand.dev/v4/basics/extract
 
 ## GLOSSARY
 
 - Extract: Stagehand method that uses AI to pull structured data from pages using natural language instructions
-  Docs → https://docs.stagehand.dev/v3/basics/extract
+  Docs → https://docs.stagehand.dev/v4/basics/extract
 - Value Proposition: The core benefit or unique selling point a company communicates to customers
 
 ## QUICKSTART
@@ -25,7 +25,7 @@
 ## EXPECTED OUTPUT
 
 - Stagehand initializes and creates a Browserbase session
-- Displays live session link for monitoring
+- Chains two Stagehand V4 extractions to produce the formatted one-liner
 - Navigates to target domain and waits for page load
 - Checks for placeholder pages via meta tag inspection
 - Extracts value proposition from landing page using AI
@@ -56,7 +56,7 @@
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
 🎮 Browserbase: https://www.browserbase.com
 💡 Templates: https://www.browserbase.com/templates
 📧 Need help? support@browserbase.com

--- a/typescript/company-value-prop-generator/index.ts
+++ b/typescript/company-value-prop-generator/index.ts
@@ -1,8 +1,8 @@
 // Stagehand + Browserbase: Value Prop One-Liner Generator - See README.md for full documentation
 
 import "dotenv/config";
-import { Stagehand } from "@browserbasehq/stagehand";
-import { z } from "zod";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
+import { z } from "zod/v4";
 
 // Domain to analyze - change this to target a different website
 const targetDomain = "www.browserbase.com"; // Or extract from email: email.split("@")[1]
@@ -12,34 +12,32 @@ const targetDomain = "www.browserbase.com"; // Or extract from email: email.spli
  * Extracts the value prop using Stagehand, then uses an LLM to format it into a short phrase starting with "your".
  */
 async function generateOneLiner(domain: string): Promise<string> {
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    model: "openai/gpt-4.1",
-    verbose: 0, //  0 = errors only, 1 = info, 2 = debug
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+  });
+  const stagehand = await Stagehand.create({
+    browser: browser,
+    model: { modelName: "openai/gpt-4.1" },
+    logging: { level: "error" },
   });
 
   try {
-    await stagehand.init();
     console.log("Stagehand initialized successfully!");
-    console.log(
-      `Live View Link: https://browserbase.com/sessions/${stagehand.browserbaseSessionId}`,
-    );
-
-    const page = stagehand.context.pages()[0];
+    const page = (await browser.context.pages())[0];
 
     // Navigate to domain
     console.log(`🌐 Navigating to https://${domain}...`);
     // 5min timeout to handle slow-loading sites or network issues
     await page.goto(`https://${domain}/`, {
       waitUntil: "domcontentloaded",
-      timeoutMs: 300000,
+      timeout: 300000,
     });
 
     console.log(`✅ Successfully loaded ${domain}`);
 
     // Extract value proposition from landing page
     console.log(`📝 Extracting value proposition for ${domain}...`);
-    const valueProp = await stagehand.extract(
+    const { data: valueProp } = await stagehand.extract(
       "extract the value proposition from the landing page",
       z.object({
         value_prop: z.string(),
@@ -58,39 +56,16 @@ async function generateOneLiner(domain: string): Promise<string> {
       throw new Error(`No value prop found for ${domain}`);
     }
 
-    // Generate one-liner using OpenAI
-    // Prompt uses few-shot examples to guide LLM toward concise, "your X" format
-    // System prompt enforces constraints (9 words max, no quotes, must start with "your")
+    // Generate the one-liner with a second V4 extraction. Including the first extraction
+    // keeps the request grounded while Stagehand's configured model handles formatting.
     console.log(`🤖 Generating email one-liner for ${domain}...`);
 
-    const response = await stagehand.llmClient.createChatCompletion({
-      logger: () => {}, // Suppress verbose LLM logs
-      options: {
-        messages: [
-          {
-            role: "system",
-            content:
-              "You are an expert at generating concise, unique descriptions of companies. Generate ONLY a concise description (no greetings or extra text). Don't use generic adjectives like 'comprehensive', 'innovative', or 'powerful'. Keep it short and concise, no more than 9 words. DO NOT USE QUOTES. Only use English. You MUST start the response with 'your'.",
-          },
-          {
-            role: "user",
-            content: `The response will be inserted into this template: "{response}"
+    const { data: formatted } = await stagehand.extract(
+      `Using the company's value proposition "${valueProp.value_prop}", write a unique English description that starts with "your", uses no quotes, avoids generic adjectives, and is no more than 9 words`,
+      z.object({ one_liner: z.string() }),
+    );
 
-Examples:
-Value prop: "Supercharge your investment team with AI-powered research"
-Response: "your AI-powered investment research platform"
-
-Value prop: "The video-first food delivery app"
-Response: "your video-first approach to food delivery"
-
-Value prop: "${valueProp.value_prop}"
-Response:`,
-          },
-        ],
-      },
-    });
-
-    const oneLiner = String(response.choices?.[0]?.message?.content || "").trim();
+    const oneLiner = formatted.one_liner.trim();
 
     // Validate LLM response is usable (not empty, not generic placeholder)
     console.log(`🔍 Validating generated one-liner...`);
@@ -112,6 +87,7 @@ Response:`,
     throw error;
   } finally {
     await stagehand.close();
+    await browser.close();
     console.log("Session closed successfully");
   }
 }

--- a/typescript/context/README.md
+++ b/typescript/context/README.md
@@ -13,16 +13,16 @@
   Docs → https://docs.browserbase.com/features/contexts
 - persist: when true, any state changes during a session are written back to the context for future reuse.
 - act: perform UI actions from a prompt (click, type, navigate).
-  Docs → https://docs.stagehand.dev/basics/act
+  Docs → https://docs.stagehand.dev/v4/basics/act
 
 ## QUICKSTART
 
-1.  cd context-template
-2.  npm install
-3.  npm install axios
-4.  cp .env.example .env
-5.  Add your Browserbase API key, Project ID, and SF Rec Park credentials to .env
-6.  npm start
+1. cd context
+2. npm install
+3. npm install axios
+4. cp .env.example .env
+5. Add your Browserbase API key, Project ID, and SF Rec Park credentials to .env
+6. npm start
 
 ## EXPECTED OUTPUT
 

--- a/typescript/context/README.md
+++ b/typescript/context/README.md
@@ -51,7 +51,7 @@
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground
 🔧 Templates: https://www.browserbase.com/templates

--- a/typescript/context/index.ts
+++ b/typescript/context/index.ts
@@ -1,10 +1,17 @@
 // Stagehand + Browserbase: Context Authentication Example - See README.md for full documentation
 
 import "dotenv/config";
-import { Stagehand } from "@browserbasehq/stagehand";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 import { Browserbase } from "@browserbasehq/sdk";
-import { z } from "zod";
+import { z } from "zod/v4";
 import axios from "axios";
+import fs from "fs";
+
+async function uploadStagehandExtension(bb: Browserbase): Promise<{ id: string }> {
+  const stagehandEntry = import.meta.resolve("@browserbasehq/stagehand");
+  const archive = new URL("./assets/stagehand-extension.zip", stagehandEntry);
+  return bb.extensions.create({ file: fs.createReadStream(archive) });
+}
 
 async function createSessionContextID() {
   console.log("Creating new Browserbase context...");
@@ -16,7 +23,9 @@ async function createSessionContextID() {
 
   // Create a single session using the context ID to perform initial login.
   console.log("Creating session for initial login...");
+  const extension = await uploadStagehandExtension(bb);
   const session = await bb.sessions.create({
+    extensionId: extension.id,
     browserSettings: {
       context: {
         id: context.id,
@@ -28,16 +37,20 @@ async function createSessionContextID() {
 
   // Connect Stagehand to the existing session (no new session created).
   console.log("Connecting Stagehand to session...");
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    model: "openai/gpt-4.1",
-    verbose: 1,
-    browserbaseSessionID: session.id,
+  const browser = await browserbase.connect({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+    sessionId: session.id,
+    extensionId: extension.id,
+  });
+  const stagehand = await Stagehand.create({
+    browser: browser,
+    model: { modelName: "openai/gpt-4.1" },
+    logging: { level: "info" },
   });
 
-  await stagehand.init(); // Connect to existing session for login process.
+  // Connect to existing session for login process.
 
-  const page = stagehand.context.pages()[0];
+  const page = (await browser.context.pages())[0];
   const email = process.env.SF_REC_PARK_EMAIL;
   const password = process.env.SF_REC_PARK_PASSWORD;
 
@@ -50,14 +63,16 @@ async function createSessionContextID() {
 
   // Perform login sequence: each step is atomic to handle dynamic page changes.
   console.log("Starting login sequence...");
-  await page.act("Click the Login button");
-  await page.act(`Fill in the email or username field with "${email}"`);
-  await page.act("Click the next, continue, or submit button to proceed");
-  await page.act(`Fill in the password field with "${password}"`);
-  await page.act("Click the login, sign in, or submit button");
+  await stagehand.act("Click the Login button");
+  await stagehand.act(`Fill in the email or username field with "${email}"`);
+  await stagehand.act("Click the next, continue, or submit button to proceed");
+  await stagehand.act(`Fill in the password field with "${password}"`);
+  await stagehand.act("Click the login, sign in, or submit button");
   console.log("Login sequence completed!");
 
   await stagehand.close();
+  await browser.close();
+  await bb.extensions.delete(extension.id, { headers: { "Content-Type": null } });
   console.log("Authentication state saved to context");
 
   // Return the context ID for reuse in future sessions.
@@ -88,25 +103,25 @@ async function main() {
 
   // Initialize new session using existing context to inherit authentication state.
   // persist: true ensures any new changes (cookies, cache) are saved back to context.
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    model: "openai/gpt-4.1",
-    verbose: 1,
-    browserbaseSessionCreateParams: {
-      browserSettings: {
-        context: {
-          id: contextId.id,
-          persist: true,
-        },
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+    browserSettings: {
+      context: {
+        id: contextId.id,
+        persist: true,
       },
     },
   });
+  const stagehand = await Stagehand.create({
+    browser: browser,
+    model: { modelName: "openai/gpt-4.1" },
+    logging: { level: "info" },
+  });
 
-  await stagehand.init(); // Creates session with inherited login state from context.
+  // Creates session with inherited login state from context.
   console.log("Authenticated session ready!");
-  console.log("Live view: https://browserbase.com/sessions/" + stagehand.browserbaseSessionID);
 
-  const page = stagehand.context.pages()[0];
+  const page = (await browser.context.pages())[0];
 
   // Navigate to authenticated area - should skip login due to persisted cookies.
   console.log("Navigating to authenticated area (should skip login)...");
@@ -116,23 +131,24 @@ async function main() {
   });
 
   // Navigate to user-specific area to access personal data.
-  await page.act("Click on the reservations button");
+  await stagehand.act("Click on the reservations button");
 
   // Extract structured user data using Zod schema for type safety.
   // Schema ensures consistent data format and validates extracted content.
   console.log("Extracting user profile data...");
-  const userData = await page.extract({
-    instruction: "Extract the user's full name and address",
-    schema: z.object({
+  const { data: userData } = await stagehand.extract(
+    "Extract the user's full name and address",
+    z.object({
       fullName: z.string().describe("the user's full name"),
       address: z.string().describe("the user's address"),
     }),
-  });
+  );
 
   console.log("Extracted user data:", userData);
 
   // Always close session to release resources and save any context changes.
   await stagehand.close();
+  await browser.close();
   console.log("Session closed successfully");
 
   // Clean up context to prevent accumulation and ensure security.
@@ -145,6 +161,6 @@ main().catch((err) => {
   console.error("  - Check .env file has SF_REC_PARK_EMAIL and SF_REC_PARK_PASSWORD");
   console.error("  - Verify BROWSERBASE_API_KEY is set");
   console.error("  - Ensure credentials are valid for SF Rec & Park");
-  console.error("Docs: https://docs.stagehand.dev/v3/first-steps/introduction");
+  console.error("Docs: https://docs.stagehand.dev/v4/first-steps/introduction");
   process.exit(1);
 });

--- a/typescript/context/index.ts
+++ b/typescript/context/index.ts
@@ -5,27 +5,27 @@ import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 import { Browserbase } from "@browserbasehq/sdk";
 import { z } from "zod/v4";
 import axios from "axios";
-import fs from "fs";
-
-async function uploadStagehandExtension(bb: Browserbase): Promise<{ id: string }> {
-  const stagehandEntry = import.meta.resolve("@browserbasehq/stagehand");
-  const archive = new URL("./assets/stagehand-extension.zip", stagehandEntry);
-  return bb.extensions.create({ file: fs.createReadStream(archive) });
-}
 
 async function createSessionContextID() {
+  const email = process.env.SF_REC_PARK_EMAIL;
+  const password = process.env.SF_REC_PARK_PASSWORD;
+  if (!process.env.BROWSERBASE_API_KEY || !email || !password) {
+    throw new Error(
+      "BROWSERBASE_API_KEY, SF_REC_PARK_EMAIL, and SF_REC_PARK_PASSWORD are required",
+    );
+  }
+
   console.log("Creating new Browserbase context...");
   // First create a context using Browserbase SDK to get a context ID.
   const bb = new Browserbase({ apiKey: process.env.BROWSERBASE_API_KEY! });
   const context = await bb.contexts.create();
 
-  console.log("Created context ID:", context.id);
+  console.log("Created Browserbase context");
 
   // Create a single session using the context ID to perform initial login.
   console.log("Creating session for initial login...");
-  const extension = await uploadStagehandExtension(bb);
-  const session = await bb.sessions.create({
-    extensionId: extension.id,
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
     browserSettings: {
       context: {
         id: context.id,
@@ -33,15 +33,7 @@ async function createSessionContextID() {
       },
     },
   });
-  console.log("Live view: https://browserbase.com/sessions/" + session.id);
-
-  // Connect Stagehand to the existing session (no new session created).
-  console.log("Connecting Stagehand to session...");
-  const browser = await browserbase.connect({
-    apiKey: process.env.BROWSERBASE_API_KEY!,
-    sessionId: session.id,
-    extensionId: extension.id,
-  });
+  console.log("Live View is available in the Browserbase Sessions dashboard");
   const stagehand = await Stagehand.create({
     browser: browser,
     model: { modelName: "openai/gpt-4.1" },
@@ -51,9 +43,6 @@ async function createSessionContextID() {
   // Connect to existing session for login process.
 
   const page = (await browser.context.pages())[0];
-  const email = process.env.SF_REC_PARK_EMAIL;
-  const password = process.env.SF_REC_PARK_PASSWORD;
-
   // Navigate to login page with extended timeout for slow-loading sites.
   console.log("Navigating to SF Rec & Park login page...");
   await page.goto("https://www.rec.us/organizations/san-francisco-rec-park", {
@@ -70,9 +59,8 @@ async function createSessionContextID() {
   await stagehand.act("Click the login, sign in, or submit button");
   console.log("Login sequence completed!");
 
-  await stagehand.close();
-  await browser.close();
-  await bb.extensions.delete(extension.id, { headers: { "Content-Type": null } });
+  await stagehand.close().catch((error) => console.warn("Stagehand cleanup warning:", error));
+  await browser.close().catch((error) => console.warn("Browser cleanup warning:", error));
   console.log("Authentication state saved to context");
 
   // Return the context ID for reuse in future sessions.
@@ -81,7 +69,7 @@ async function createSessionContextID() {
 
 async function deleteContext(contextId: string) {
   try {
-    console.log("Cleaning up context:", contextId);
+    console.log("Cleaning up Browserbase context");
     // Delete context via Browserbase API to clean up stored authentication data.
     // This prevents accumulation of unused contexts and ensures security cleanup.
     const response = await axios.delete(`https://api.browserbase.com/v1/contexts/${contextId}`, {
@@ -139,16 +127,20 @@ async function main() {
   const { data: userData } = await stagehand.extract(
     "Extract the user's full name and address",
     z.object({
-      fullName: z.string().describe("the user's full name"),
-      address: z.string().describe("the user's address"),
+      fullName: z.string().min(1).describe("the user's full name"),
+      address: z.string().min(1).describe("the user's address"),
     }),
   );
+
+  if (/sign in|log in/i.test(`${userData.fullName} ${userData.address}`)) {
+    throw new Error("The reused context did not reach authenticated profile data");
+  }
 
   console.log("Extracted user data:", userData);
 
   // Always close session to release resources and save any context changes.
-  await stagehand.close();
-  await browser.close();
+  await stagehand.close().catch((error) => console.warn("Stagehand cleanup warning:", error));
+  await browser.close().catch((error) => console.warn("Browser cleanup warning:", error));
   console.log("Session closed successfully");
 
   // Clean up context to prevent accumulation and ensure security.

--- a/typescript/council-events/README.md
+++ b/typescript/council-events/README.md
@@ -30,7 +30,7 @@
 
 - Navigates to Philadelphia Council website
 - Clicks calendar from the navigation menu
-- Selects 2025 from the month dropdown
+- Selects 2025 from the year dropdown
 - Extracts structured event data including name, date, and time
 - Returns typed object with event information
 

--- a/typescript/council-events/README.md
+++ b/typescript/council-events/README.md
@@ -10,9 +10,9 @@
 ## GLOSSARY
 
 - act: perform UI actions from a natural language prompt (type, click, navigate).
-  Docs → https://docs.stagehand.dev/basics/act
+  Docs → https://docs.stagehand.dev/v4/basics/act
 - extract: pull structured data from web pages into validated objects.
-  Docs → https://docs.stagehand.dev/basics/extract
+  Docs → https://docs.stagehand.dev/v4/basics/extract
 - schema: a Zod definition that enforces data types, optional fields, and validation rules.
   Docs → https://zod.dev/
 - council events automation: navigate to council website, select calendar, and extract event information.

--- a/typescript/council-events/README.md
+++ b/typescript/council-events/README.md
@@ -57,7 +57,7 @@
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground
 🔧 Templates: https://www.browserbase.com/templates

--- a/typescript/council-events/index.ts
+++ b/typescript/council-events/index.ts
@@ -1,7 +1,7 @@
 // Stagehand + Browserbase: Philadelphia Council Events Scraper - See README.md for full documentation
 import "dotenv/config";
-import { Stagehand } from "@browserbasehq/stagehand";
-import { z } from "zod";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
+import { z } from "zod/v4";
 
 /**
  * Searches Philadelphia Council Events for 2025 and extracts event information.
@@ -11,25 +11,22 @@ async function main() {
   console.log("Starting Philadelphia Council Events automation...");
 
   // Initialize Stagehand with Browserbase for cloud-based browser automation
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 1,
-    // 0 = errors only, 1 = info, 2 = debug
-    // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
-    // https://docs.stagehand.dev/configuration/logging
-    model: "openai/gpt-4.1",
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+  });
+  const stagehand = await Stagehand.create({
+    browser: browser,
+    model: { modelName: "openai/gpt-4.1" },
+    logging: { level: "info" },
   });
 
   try {
     // Initialize browser session
     console.log("Initializing browser session...");
-    await stagehand.init();
+
     console.log("Stagehand session started successfully");
 
-    // Provide live session URL for debugging and monitoring
-    console.log(`Watch live: https://browserbase.com/sessions/${stagehand.browserbaseSessionID}`);
-
-    const page = stagehand.context.pages()[0];
+    const page = (await browser.context.pages())[0];
 
     // Navigate to Philadelphia Council
     console.log("Navigating to: https://phila.legistar.com/");
@@ -46,7 +43,7 @@ async function main() {
 
     // Extract event data using AI to parse the structured information
     console.log("Extracting event information...");
-    const results = await stagehand.extract(
+    const { data: results } = await stagehand.extract(
       "Extract the table with the name, date and time of the events",
       z.object({
         results: z.array(
@@ -77,6 +74,7 @@ async function main() {
     // Clean up browser session
     console.log("Closing browser session...");
     await stagehand.close();
+    await browser.close();
     console.log("Session closed successfully");
   }
 }

--- a/typescript/council-events/index.ts
+++ b/typescript/council-events/index.ts
@@ -37,9 +37,9 @@ async function main() {
     console.log("Clicking calendar from the navigation menu");
     await stagehand.act("click calendar from the navigation menu");
 
-    // Select 2025 from the month dropdown
-    console.log("Selecting 2025 from the month dropdown");
-    await stagehand.act("select 2025 from the month dropdown");
+    // Select 2025 from the year dropdown
+    console.log("Selecting 2025 from the year dropdown");
+    await stagehand.act("select 2025 from the year dropdown");
 
     // Extract event data using AI to parse the structured information
     console.log("Extracting event information...");

--- a/typescript/download-financial-statements/README.md
+++ b/typescript/download-financial-statements/README.md
@@ -5,12 +5,12 @@
 - Goal: automate downloading Apple's quarterly financial statements (PDFs) from their investor relations site.
 - Download Handling: Browserbase automatically captures PDFs opened during the session and bundles them into a ZIP file.
 - Retry Logic: polls Browserbase downloads API with configurable timeout to ensure files are ready before retrieval.
-- Live Debugging: displays live view URL for real-time session monitoring.
+- Live Debugging: the session can be monitored from the Browserbase Sessions dashboard without logging a signed URL.
 
 ## GLOSSARY
 
-- act: perform UI actions from a prompt (click, scroll, navigate)
-  Docs → https://docs.stagehand.dev/basics/act
+- page APIs: use the V4 browser context and page directly for known navigation and link discovery
+  Docs → https://docs.stagehand.dev/v4/reference/page
 - downloads API: retrieve files downloaded during a Browserbase session as a ZIP archive
   Docs → https://docs.browserbase.com/features/screenshots#pdfs
 - live view: real-time browser debugging interface for monitoring automation
@@ -27,9 +27,9 @@
 ## EXPECTED OUTPUT
 
 - Initializes Stagehand session with Browserbase
-- Navigates to Apple.com → Investors section
-- Locates Q1-Q4 2025 quarterly earnings reports
-- Clicks each Financial Statements PDF link (triggers downloads)
+- Navigates directly to Apple Investor Relations
+- Discovers and validates four unique FY2025 Financial Statements PDF URLs
+- Opens each statement to trigger Browserbase downloads
 - Polls Browserbase API until downloads are ready
 - Saves all PDFs as `downloaded_files.zip` in current directory
 - Displays Stagehand metrics and closes cleanly
@@ -39,7 +39,7 @@
 - "Cannot find module": ensure all dependencies are installed
 - Missing credentials: verify .env contains BROWSERBASE_API_KEY
 - Download timeout: increase `retryForSeconds` parameter if downloads take longer than 45 seconds
-- Empty ZIP file: ensure PDFs were actually triggered (check live view link to debug)
+- Empty ZIP file: ensure PDFs were actually triggered (inspect the session in the Browserbase dashboard)
 - Network issues: check internet connection and Apple website accessibility
 
 ## USE CASES
@@ -50,7 +50,7 @@
 
 ## NEXT STEPS
 
-• Generalize for other sites: Extract URL patterns, adapt act() prompts, and support multiple companies/document types.
+• Generalize for other sites: Adapt URL/link matching and support multiple companies or document types.
 • Parse downloaded PDFs: Unzip, OCR/parse text (PyPDF2/pdfplumber), and load into structured format (CSV/DB/JSON).
 • Add validation: Check file count, sizes, naming conventions; alert on failures; retry missing quarters.
 

--- a/typescript/download-financial-statements/README.md
+++ b/typescript/download-financial-statements/README.md
@@ -32,7 +32,7 @@
 - Clicks each Financial Statements PDF link (triggers downloads)
 - Polls Browserbase API until downloads are ready
 - Saves all PDFs as `downloaded_files.zip` in current directory
-- Displays session history and closes cleanly
+- Displays Stagehand metrics and closes cleanly
 
 ## COMMON PITFALLS
 
@@ -56,7 +56,7 @@
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground
 🔧 Templates: https://www.browserbase.com/templates

--- a/typescript/download-financial-statements/index.ts
+++ b/typescript/download-financial-statements/index.ts
@@ -5,12 +5,6 @@ import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 import "dotenv/config";
 import fs from "fs";
 
-async function uploadStagehandExtension(bb: Browserbase): Promise<{ id: string }> {
-  const stagehandEntry = import.meta.resolve("@browserbasehq/stagehand");
-  const archive = new URL("./assets/stagehand-extension.zip", stagehandEntry);
-  return bb.extensions.create({ file: fs.createReadStream(archive) });
-}
-
 /**
  * Polls Browserbase API for downloads with timeout handling.
  * Retries every 2 seconds until downloads are ready or timeout is reached.
@@ -74,15 +68,13 @@ async function main(): Promise<void> {
     apiKey: process.env.BROWSERBASE_API_KEY as string,
   });
 
-  const extension = await uploadStagehandExtension(bb);
-  const session = await bb.sessions.create({ extensionId: extension.id });
-
-  // Attach Stagehand to the Browserbase session so its ID remains available for downloads.
-  const browser = await browserbase.connect({
+  // V4's browser factory provisions and owns the Stagehand extension. The returned
+  // browser exposes its Browserbase session ID for downloads and Live View APIs.
+  const browser = await browserbase.launch({
     apiKey: process.env.BROWSERBASE_API_KEY!,
-    sessionId: session.id,
-    extensionId: extension.id,
   });
+  const sessionId = browser.sessionId;
+  if (!sessionId) throw new Error("Browserbase launch did not return a session ID");
   const stagehand: Stagehand = await Stagehand.create({
     browser: browser,
     logging: { level: "error", onLog: console.log },
@@ -95,32 +87,51 @@ async function main(): Promise<void> {
     const context = browser.context;
     const page = (await context.pages())[0];
 
-    // Display live view URL for debugging and monitoring
-    const liveViewLinks = await bb.sessions.debug(session.id);
-    console.log(`Live View Link: ${liveViewLinks.debuggerFullscreenUrl}`);
+    // The session can be monitored from the Browserbase Sessions dashboard.
+    // Avoid printing its signed Live View URL into application logs.
+    console.log("Live View is available in the Browserbase Sessions dashboard");
 
-    // Navigate to Apple homepage with extended timeout for slow-loading sites
-    console.log("Navigating to Apple.com...");
-    await page.goto("https://www.apple.com/", { timeout: 60000 });
+    // Collect all four URLs before opening any PDF. Browserbase captures PDF
+    // navigations as downloads, which can close the page that initiated them.
+    console.log("Navigating to Apple Investor Relations...");
+    await page.goto("https://investor.apple.com/investor-relations/default.aspx", {
+      waitUntil: "domcontentloaded",
+      timeout: 60000,
+    });
+    const statementUrls = await page.evaluate(() =>
+      Array.from(document.querySelectorAll<HTMLAnchorElement>("a"))
+        .filter(
+          (link) =>
+            link.textContent?.trim() === "Financial Statements" && /fy2025/i.test(link.href),
+        )
+        .map((link) => link.href)
+        .slice(0, 4),
+    );
+    if (statementUrls.length !== 4 || new Set(statementUrls).size !== 4) {
+      throw new Error(`Expected four FY2025 statements, found ${statementUrls.length}`);
+    }
 
-    // Navigate to investor relations section
-    console.log("Navigating to Investors section...");
-    await stagehand.act("Click the 'Investors' button at the bottom of the page'");
-    await stagehand.act("Scroll down to the Financial Data section of the page");
-    await stagehand.act("Under Quarterly Earnings Reports, click on '2025'");
-
-    // Download all quarterly financial statements
-    // When a URL of a PDF is opened, Browserbase automatically downloads and stores the PDF
-    // See https://docs.browserbase.com/features/screenshots#pdfs for more info
-    console.log("Downloading quarterly financial statements...");
-    await stagehand.act("Click the 'Financial Statements' link under Q4");
-    await stagehand.act("Click the 'Financial Statements' link under Q3");
-    await stagehand.act("Click the 'Financial Statements' link under Q2");
-    await stagehand.act("Click the 'Financial Statements' link under Q1");
+    console.log("Downloading four quarterly financial statements...");
+    for (const [index, statementUrl] of statementUrls.entries()) {
+      const response = await fetch(statementUrl, { method: "HEAD" });
+      if (!response.ok || !response.headers.get("content-type")?.includes("application/pdf")) {
+        throw new Error(`Q${4 - index} statement URL did not return a PDF`);
+      }
+      await page.evaluate((url: string) => {
+        const link = document.createElement("a");
+        link.href = url;
+        link.target = "_blank";
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+      }, statementUrl);
+      await page.waitForTimeout(500);
+      console.log(`Triggered FY2025 Q${4 - index} download`);
+    }
 
     // Retrieve all downloads triggered during this session from Browserbase API
     console.log("Retrieving downloads from Browserbase...");
-    await saveDownloadsWithRetry(bb, session.id, 45);
+    await saveDownloadsWithRetry(bb, sessionId, 45);
     console.log("All downloads completed successfully!");
 
     console.log("\nStagehand Metrics:");
@@ -130,9 +141,8 @@ async function main(): Promise<void> {
     throw error;
   } finally {
     // Always close session to release resources and clean up
-    await stagehand.close();
-    await browser.close();
-    await bb.extensions.delete(extension.id, { headers: { "Content-Type": null } });
+    await stagehand.close().catch((error) => console.warn("Stagehand cleanup warning:", error));
+    await browser.close().catch((error) => console.warn("Browser cleanup warning:", error));
     console.log("Session closed successfully");
   }
 }

--- a/typescript/download-financial-statements/index.ts
+++ b/typescript/download-financial-statements/index.ts
@@ -1,9 +1,15 @@
 // Stagehand + Browserbase: Download Apple's Quarterly Financial Statements - See README.md for full documentation
 
 import { Browserbase } from "@browserbasehq/sdk";
-import { Stagehand } from "@browserbasehq/stagehand";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 import "dotenv/config";
 import fs from "fs";
+
+async function uploadStagehandExtension(bb: Browserbase): Promise<{ id: string }> {
+  const stagehandEntry = import.meta.resolve("@browserbasehq/stagehand");
+  const archive = new URL("./assets/stagehand-extension.zip", stagehandEntry);
+  return bb.extensions.create({ file: fs.createReadStream(archive) });
+}
 
 /**
  * Polls Browserbase API for downloads with timeout handling.
@@ -68,31 +74,34 @@ async function main(): Promise<void> {
     apiKey: process.env.BROWSERBASE_API_KEY as string,
   });
 
-  // Initialize Stagehand with Browserbase for cloud-based browser automation
-  const stagehand: Stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 0,
-    // 0 = errors only, 1 = info, 2 = debug
-    // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
-    // https://docs.stagehand.dev/configuration/logging
-    logger: console.log,
-    disablePino: true,
+  const extension = await uploadStagehandExtension(bb);
+  const session = await bb.sessions.create({ extensionId: extension.id });
+
+  // Attach Stagehand to the Browserbase session so its ID remains available for downloads.
+  const browser = await browserbase.connect({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+    sessionId: session.id,
+    extensionId: extension.id,
+  });
+  const stagehand: Stagehand = await Stagehand.create({
+    browser: browser,
+    logging: { level: "error", onLog: console.log },
   });
 
   try {
     // Initialize browser session to start automation
-    await stagehand.init();
+
     console.log("Stagehand initialized successfully!");
-    const context = stagehand.context;
-    const page = context.pages()[0];
+    const context = browser.context;
+    const page = (await context.pages())[0];
 
     // Display live view URL for debugging and monitoring
-    const liveViewLinks = await bb.sessions.debug(stagehand.browserbaseSessionId!);
+    const liveViewLinks = await bb.sessions.debug(session.id);
     console.log(`Live View Link: ${liveViewLinks.debuggerFullscreenUrl}`);
 
     // Navigate to Apple homepage with extended timeout for slow-loading sites
     console.log("Navigating to Apple.com...");
-    await page.goto("https://www.apple.com/", { timeoutMs: 60000 });
+    await page.goto("https://www.apple.com/", { timeout: 60000 });
 
     // Navigate to investor relations section
     console.log("Navigating to Investors section...");
@@ -111,17 +120,19 @@ async function main(): Promise<void> {
 
     // Retrieve all downloads triggered during this session from Browserbase API
     console.log("Retrieving downloads from Browserbase...");
-    await saveDownloadsWithRetry(bb, stagehand.browserbaseSessionId!, 45);
+    await saveDownloadsWithRetry(bb, session.id, 45);
     console.log("All downloads completed successfully!");
 
-    console.log("\nStagehand History:");
-    console.log(stagehand.history);
+    console.log("\nStagehand Metrics:");
+    console.log(await stagehand.metrics());
   } catch (error) {
     console.error("Error during automation:", error);
     throw error;
   } finally {
     // Always close session to release resources and clean up
     await stagehand.close();
+    await browser.close();
+    await bb.extensions.delete(extension.id, { headers: { "Content-Type": null } });
     console.log("Session closed successfully");
   }
 }
@@ -132,6 +143,6 @@ main().catch((err) => {
   console.error("  - Check .env file has BROWSERBASE_API_KEY");
   console.error("  - Verify internet connection and Apple website accessibility");
   console.error("  - Ensure sufficient timeout for slow-loading pages");
-  console.error("Docs: https://docs.stagehand.dev/v3/first-steps/introduction");
+  console.error("Docs: https://docs.stagehand.dev/v4/first-steps/introduction");
   process.exit(1);
 });

--- a/typescript/dynamic-form-filling/README.md
+++ b/typescript/dynamic-form-filling/README.md
@@ -1,20 +1,17 @@
-# Stagehand + Browserbase: Dynamic Form Filling with Agent
+# Stagehand V4 + Browserbase: Dynamic Form Filling
 
 ## AT A GLANCE
 
-- Goal: Automate intelligent form filling using an Stagehand AI agent that understands form context and uses semantic matching.
-- Agent-Powered: Uses Stagehand Agent to autonomously fill forms by extracting information from natural language descriptions.
-- Semantic Matching: Agent intelligently selects form options even when exact wording doesn't match, choosing the closest semantic match.
-- Custom Instructions: Demonstrates how to configure agent behavior with system prompts for reliable form completion.
-- Docs → https://docs.stagehand.dev/basics/agent
+- Goal: automate form filling through explicit, reviewable Stagehand V4 `act()` calls.
+- Semantic Matching: each action uses a natural-language instruction to select the closest matching field or option.
+- V4 Control Flow: application code owns the multi-step workflow because V4 has no `agent()` orchestrator.
+- Docs → https://docs.stagehand.dev/v4/basics/act
 
 ## GLOSSARY
 
-- agent: create an autonomous AI agent that can execute complex multi-step tasks
-  Docs → https://docs.stagehand.dev/basics/agent#what-is-agent
+- act: perform one model-backed browser action from a natural-language instruction
+  Docs → https://docs.stagehand.dev/v4/basics/act
 - semantic matching: selecting form options based on meaning rather than exact text match
-- system prompt: custom instructions that guide agent behavior and decision-making
-  Docs → https://docs.stagehand.dev/basics/agent#using-agent
 
 ## QUICKSTART
 
@@ -28,22 +25,17 @@
 ## EXPECTED OUTPUT
 
 - Initializes Stagehand session with Browserbase
-- Displays live session link for monitoring
 - Navigates to the target form
-- Agent analyzes form structure and available fields
-- Agent extracts relevant information from trip details
-- Agent fills form fields using semantic matching for dropdowns/checkboxes
-- Agent submits the form when complete
-- Outputs success status and agent message
+- Explicit V4 actions fill fields and choose dropdown/checkbox options semantically
+- Application code submits the form after all steps complete
 - Closes session cleanly
 
 ## COMMON PITFALLS
 
 - Dependency install errors: ensure pnpm install completed
 - Missing credentials: verify .env contains BROWSERBASE_API_KEY
-- Agent stopping early: increase maxSteps (default 30) for complex forms with many fields
 - Form not submitting: verify the form URL is accessible and form fields are visible
-- Semantic matching issues: adjust system prompt to better guide agent's matching behavior
+- Semantic matching issues: make the individual `act()` instruction more specific
 - Find more information on your Browserbase dashboard -> https://www.browserbase.com/sign-in
 
 ## USE CASES
@@ -55,7 +47,7 @@
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground
 🔧 Templates: https://www.browserbase.com/templates

--- a/typescript/dynamic-form-filling/README.md
+++ b/typescript/dynamic-form-filling/README.md
@@ -1,55 +1,30 @@
-# Stagehand V4 + Browserbase: Dynamic Form Filling
+# Stagehand Code Mode + Vercel AI SDK: Dynamic Form Filling
 
 ## AT A GLANCE
 
-- Goal: automate form filling through explicit, reviewable Stagehand V4 `act()` calls.
-- Semantic Matching: each action uses a natural-language instruction to select the closest matching field or option.
-- V4 Control Flow: application code owns the multi-step workflow because V4 has no `agent()` orchestrator.
-- Docs → https://docs.stagehand.dev/v4/basics/act
-
-## GLOSSARY
-
-- act: perform one model-backed browser action from a natural-language instruction
-  Docs → https://docs.stagehand.dev/v4/basics/act
-- semantic matching: selecting form options based on meaning rather than exact text match
+- Goal: let a bring-your-own agent interpret trip details and complete a dynamic form.
+- Agent framework: Vercel AI SDK `ToolLoopAgent` owns the multi-step loop.
+- Browser tool: Stagehand code mode exposes the single `code_execute` MCP tool.
+- The agent is instructed to inspect before acting and never invent missing values.
 
 ## QUICKSTART
 
-1. pnpm install
-2. cp .env.example .env
-3. Add your Browserbase API key to .env (BROWSERBASE_API_KEY)
-4. Customize the `tripDetails` variable in index.ts with your own form data
-5. Update the form URL if using a different form
-6. pnpm start
+1. `cd dynamic-form-filling`
+2. `pnpm install`
+3. Add `BROWSERBASE_API_KEY` and `AI_GATEWAY_API_KEY` to `.env`
+4. Customize `tripDetails` in `index.ts`
+5. `pnpm start`
 
 ## EXPECTED OUTPUT
 
-- Initializes Stagehand session with Browserbase
-- Navigates to the target form
-- Explicit V4 actions fill fields and choose dropdown/checkbox options semantically
-- Application code submits the form after all steps complete
-- Closes session cleanly
+- The agent opens the form, maps the supplied trip details to its fields, reviews the result, and submits it.
+- The MCP client closes the Stagehand client and Browserbase browser in `finally`.
 
-## COMMON PITFALLS
+## SAFETY
 
-- Dependency install errors: ensure pnpm install completed
-- Missing credentials: verify .env contains BROWSERBASE_API_KEY
-- Form not submitting: verify the form URL is accessible and form fields are visible
-- Semantic matching issues: make the individual `act()` instruction more specific
-- Find more information on your Browserbase dashboard -> https://www.browserbase.com/sign-in
+This example submits a form. Use a test form and review the prompt before running. Code mode executes model-authored JavaScript and is not itself a security sandbox.
 
-## USE CASES
+## RESOURCES
 
-• Dynamic form automation: Fill out forms with variable data from natural language descriptions without hardcoding field mappings.
-• Survey and questionnaire automation: Automatically complete surveys, feedback forms, or registration forms with intelligent option selection.
-• Multi-step form workflows: Handle complex multi-page forms where the agent navigates between steps and maintains context.
-• Form testing and validation: Test form behavior with different data sets to ensure proper validation and error handling.
-
-## HELPFUL RESOURCES
-
-📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
-🎮 Browserbase: https://www.browserbase.com
-💡 Try it out: https://www.browserbase.com/playground
-🔧 Templates: https://www.browserbase.com/templates
-📧 Need help? support@browserbase.com
-💬 Discord: http://stagehand.dev/discord
+- Stagehand: https://docs.stagehand.dev
+- Vercel AI SDK MCP tools: https://ai-sdk.dev/docs/ai-sdk-core/mcp-tools

--- a/typescript/dynamic-form-filling/index.ts
+++ b/typescript/dynamic-form-filling/index.ts
@@ -1,73 +1,49 @@
 // Dynamic Form Filling with Agent - See README.md for full documentation
 
 import "dotenv/config";
-import { Stagehand } from "@browserbasehq/stagehand";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 
 // Trip details to be used for form filling
 const tripDetails = `I'm planning a Summer in Japan. We're going to Tokyo, Kyoto, and Osaka (Japan) for 14 days. There will be 2 of us, and our budget is around $3,500 USD. We have a couple of dietary needs: vegetarian, and no shellfish. For activities, we'd love food tours, historical sites and temples, nature/scenic walks, local markets, and generally an itinerary that's easy to do with public transit. For accommodation, we prefer mid-range hotels or a traditional ryokan. We like a relaxed pace, with maybe a few busier days mixed in. It's our first time in Japan, and we'd love help balancing must-see attractions with less touristy experiences, plus recommendations for vegetarian-friendly restaurants.`;
 
 async function main() {
   // Initialize Stagehand with Browserbase for cloud-based browser automation.
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 0,
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
   });
+  const stagehand = await Stagehand.create({ browser: browser, logging: { level: "error" } });
 
   try {
     // Initialize browser session to start automation.
-    await stagehand.init();
-    console.log(`Stagehand Session Started`);
-    console.log(`Watch live: https://browserbase.com/sessions/${stagehand.browserbaseSessionId}`);
 
-    const page = stagehand.context.pages()[0];
+    console.log(`Stagehand Session Started`);
+    const page = (await browser.context.pages())[0];
 
     // Navigate to the trip example form.
     console.log("Navigating to form...");
     await page.goto("https://forms.gle/DVX84XynAJwUWNu26");
 
-    // Create agent with custom system prompt for intelligent form filling.
-    // The agent will use semantic matching to select appropriate form options.
-    const agent = stagehand.agent({
-      cua: false,
-      model: "google/gemini-2.5-pro", // Routed through Model Gateway
-      systemPrompt: `You are filling out a trip planning form. 
-    - When filling out fields, extract relevant information from the trip details provided
-    - For fields with options (radio buttons, dropdowns, checkboxes), always choose the closest matching option from the available choices
-    - Use semantic matching - look for options that convey similar meaning even if the exact wording differs
-    - Only select "Other" if no other option reasonably matches the trip details
-    - For checkbox fields, select all options that semantically match the trip details`,
-    });
-
-    // Instruction for the agent to fill out the form with trip details.
-    const instruction = `Fill out this form with the following trip details: ${tripDetails}
-
-Make sure to:
-- Fill in all required fields
-- When an exact match isn't available, choose the closest matching option from the available choices
-- Use semantic matching to find the best option - look for options that convey similar meaning even if the wording differs
-- Only select "Other" if no other option reasonably matches the trip details
-- Extract relevant information from the trip details (duration, accommodation preferences, activities, dietary needs, etc.) and map them to the form fields
-- IMPORTANT: Once all fields are filled out, you must click the submit button to complete the form submission`;
-
-    // Execute agent to autonomously fill out the form based on details.
-    console.log("\nFilling out the form with agent...");
-    const result = await agent.execute({
-      instruction,
-      maxSteps: 30,
-    });
-
-    if (result.success) {
-      console.log("Form filled successfully!");
-      console.log("Agent message:", result.message);
-    } else {
-      console.log("Form filling may be incomplete");
-      console.log("Agent message:", result.message);
-    }
+    // V4 replaces agent() with explicit, reviewable steps. Each act call performs one action.
+    console.log("\nFilling out the form with Stagehand V4 primitives...");
+    await stagehand.act("Fill the trip destinations field with Tokyo, Kyoto, and Osaka, Japan");
+    await stagehand.act("Set the trip duration to 14 days");
+    await stagehand.act("Set the number of travelers to 2");
+    await stagehand.act("Set the trip budget to 3500 USD");
+    await stagehand.act("Select vegetarian and no shellfish as dietary needs");
+    await stagehand.act(
+      "Select food tours, historical sites and temples, nature walks, and local markets as activities",
+    );
+    await stagehand.act("Select mid-range hotel or traditional ryokan as accommodation");
+    await stagehand.act("Select a relaxed travel pace and public transit preference");
+    await stagehand.act(`Fill any additional details field with: ${tripDetails}`);
+    await stagehand.act("Click the submit button");
+    console.log("Form filled successfully!");
   } catch (error) {
     console.error("Error during form filling:", error);
   } finally {
     // Always close session to release resources and clean up.
     await stagehand.close();
+    await browser.close();
     console.log("Session closed successfully");
   }
 }
@@ -77,6 +53,6 @@ main().catch((err) => {
   console.error("Common issues:");
   console.error("  - Check .env file has BROWSERBASE_API_KEY");
   console.error("  - Ensure the form URL is accessible and form fields are available");
-  console.error("Docs: https://docs.stagehand.dev/v3/first-steps/introduction");
+  console.error("Docs: https://docs.stagehand.dev/v4/first-steps/introduction");
   process.exit(1);
 });

--- a/typescript/dynamic-form-filling/index.ts
+++ b/typescript/dynamic-form-filling/index.ts
@@ -5,12 +5,17 @@ import { createMCPClient } from "@ai-sdk/mcp";
 import { Experimental_StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
 import { ToolLoopAgent, stepCountIs } from "ai";
 
+const childEnv = Object.fromEntries(
+  Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+);
+
 const tripDetails = `I'm planning a Summer in Japan. We're going to Tokyo, Kyoto, and Osaka (Japan) for 14 days. There will be 2 of us, and our budget is around $3,500 USD. We have a couple of dietary needs: vegetarian, and no shellfish. For activities, we'd love food tours, historical sites and temples, nature/scenic walks, local markets, and generally an itinerary that's easy to do with public transit. For accommodation, we prefer mid-range hotels or a traditional ryokan. We like a relaxed pace, with maybe a few busier days mixed in. It's our first time in Japan, and we'd love help balancing must-see attractions with less touristy experiences, plus recommendations for vegetarian-friendly restaurants.`;
 
 async function main() {
   const mcpClient = await createMCPClient({
     transport: new Experimental_StdioMCPTransport({
       command: "stagehand-codemode",
+      env: childEnv,
       stderr: "inherit",
     }),
   });

--- a/typescript/dynamic-form-filling/index.ts
+++ b/typescript/dynamic-form-filling/index.ts
@@ -1,58 +1,44 @@
-// Dynamic Form Filling with Agent - See README.md for full documentation
+// Dynamic Form Filling with a bring-your-own agent - See README.md for full documentation
 
 import "dotenv/config";
-import { browserbase, Stagehand } from "@browserbasehq/stagehand";
+import { createMCPClient } from "@ai-sdk/mcp";
+import { Experimental_StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
+import { ToolLoopAgent, stepCountIs } from "ai";
 
-// Trip details to be used for form filling
 const tripDetails = `I'm planning a Summer in Japan. We're going to Tokyo, Kyoto, and Osaka (Japan) for 14 days. There will be 2 of us, and our budget is around $3,500 USD. We have a couple of dietary needs: vegetarian, and no shellfish. For activities, we'd love food tours, historical sites and temples, nature/scenic walks, local markets, and generally an itinerary that's easy to do with public transit. For accommodation, we prefer mid-range hotels or a traditional ryokan. We like a relaxed pace, with maybe a few busier days mixed in. It's our first time in Japan, and we'd love help balancing must-see attractions with less touristy experiences, plus recommendations for vegetarian-friendly restaurants.`;
 
 async function main() {
-  // Initialize Stagehand with Browserbase for cloud-based browser automation.
-  const browser = await browserbase.launch({
-    apiKey: process.env.BROWSERBASE_API_KEY!,
+  const mcpClient = await createMCPClient({
+    transport: new Experimental_StdioMCPTransport({
+      command: "stagehand-codemode",
+      stderr: "inherit",
+    }),
   });
-  const stagehand = await Stagehand.create({ browser: browser, logging: { level: "error" } });
 
   try {
-    // Initialize browser session to start automation.
+    const tools = await mcpClient.tools();
+    if (!tools.code_execute) throw new Error("Stagehand code mode did not expose code_execute");
 
-    console.log(`Stagehand Session Started`);
-    const page = (await browser.context.pages())[0];
+    const agent = new ToolLoopAgent({
+      model: process.env.AGENT_MODEL ?? "anthropic/claude-sonnet-4.6",
+      instructions:
+        "You are a browser form-filling agent. Use code_execute for all browser work. Inspect the page before acting, prefer deterministic locators, use Stagehand act or observe inside code_execute when labels are ambiguous, and never invent values that the user did not provide.",
+      tools,
+      stopWhen: stepCountIs(20),
+    });
 
-    // Navigate to the trip example form.
-    console.log("Navigating to form...");
-    await page.goto("https://forms.gle/DVX84XynAJwUWNu26");
-
-    // V4 replaces agent() with explicit, reviewable steps. Each act call performs one action.
-    console.log("\nFilling out the form with Stagehand V4 primitives...");
-    await stagehand.act("Fill the trip destinations field with Tokyo, Kyoto, and Osaka, Japan");
-    await stagehand.act("Set the trip duration to 14 days");
-    await stagehand.act("Set the number of travelers to 2");
-    await stagehand.act("Set the trip budget to 3500 USD");
-    await stagehand.act("Select vegetarian and no shellfish as dietary needs");
-    await stagehand.act(
-      "Select food tours, historical sites and temples, nature walks, and local markets as activities",
-    );
-    await stagehand.act("Select mid-range hotel or traditional ryokan as accommodation");
-    await stagehand.act("Select a relaxed travel pace and public transit preference");
-    await stagehand.act(`Fill any additional details field with: ${tripDetails}`);
-    await stagehand.act("Click the submit button");
-    console.log("Form filled successfully!");
-  } catch (error) {
-    console.error("Error during form filling:", error);
+    const result = await agent.generate({
+      prompt: `Open https://forms.gle/DVX84XynAJwUWNu26 and complete the trip-planning form from these details:\n\n${tripDetails}\n\nReview every answer, submit the form, and report whether submission succeeded.`,
+    });
+    console.log(result.text);
   } finally {
-    // Always close session to release resources and clean up.
-    await stagehand.close();
-    await browser.close();
-    console.log("Session closed successfully");
+    await mcpClient.close();
+    console.log("Stagehand code-mode session closed successfully");
   }
 }
 
-main().catch((err) => {
-  console.error("Error in dynamic form filling:", err);
-  console.error("Common issues:");
-  console.error("  - Check .env file has BROWSERBASE_API_KEY");
-  console.error("  - Ensure the form URL is accessible and form fields are available");
-  console.error("Docs: https://docs.stagehand.dev/v4/first-steps/introduction");
+main().catch((error) => {
+  console.error("Error in dynamic form filling:", error);
+  console.error("Check BROWSERBASE_API_KEY and AI_GATEWAY_API_KEY in .env");
   process.exit(1);
 });

--- a/typescript/dynamic-form-filling/package.json
+++ b/typescript/dynamic-form-filling/package.json
@@ -1,9 +1,8 @@
 {
-  "name": "exa-browserbase",
+  "name": "dynamic-form-filling-template",
   "version": "1.0.0",
-  "description": "Stagehand + Browserbase + Exa: AI-Powered Job Search and Application",
+  "private": true,
   "type": "module",
-  "main": "index.ts",
   "scripts": {
     "start": "tsx index.ts"
   },
@@ -11,13 +10,12 @@
     "@ai-sdk/mcp": "^2.0.29",
     "@browserbasehq/stagehand-codemode": "github:browserbase/stagehand#54302fc5f13be5ad8e717d8e1388502de22be2ed&path:/packages/integrations",
     "ai": "^7.0.58",
-    "dotenv": "latest",
-    "exa-js": "latest"
+    "dotenv": "^17.4.2"
   },
   "devDependencies": {
-    "@types/node": "latest",
-    "tsx": "latest",
-    "typescript": "latest"
+    "@types/node": "^25.5.0",
+    "tsx": "^4.23.1",
+    "typescript": "^5.9.3"
   },
   "//": "TODO: Replace this commit pin with @browserbasehq/stagehand-codemode@4.0.0 after it is published.",
   "engines": {

--- a/typescript/exa-browserbase/README.md
+++ b/typescript/exa-browserbase/README.md
@@ -3,25 +3,24 @@
 ## AT A GLANCE
 
 - **Goal**: Automate job applications with AI that writes smart, tailored responses for each role.
-- **Pattern Template**: combines Exa search, Browserbase browsers, and explicit Stagehand V4 actions.
-- **Workflow**: Exa finds careers pages, Stagehand reads a posting, and application-controlled `act()` calls fill the form.
+- **Pattern Template**: combines Exa search, a Vercel AI SDK agent, and Stagehand code mode.
+- **Workflow**: Exa finds careers pages, then one bring-your-own agent per company uses `code_execute` to inspect and fill an application.
 - **Plans**: Sequential mode works on all plans; concurrent applications and proxies require Startup or Developer plan or higher ([concurrency](https://docs.browserbase.com/guides/concurrency-rate-limits), [proxies](https://docs.browserbase.com/features/proxies)).
-- Docs → [Stagehand Act](https://docs.stagehand.dev/v4/basics/act) | [Exa Search](https://docs.exa.ai/reference/search) | [Stagehand Extract](https://docs.stagehand.dev/v4/basics/extract)
+- Docs → [Vercel AI SDK Agents](https://ai-sdk.dev/docs/agents/building-agents) | [Exa Search](https://docs.exa.ai/reference/search) | [Stagehand](https://docs.stagehand.dev)
 
 ## THE 5-STEP FLOW
 
 1. **Search for companies** — Exa finds companies matching your criteria (e.g., "AI startups in SF")
 2. **Find careers pages** — For each company, Exa searches for their careers/jobs page
-3. **Extract job details** — Stagehand reads the job posting and extracts structured data (title, requirements, responsibilities)
-4. **Form filling** — explicit Stagehand actions fill known application fields without submitting
-5. **Resume upload** — Stagehand V4 locators handle resume/CV file inputs
+3. **Start a browser agent** — Vercel AI SDK owns the loop and receives Stagehand's `code_execute` MCP tool
+4. **Inspect and fill** — the agent reads the posting and fills known fields with deterministic V4 APIs or Stagehand AI primitives
+5. **Stop for review** — the agent uploads the resume but stops before final submission
 
 ## GLOSSARY
 
-- **act**: A model-backed primitive for one browser action from a natural-language instruction.
-  Docs → https://docs.stagehand.dev/v4/basics/act
-- **extract**: Pull structured data from web pages. You define what you want (job title, requirements, etc.) and it returns clean JSON.
-  Docs → https://docs.stagehand.dev/basics/extract
+- **ToolLoopAgent**: the Vercel AI SDK loop that reasons and selects tools.
+  Docs → https://ai-sdk.dev/docs/agents/building-agents
+- **code_execute**: Stagehand code mode's stateful MCP tool for browser JavaScript, V4 page APIs, locators, and AI primitives.
 - **Exa Search**: AI search engine that finds relevant web content. Can search for companies, find similar pages, and filter by date.
   Docs → https://docs.exa.ai/reference/search
 - **Tailored responses**: The AI reads the job requirements and writes custom answers for cover letters and open-ended questions that highlight relevant skills.
@@ -33,8 +32,8 @@
 3. cp .env.example .env
 4. Add required API keys to .env:
    - `BROWSERBASE_API_KEY` — from Browserbase
+   - `AI_GATEWAY_API_KEY` — from Vercel AI Gateway
    - `EXA_API_KEY` — from https://dashboard.exa.ai/api-keys
-   - Configure your Browserbase API key with OpenRouter/Anthropic
 5. Update `applicationDetails` object with candidate information
 6. Update `resumePath` to point to your PDF resume
 7. pnpm start
@@ -46,12 +45,16 @@
 - Creates a tailored cover letter based on the job
 - Handles location and visa questions smartly
 - Stops before submitting (for testing/review purposes)
-- Closes session cleanly
+- Closes every MCP client, Stagehand instance, and browser cleanly
+
+## SAFETY
+
+Code mode executes model-authored JavaScript and is not itself a security sandbox. Isolate it when prompts or pages are untrusted. Keep the stop-before-submit instruction when adapting this example.
 
 ## HELPFUL RESOURCES
 
 📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
-📚 Stagehand Act: https://docs.stagehand.dev/v4/basics/act
+📚 Vercel AI SDK MCP Tools: https://ai-sdk.dev/docs/ai-sdk-core/mcp-tools
 📚 Exa API Key: https://dashboard.exa.ai/api-keys
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground

--- a/typescript/exa-browserbase/README.md
+++ b/typescript/exa-browserbase/README.md
@@ -3,28 +3,27 @@
 ## AT A GLANCE
 
 - **Goal**: Automate job applications with AI that writes smart, tailored responses for each role.
-- **Pattern Template**: Shows how to combine Exa (find companies & jobs) + Browserbase (control browser) + Stagehand Agent (fill forms smartly).
-- **Workflow**: Exa finds companies you want, then finds their careers pages. Browserbase opens the page, Stagehand reads the job posting, and an AI agent fills out the application form with answers tailored to that specific job.
+- **Pattern Template**: combines Exa search, Browserbase browsers, and explicit Stagehand V4 actions.
+- **Workflow**: Exa finds careers pages, Stagehand reads a posting, and application-controlled `act()` calls fill the form.
 - **Plans**: Sequential mode works on all plans; concurrent applications and proxies require Startup or Developer plan or higher ([concurrency](https://docs.browserbase.com/guides/concurrency-rate-limits), [proxies](https://docs.browserbase.com/features/proxies)).
-- Docs → [Stagehand Agent](https://docs.stagehand.dev/basics/agent) | [Exa Search](https://docs.exa.ai/reference/search) | [Stagehand Extract](https://docs.stagehand.dev/basics/extract)
+- Docs → [Stagehand Act](https://docs.stagehand.dev/v4/basics/act) | [Exa Search](https://docs.exa.ai/reference/search) | [Stagehand Extract](https://docs.stagehand.dev/v4/basics/extract)
 
 ## THE 5-STEP FLOW
 
 1. **Search for companies** — Exa finds companies matching your criteria (e.g., "AI startups in SF")
 2. **Find careers pages** — For each company, Exa searches for their careers/jobs page
 3. **Extract job details** — Stagehand reads the job posting and extracts structured data (title, requirements, responsibilities)
-4. **Smart form filling** — AI agent fills out application fields with tailored responses based on the job description
-5. **Resume upload** — Playwright handles file uploads for resume/CV attachments
+4. **Form filling** — explicit Stagehand actions fill known application fields without submitting
+5. **Resume upload** — Stagehand V4 locators handle resume/CV file inputs
 
 ## GLOSSARY
 
-- **agent**: An AI that can plan and do multi-step tasks on its own. It looks at the page and decides what to do next without needing step-by-step instructions.
-  Docs → https://docs.stagehand.dev/basics/agent
+- **act**: A model-backed primitive for one browser action from a natural-language instruction.
+  Docs → https://docs.stagehand.dev/v4/basics/act
 - **extract**: Pull structured data from web pages. You define what you want (job title, requirements, etc.) and it returns clean JSON.
   Docs → https://docs.stagehand.dev/basics/extract
 - **Exa Search**: AI search engine that finds relevant web content. Can search for companies, find similar pages, and filter by date.
   Docs → https://docs.exa.ai/reference/search
-- **Hybrid mode**: Agent mode that combines reading the page code (DOM) and looking at the page visually. Works better across different websites.
 - **Tailored responses**: The AI reads the job requirements and writes custom answers for cover letters and open-ended questions that highlight relevant skills.
 
 ## QUICKSTART
@@ -51,8 +50,8 @@
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
-📚 Stagehand Agent: https://docs.stagehand.dev/basics/agent
+📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
+📚 Stagehand Act: https://docs.stagehand.dev/v4/basics/act
 📚 Exa API Key: https://dashboard.exa.ai/api-keys
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground

--- a/typescript/exa-browserbase/index.ts
+++ b/typescript/exa-browserbase/index.ts
@@ -6,6 +6,10 @@ import { Experimental_StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
 import { ToolLoopAgent, stepCountIs } from "ai";
 import { Exa } from "exa-js";
 
+const childEnv = Object.fromEntries(
+  Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+);
+
 const applicationDetails = {
   name: "John Doe",
   email: "john.doe@example.com",
@@ -44,6 +48,7 @@ async function applyToJob(careersPage: CareersPage, index: number): Promise<Appl
   const mcpClient = await createMCPClient({
     transport: new Experimental_StdioMCPTransport({
       command: "stagehand-codemode",
+      env: childEnv,
       stderr: "inherit",
     }),
   });
@@ -64,6 +69,9 @@ async function applyToJob(careersPage: CareersPage, index: number): Promise<Appl
     const result = await agent.generate({
       prompt: `Open ${careersPage.careersUrl}. Choose the first relevant open role, read its requirements, open its application, and fill every field you can from this applicant record:\n${JSON.stringify(applicationDetails, null, 2)}\nUpload the resume from ${JSON.stringify(applicationDetails.resumePath)} when a file input is present. Stop before final submission and summarize what remains for human review.`,
     });
+    if (!result.text.trim()) {
+      throw new Error("Agent returned no application review summary");
+    }
 
     return {
       company: careersPage.company,
@@ -84,6 +92,14 @@ async function applyToJob(careersPage: CareersPage, index: number): Promise<Appl
 }
 
 async function main() {
+  if (
+    !process.env.BROWSERBASE_API_KEY ||
+    !process.env.AI_GATEWAY_API_KEY ||
+    !process.env.EXA_API_KEY
+  ) {
+    throw new Error("BROWSERBASE_API_KEY, AI_GATEWAY_API_KEY, and EXA_API_KEY are required");
+  }
+
   const exa = new Exa(process.env.EXA_API_KEY);
   console.log(`Searching for companies: ${searchConfig.companyQuery}`);
   const companies = await exa.searchAndContents(searchConfig.companyQuery, {
@@ -108,6 +124,9 @@ async function main() {
     const careersUrl = careers.results[0]?.url;
     if (careersUrl) careersPages.push({ company: company.title || domain, careersUrl });
   }
+  if (careersPages.length === 0) {
+    throw new Error("Exa returned no company careers pages");
+  }
 
   const results: ApplicationResult[] = [];
   const batchSize = searchConfig.concurrent ? searchConfig.maxConcurrentBrowsers : 1;
@@ -116,6 +135,11 @@ async function main() {
     results.push(
       ...(await Promise.all(batch.map((page, offset) => applyToJob(page, index + offset)))),
     );
+  }
+
+  const failures = results.filter((result) => !result.success);
+  if (failures.length > 0) {
+    throw new Error(`${failures.length} of ${results.length} application reviews failed`);
   }
 
   console.log(JSON.stringify(results, null, 2));

--- a/typescript/exa-browserbase/index.ts
+++ b/typescript/exa-browserbase/index.ts
@@ -1,10 +1,9 @@
 // Stagehand + Browserbase + Exa: AI-Powered Job Search and Application - See README.md for full documentation
 
 import "dotenv/config";
-import { Stagehand } from "@browserbasehq/stagehand";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 import Exa from "exa-js";
-import { z } from "zod";
-import { chromium } from "playwright-core";
+import { z } from "zod/v4";
 
 // Candidate application details - customize these for your job search
 const applicationDetails = {
@@ -51,94 +50,18 @@ interface CareersPage {
   careersUrl: string;
 }
 
-// System prompt for the job application agent
-const agentSystemPrompt = `You are an intelligent job application assistant with decision-making power.
-
-Your responsibilities:
-- First, navigate to find a job posting and click through to its application page before filling out the form
-- Analyze the job description to understand what the company is looking for
-- Tailor responses to align with job requirements when available
-- Craft thoughtful responses that highlight relevant experience/skills
-- For cover letter or "why interested" fields, reference specific aspects of the job/company
-- For location/relocation questions, use the willingToRelocate flag to guide your answer
-- For visa/sponsorship questions, answer honestly based on requiresSponsorship
-- Skip resume/file upload fields - the resume will be uploaded automatically
-- Use the provided application details as the source of truth for factual information
-- IMPORTANT: Do NOT click the submit button - this is for testing purposes only
-
-Think critically about each field and present the candidate in the best professional light.`;
-
-// Builds the instruction prompt for the agent based on available job description
-function buildAgentInstruction(jobDescription: z.infer<typeof jobDescriptionSchema>): string {
-  const hasJobDescription = jobDescription.jobTitle || jobDescription.fullDescription;
-
-  if (hasJobDescription) {
-    return `You are filling out a job application. Here is the job description that was found:
-
-JOB DESCRIPTION:
-${JSON.stringify(jobDescription, null, 2)}
-
-CANDIDATE INFORMATION:
-${JSON.stringify(applicationDetails, null, 2)}
-
-YOUR TASK:
-- Fill out all text fields in the application form
-- Reference specific aspects of the job description
-- Highlight relevant skills/experience from the candidate's background
-- Show alignment between candidate and role
-- Skip file upload fields (resume will be handled separately)
-
-Remember: Your goal is to fill out this application in a way that maximizes the candidate's chances by showing strong alignment with this specific role.`;
-  }
-
-  return `You are filling out a job application. No detailed job description was found on this page.
-
-CANDIDATE INFORMATION:
-${JSON.stringify(applicationDetails, null, 2)}
-
-YOUR TASK:
-- Fill out all text fields in the application form
-- Write professional, thoughtful responses
-- Highlight the candidate's general strengths and qualifications
-- Express genuine interest and enthusiasm
-- Skip file upload fields (resume will be handled separately)
-
-Remember: Even without a job description, present the candidate professionally and enthusiastically.`;
-}
-
-// Uploads resume file using Playwright, checking main page and iframes
+// Uploads the resume with Stagehand V4's locator API.
 async function uploadResume(stagehand: Stagehand, logPrefix: string = ""): Promise<void> {
   console.log(`${logPrefix}Attempting to upload resume...`);
 
-  const browser = await chromium.connectOverCDP(stagehand.connectURL());
-  const pwContext = browser.contexts()[0];
-  const pwPage = pwContext.pages()[0];
+  const page = await stagehand.browser.context.activePage();
+  if (!page) throw new Error("No active page is available for resume upload");
+  const fileInputs = await page.locator('input[type="file"]').count();
 
-  // Check main page for file input
-  const mainPageInputs = await pwPage.locator('input[type="file"]').count();
-
-  if (mainPageInputs > 0) {
-    await pwPage.locator('input[type="file"]').first().setInputFiles(applicationDetails.resumePath);
+  if (fileInputs > 0) {
+    await page.locator('input[type="file"]').first().setInputFiles(applicationDetails.resumePath);
     console.log(`${logPrefix}Resume uploaded successfully from main page!`);
     return;
-  }
-
-  // Check inside iframes for file input
-  const frames = pwPage.frames();
-  for (const frame of frames) {
-    try {
-      const frameInputCount = await frame.locator('input[type="file"]').count();
-      if (frameInputCount > 0) {
-        await frame
-          .locator('input[type="file"]')
-          .first()
-          .setInputFiles(applicationDetails.resumePath);
-        console.log(`${logPrefix}Resume uploaded successfully from iframe!`);
-        return;
-      }
-    } catch {
-      // Frame not accessible, continue to next
-    }
   }
 
   console.log(`${logPrefix}No file upload field found on page`);
@@ -158,43 +81,46 @@ async function applyToJob(careersPage: CareersPage, index: number): Promise<Appl
   const logPrefix = `[${index + 1}/${searchConfig.numCompanies}] ${careersPage.company}: `;
   console.log(`\n${logPrefix}Starting application...`);
 
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 0,
-    experimental: true,
-    model: "google/gemini-2.5-pro",
-    // Browserbase session configuration (proxies require Developer plan or higher)
-    browserbaseSessionCreateParams: {
-      proxies: searchConfig.useProxy,
-    },
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+    proxies: searchConfig.useProxy,
+  });
+  const stagehand = await Stagehand.create({
+    browser: browser,
+    model: { modelName: "google/gemini-2.5-pro" },
+    logging: { level: "error" },
   });
 
   try {
-    await stagehand.init();
-    const sessionUrl = `https://browserbase.com/sessions/${stagehand.browserbaseSessionId}`;
-    console.log(`${logPrefix}Session started: ${sessionUrl}`);
+    console.log(`${logPrefix}Session started`);
 
-    const page = stagehand.context.pages()[0];
+    const page = (await browser.context.pages())[0];
     await page.goto(careersPage.careersUrl);
 
+    await stagehand.act("Open the first relevant job posting on this careers page");
+
     // Extract job description
-    const jobDescription = await stagehand.extract(
+    const { data: jobDescription } = await stagehand.extract(
       "extract the full job description including title, requirements, responsibilities, and any important details about the role",
       jobDescriptionSchema,
     );
 
-    // Initialize and run agent
-    const agent = stagehand.agent({
-      mode: "hybrid",
-      model: "google/gemini-3-flash-preview",
-      systemPrompt: agentSystemPrompt,
-    });
-
-    const instruction = buildAgentInstruction(jobDescription);
-    const result = await agent.execute({
-      instruction,
-      maxSteps: 50,
-    });
+    await stagehand.act("Open the application form for this job");
+    await stagehand.act(`Fill the applicant name field with ${applicationDetails.name}`);
+    await stagehand.act(`Fill the email field with ${applicationDetails.email}`);
+    await stagehand.act(`Fill the phone field with ${applicationDetails.phone}`);
+    await stagehand.act(`Fill the LinkedIn field with ${applicationDetails.linkedInUrl}`);
+    await stagehand.act(`Fill the portfolio field with ${applicationDetails.portfolioUrl}`);
+    await stagehand.act(`Fill the location field with ${applicationDetails.currentLocation}`);
+    await stagehand.act(
+      `Answer relocation questions with ${applicationDetails.willingToRelocate ? "yes" : "no"}`,
+    );
+    await stagehand.act(
+      `Answer sponsorship questions with ${applicationDetails.requiresSponsorship ? "yes" : "no"}`,
+    );
+    await stagehand.act(
+      `Fill the cover letter field with: ${applicationDetails.coverLetter} Relevant role: ${jobDescription.jobTitle ?? "the selected position"}`,
+    );
 
     // Upload resume after form filling
     try {
@@ -203,18 +129,13 @@ async function applyToJob(careersPage: CareersPage, index: number): Promise<Appl
       console.log(`${logPrefix}Could not upload resume:`, uploadError);
     }
 
-    if (result.success) {
-      console.log(`${logPrefix}Form filled successfully!`);
-    } else {
-      console.log(`${logPrefix}Form filling may be incomplete`);
-    }
+    console.log(`${logPrefix}Form filled successfully!`);
 
     return {
       company: careersPage.company,
       careersUrl: careersPage.careersUrl,
-      success: result.success,
-      message: result.message,
-      sessionUrl,
+      success: true,
+      message: "Application form filled without submitting",
     };
   } catch (error) {
     console.error(`${logPrefix}Error:`, error);
@@ -226,6 +147,7 @@ async function applyToJob(careersPage: CareersPage, index: number): Promise<Appl
     };
   } finally {
     await stagehand.close();
+    await browser.close();
     console.log(`${logPrefix}Session closed`);
   }
 }
@@ -351,11 +273,9 @@ async function main() {
 main().catch((err) => {
   console.error("Error in Exa + Browserbase job application:", err);
   console.error("Common issues:");
-  console.error(
-    "  - Check .env file has BROWSERBASE_API_KEY and EXA_API_KEY",
-  );
+  console.error("  - Check .env file has BROWSERBASE_API_KEY and EXA_API_KEY");
   console.error("  - Verify companies exist for the search query");
   console.error("  - Ensure careers pages are accessible");
-  console.error("Docs: https://docs.stagehand.dev/v3/first-steps/introduction");
+  console.error("Docs: https://docs.stagehand.dev/v4/first-steps/introduction");
   process.exit(1);
 });

--- a/typescript/exa-browserbase/index.ts
+++ b/typescript/exa-browserbase/index.ts
@@ -1,11 +1,11 @@
-// Stagehand + Browserbase + Exa: AI-Powered Job Search and Application - See README.md for full documentation
+// Stagehand + Browserbase + Exa: agentic job search and application
 
 import "dotenv/config";
-import { browserbase, Stagehand } from "@browserbasehq/stagehand";
-import Exa from "exa-js";
-import { z } from "zod/v4";
+import { createMCPClient } from "@ai-sdk/mcp";
+import { Experimental_StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
+import { ToolLoopAgent, stepCountIs } from "ai";
+import { Exa } from "exa-js";
 
-// Candidate application details - customize these for your job search
 const applicationDetails = {
   name: "John Doe",
   email: "john.doe@example.com",
@@ -20,125 +20,58 @@ const applicationDetails = {
   coverLetter: "I am excited to apply for this position...",
 };
 
-// Search configuration - modify to target different companies
 const searchConfig = {
   companyQuery: "AI startups in SF",
   numCompanies: 5,
-  // Concurrency: set to false for sequential (works on all plans); true = concurrent (requires Startup or Developer plan or higher)
   concurrent: true,
-  maxConcurrentBrowsers: 5, // Max browsers when concurrent
-  // Proxies: requires Developer plan or higher; residential proxies help avoid bot detection (https://docs.browserbase.com/features/proxies)
-  useProxy: true,
+  maxConcurrentBrowsers: 5,
 };
 
-// Zod schema for extracting structured job description data
-const jobDescriptionSchema = z.object({
-  jobTitle: z.string().optional(),
-  companyName: z.string().optional(),
-  requirements: z.array(z.string()).optional(),
-  responsibilities: z.array(z.string()).optional(),
-  benefits: z.array(z.string()).optional(),
-  location: z.string().optional(),
-  workType: z.string().optional(),
-  fullDescription: z.string().optional(),
-});
-
-// Careers page data structure for tracking discovered job pages
 interface CareersPage {
   company: string;
-  url: string;
   careersUrl: string;
 }
 
-// Uploads the resume with Stagehand V4's locator API.
-async function uploadResume(stagehand: Stagehand, logPrefix: string = ""): Promise<void> {
-  console.log(`${logPrefix}Attempting to upload resume...`);
-
-  const page = await stagehand.browser.context.activePage();
-  if (!page) throw new Error("No active page is available for resume upload");
-  const fileInputs = await page.locator('input[type="file"]').count();
-
-  if (fileInputs > 0) {
-    await page.locator('input[type="file"]').first().setInputFiles(applicationDetails.resumePath);
-    console.log(`${logPrefix}Resume uploaded successfully from main page!`);
-    return;
-  }
-
-  console.log(`${logPrefix}No file upload field found on page`);
-}
-
-// Result of a single job application attempt
 interface ApplicationResult {
   company: string;
   careersUrl: string;
   success: boolean;
   message: string;
-  sessionUrl?: string;
 }
 
-// Applies to a single job posting
 async function applyToJob(careersPage: CareersPage, index: number): Promise<ApplicationResult> {
-  const logPrefix = `[${index + 1}/${searchConfig.numCompanies}] ${careersPage.company}: `;
-  console.log(`\n${logPrefix}Starting application...`);
-
-  const browser = await browserbase.launch({
-    apiKey: process.env.BROWSERBASE_API_KEY!,
-    proxies: searchConfig.useProxy,
-  });
-  const stagehand = await Stagehand.create({
-    browser: browser,
-    model: { modelName: "google/gemini-2.5-pro" },
-    logging: { level: "error" },
+  const prefix = `[${index + 1}/${searchConfig.numCompanies}] ${careersPage.company}:`;
+  const mcpClient = await createMCPClient({
+    transport: new Experimental_StdioMCPTransport({
+      command: "stagehand-codemode",
+      stderr: "inherit",
+    }),
   });
 
   try {
-    console.log(`${logPrefix}Session started`);
+    const tools = await mcpClient.tools();
+    if (!tools.code_execute) throw new Error("Stagehand code mode did not expose code_execute");
 
-    const page = (await browser.context.pages())[0];
-    await page.goto(careersPage.careersUrl);
+    const agent = new ToolLoopAgent({
+      model: process.env.AGENT_MODEL ?? "anthropic/claude-sonnet-4.6",
+      instructions:
+        "You are a careful job-application browser agent. Use code_execute for all browser work. Inspect before acting, prefer deterministic locators, use Stagehand AI primitives inside code_execute for semantic work, never invent applicant facts, and never submit an application unless explicitly instructed.",
+      tools,
+      stopWhen: stepCountIs(30),
+    });
 
-    await stagehand.act("Open the first relevant job posting on this careers page");
-
-    // Extract job description
-    const { data: jobDescription } = await stagehand.extract(
-      "extract the full job description including title, requirements, responsibilities, and any important details about the role",
-      jobDescriptionSchema,
-    );
-
-    await stagehand.act("Open the application form for this job");
-    await stagehand.act(`Fill the applicant name field with ${applicationDetails.name}`);
-    await stagehand.act(`Fill the email field with ${applicationDetails.email}`);
-    await stagehand.act(`Fill the phone field with ${applicationDetails.phone}`);
-    await stagehand.act(`Fill the LinkedIn field with ${applicationDetails.linkedInUrl}`);
-    await stagehand.act(`Fill the portfolio field with ${applicationDetails.portfolioUrl}`);
-    await stagehand.act(`Fill the location field with ${applicationDetails.currentLocation}`);
-    await stagehand.act(
-      `Answer relocation questions with ${applicationDetails.willingToRelocate ? "yes" : "no"}`,
-    );
-    await stagehand.act(
-      `Answer sponsorship questions with ${applicationDetails.requiresSponsorship ? "yes" : "no"}`,
-    );
-    await stagehand.act(
-      `Fill the cover letter field with: ${applicationDetails.coverLetter} Relevant role: ${jobDescription.jobTitle ?? "the selected position"}`,
-    );
-
-    // Upload resume after form filling
-    try {
-      await uploadResume(stagehand, logPrefix);
-    } catch (uploadError) {
-      console.log(`${logPrefix}Could not upload resume:`, uploadError);
-    }
-
-    console.log(`${logPrefix}Form filled successfully!`);
+    console.log(`${prefix} starting code-mode agent`);
+    const result = await agent.generate({
+      prompt: `Open ${careersPage.careersUrl}. Choose the first relevant open role, read its requirements, open its application, and fill every field you can from this applicant record:\n${JSON.stringify(applicationDetails, null, 2)}\nUpload the resume from ${JSON.stringify(applicationDetails.resumePath)} when a file input is present. Stop before final submission and summarize what remains for human review.`,
+    });
 
     return {
       company: careersPage.company,
       careersUrl: careersPage.careersUrl,
       success: true,
-      message: "Application form filled without submitting",
+      message: result.text,
     };
   } catch (error) {
-    console.error(`${logPrefix}Error:`, error);
     return {
       company: careersPage.company,
       careersUrl: careersPage.careersUrl,
@@ -146,22 +79,14 @@ async function applyToJob(careersPage: CareersPage, index: number): Promise<Appl
       message: error instanceof Error ? error.message : String(error),
     };
   } finally {
-    await stagehand.close();
-    await browser.close();
-    console.log(`${logPrefix}Session closed`);
+    await mcpClient.close();
   }
 }
 
 async function main() {
-  console.log("Starting Exa + Browserbase Job Search and Application...");
-
-  // Initialize Exa client for AI-powered company search
   const exa = new Exa(process.env.EXA_API_KEY);
-
-  // Search for companies matching the criteria using Exa
-  console.log(`Searching for companies: "${searchConfig.companyQuery}"...`);
-
-  const companyResults = await exa.searchAndContents(searchConfig.companyQuery, {
+  console.log(`Searching for companies: ${searchConfig.companyQuery}`);
+  const companies = await exa.searchAndContents(searchConfig.companyQuery, {
     category: "company",
     text: true,
     type: "auto",
@@ -169,25 +94,10 @@ async function main() {
     numResults: searchConfig.numCompanies,
   });
 
-  console.log(`Found ${companyResults.results.length} companies:`);
-  companyResults.results.forEach((company, i) => {
-    console.log(`  ${i + 1}. ${company.title} - ${company.url}`);
-  });
-
-  if (companyResults.results.length === 0) {
-    console.log("No companies found. Exiting.");
-    return;
-  }
-
-  // Find careers pages for each discovered company
-  console.log("\nSearching for careers pages...");
   const careersPages: CareersPage[] = [];
-
-  for (const company of companyResults.results) {
-    const companyDomain = new URL(company.url).hostname.replace("www.", "");
-    console.log(`  Looking for careers page: ${companyDomain}...`);
-
-    const careersResult = await exa.searchAndContents(`${companyDomain} careers page`, {
+  for (const company of companies.results) {
+    const domain = new URL(company.url).hostname.replace("www.", "");
+    const careers = await exa.searchAndContents(`${domain} careers page`, {
       context: true,
       excludeDomains: ["linkedin.com"],
       numResults: 5,
@@ -195,87 +105,24 @@ async function main() {
       type: "deep",
       livecrawl: "fallback",
     });
-
-    if (careersResult.results.length > 0) {
-      const careersUrl = careersResult.results[0].url;
-      console.log(`    Found: ${careersUrl}`);
-      careersPages.push({
-        company: company.title || companyDomain,
-        url: company.url,
-        careersUrl: careersUrl,
-      });
-    } else {
-      console.log(`    No careers page found for ${companyDomain}`);
-    }
+    const careersUrl = careers.results[0]?.url;
+    if (careersUrl) careersPages.push({ company: company.title || domain, careersUrl });
   }
 
-  console.log(`\nFound ${careersPages.length} careers pages total.`);
-
-  if (careersPages.length === 0) {
-    console.log("No careers pages found. Exiting.");
-    return;
+  const results: ApplicationResult[] = [];
+  const batchSize = searchConfig.concurrent ? searchConfig.maxConcurrentBrowsers : 1;
+  for (let index = 0; index < careersPages.length; index += batchSize) {
+    const batch = careersPages.slice(index, index + batchSize);
+    results.push(
+      ...(await Promise.all(batch.map((page, offset) => applyToJob(page, index + offset)))),
+    );
   }
 
-  // Apply to jobs either concurrently or sequentially based on config
-  console.log(`\n${"=".repeat(50)}`);
-  console.log(
-    `Starting applications (${searchConfig.concurrent ? `concurrent, max ${searchConfig.maxConcurrentBrowsers} browsers` : "sequential"})...`,
-  );
-  console.log(`${"=".repeat(50)}`);
-
-  let results: ApplicationResult[];
-
-  if (searchConfig.concurrent) {
-    // Run applications concurrently with limited parallelism
-    const chunks: CareersPage[][] = [];
-    for (let i = 0; i < careersPages.length; i += searchConfig.maxConcurrentBrowsers) {
-      chunks.push(careersPages.slice(i, i + searchConfig.maxConcurrentBrowsers));
-    }
-
-    results = [];
-    for (const chunk of chunks) {
-      const chunkResults = await Promise.all(
-        chunk.map((page, idx) => applyToJob(page, results.length + idx)),
-      );
-      results.push(...chunkResults);
-    }
-  } else {
-    // Run applications sequentially
-    results = [];
-    for (let i = 0; i < careersPages.length; i++) {
-      const result = await applyToJob(careersPages[i], i);
-      results.push(result);
-    }
-  }
-
-  // Print summary
-  console.log(`\n${"=".repeat(50)}`);
-  console.log("APPLICATION SUMMARY");
-  console.log(`${"=".repeat(50)}`);
-
-  const successful = results.filter((r) => r.success);
-  const failed = results.filter((r) => !r.success);
-
-  console.log(
-    `\nTotal: ${results.length} | Success: ${successful.length} | Failed: ${failed.length}\n`,
-  );
-
-  results.forEach((r, i) => {
-    const status = r.success ? "[SUCCESS]" : "[FAILED]";
-    console.log(`${i + 1}. ${status} ${r.company}`);
-    console.log(`   URL: ${r.careersUrl}`);
-    if (r.sessionUrl) {
-      console.log(`   Session: ${r.sessionUrl}`);
-    }
-  });
+  console.log(JSON.stringify(results, null, 2));
 }
 
-main().catch((err) => {
-  console.error("Error in Exa + Browserbase job application:", err);
-  console.error("Common issues:");
-  console.error("  - Check .env file has BROWSERBASE_API_KEY and EXA_API_KEY");
-  console.error("  - Verify companies exist for the search query");
-  console.error("  - Ensure careers pages are accessible");
-  console.error("Docs: https://docs.stagehand.dev/v4/first-steps/introduction");
+main().catch((error) => {
+  console.error("Error in Exa + Browserbase job application:", error);
+  console.error("Check BROWSERBASE_API_KEY, AI_GATEWAY_API_KEY, and EXA_API_KEY in .env");
   process.exit(1);
 });

--- a/typescript/exa-browserbase/package.json
+++ b/typescript/exa-browserbase/package.json
@@ -8,15 +8,19 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@browserbasehq/stagehand": "latest",
+    "@browserbasehq/stagehand": "github:browserbase/stagehand#089f2aaeaea75696685949e0835aece95db54358&path:/packages/sdk-ts",
     "dotenv": "latest",
     "exa-js": "latest",
-    "playwright-core": "latest",
-    "zod": "latest"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "latest",
     "tsx": "latest",
     "typescript": "latest"
-  }
+  },
+  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand@4.0.0 after it is published.",
+  "engines": {
+    "node": ">=22.18.0"
+  },
+  "packageManager": "pnpm@10.24.0"
 }

--- a/typescript/extend-browserbase/README.md
+++ b/typescript/extend-browserbase/README.md
@@ -12,9 +12,9 @@
 ## GLOSSARY
 
 - **act**: perform UI actions from natural language prompts (click, scroll, navigate)
-  Docs → https://docs.stagehand.dev/basics/act
+  Docs → https://docs.stagehand.dev/v4/basics/act
 - **observe**: find and return interactive elements on the page matching a description, without performing actions. Used here to locate all individual download buttons before clicking them.
-  Docs → https://docs.stagehand.dev/basics/observe
+  Docs → https://docs.stagehand.dev/v4/basics/observe
 - **Browserbase Downloads**: When files are downloaded during a browser session, Browserbase captures and stores them. Files are retrieved via the Session Downloads API as a ZIP archive.
   Docs → https://docs.browserbase.com/features/downloads
 - **Extend AI extraction**: A configurable document extraction pipeline that parses files against a JSON schema and returns structured data. Config can be passed inline or via a saved extractor resource.
@@ -33,7 +33,7 @@
 
 ## EXPECTED OUTPUT
 
-- Initializes Stagehand session with Browserbase and opens the live view link
+- Initializes Stagehand V4 with Browserbase; Live View remains available in the Sessions dashboard
 - Navigates to the expense portal and finds all per-receipt download links via observe
 - Clicks each download button; Browserbase captures files
 - After closing the session, polls for the session's download ZIP and extracts to `output/documents/`
@@ -45,7 +45,7 @@
 - "Cannot find module": ensure pnpm install completed in the extend-browserbase directory
 - Missing credentials: verify .env contains BROWSERBASE_API_KEY
 - Download timeout: increase `retryForSeconds` parameter in `saveDownloadsWithRetry` if downloads take longer than 60 seconds
-- Empty ZIP file: ensure downloads were actually triggered (check live view link to debug)
+- Empty ZIP file: ensure downloads were actually triggered (inspect the session in the Browserbase dashboard)
 - Rate limiting on Extend: the script retries with exponential backoff on 429 errors, but very large batches may need the batch size reduced from 9
 - Find more information on your Browserbase dashboard → https://www.browserbase.com/sign-in
 

--- a/typescript/extend-browserbase/README.md
+++ b/typescript/extend-browserbase/README.md
@@ -64,7 +64,7 @@
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
 📚 Browserbase Downloads: https://docs.browserbase.com/features/downloads
 📚 Extend AI: https://docs.extend.app
 🎮 Browserbase: https://www.browserbase.com

--- a/typescript/extend-browserbase/index.ts
+++ b/typescript/extend-browserbase/index.ts
@@ -2,12 +2,18 @@
 
 import "dotenv/config";
 import { Browserbase } from "@browserbasehq/sdk";
-import { Stagehand } from "@browserbasehq/stagehand";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 import fs from "fs";
 import path from "path";
 import AdmZip from "adm-zip";
 import { ExtendClient } from "extend-ai";
 import open from "open";
+
+async function uploadStagehandExtension(bb: Browserbase): Promise<{ id: string }> {
+  const stagehandEntry = import.meta.resolve("@browserbasehq/stagehand");
+  const archive = new URL("./assets/stagehand-extension.zip", stagehandEntry);
+  return bb.extensions.create({ file: fs.createReadStream(archive) });
+}
 
 // Opens a URL in the default browser (cross-platform)
 function openInBrowser(url: string): void {
@@ -259,7 +265,7 @@ async function parseReceiptsWithExtend(filePaths: string[]): Promise<void> {
           const blob = new Blob([fileBuffer]);
           const uploadResponse = await client.files.upload(
             blob as Parameters<typeof client.files.upload>[0],
-            { maxRetries: 4 },
+            {},
           );
           const fileId = uploadResponse.id;
 
@@ -346,24 +352,29 @@ async function main(): Promise<void> {
     apiKey: process.env.BROWSERBASE_API_KEY as string,
   });
 
+  const extension = await uploadStagehandExtension(bb);
+  const session = await bb.sessions.create({ extensionId: extension.id });
+
   // Initialize Stagehand with Browserbase for cloud-based browser automation
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 1,
-    // 0 = errors only, 1 = info, 2 = debug
-    // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
-    // https://docs.stagehand.dev/configuration/logging
-    model: "google/gemini-2.5-flash", // Routed through Model Gateway
+  const browser = await browserbase.connect({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+    sessionId: session.id,
+    extensionId: extension.id,
+  });
+  const stagehand = await Stagehand.create({
+    browser: browser,
+    model: { modelName: "google/gemini-2.5-flash" },
+    logging: { level: "info" },
   });
 
   let sessionId: string | undefined;
 
   try {
     // Initialize browser session to start automation
-    await stagehand.init();
+
     console.log("Stagehand initialized successfully!");
-    const page = stagehand.context.pages()[0];
-    sessionId = stagehand.browserbaseSessionId;
+    const page = (await browser.context.pages())[0];
+    sessionId = session.id;
 
     // Get live view URL for monitoring browser session in real-time
     if (sessionId) {
@@ -380,7 +391,7 @@ async function main(): Promise<void> {
 
     // Use observe to find all individual download buttons (not the Download All button)
     console.log("\nFinding all individual download buttons...");
-    const downloadButtons = await stagehand.observe(
+    const { data: downloadButtons } = await stagehand.observe(
       "Find all the small Download links on individual receipt cards.",
     );
 
@@ -394,7 +405,7 @@ async function main(): Promise<void> {
       try {
         await stagehand.act(action, { page });
         successCount++;
-      } catch (clickError) {
+      } catch (_clickError) {
         // If click fails, scroll element into view and retry
         console.log(`  Could not click download button ${i + 1}, trying to scroll and retry...`);
         try {
@@ -422,6 +433,8 @@ async function main(): Promise<void> {
 
       // Close the browser session before fetching downloads
       await stagehand.close();
+      await browser.close();
+      await bb.extensions.delete(extension.id, { headers: { "Content-Type": null } });
 
       // Wait for session to finalize downloads before polling
       await new Promise((resolve) => setTimeout(resolve, 2000));
@@ -452,6 +465,8 @@ async function main(): Promise<void> {
     console.error("Error during automation:", error);
     try {
       await stagehand.close();
+      await browser.close();
+      await bb.extensions.delete(extension.id, { headers: { "Content-Type": null } });
     } catch {
       // Ignore close errors during cleanup
     }
@@ -465,6 +480,6 @@ main().catch((err) => {
   console.error("  - Check .env file has BROWSERBASE_API_KEY");
   console.error("  - Add EXTEND_API_KEY to .env to enable receipt parsing with Extend AI");
   console.error("  - Verify internet connection and expense portal accessibility");
-  console.error("Docs: https://docs.stagehand.dev/v3/first-steps/introduction");
+  console.error("Docs: https://docs.stagehand.dev/v4/first-steps/introduction");
   process.exit(1);
 });

--- a/typescript/extend-browserbase/index.ts
+++ b/typescript/extend-browserbase/index.ts
@@ -7,20 +7,6 @@ import fs from "fs";
 import path from "path";
 import AdmZip from "adm-zip";
 import { ExtendClient } from "extend-ai";
-import open from "open";
-
-async function uploadStagehandExtension(bb: Browserbase): Promise<{ id: string }> {
-  const stagehandEntry = import.meta.resolve("@browserbasehq/stagehand");
-  const archive = new URL("./assets/stagehand-extension.zip", stagehandEntry);
-  return bb.extensions.create({ file: fs.createReadStream(archive) });
-}
-
-// Opens a URL in the default browser (cross-platform)
-function openInBrowser(url: string): void {
-  open(url).catch(() => {
-    console.log(`Could not auto-open: ${url}`);
-  });
-}
 
 // Polls Browserbase API for completed downloads with retry logic.
 // Retries every 2 seconds until downloads are ready or timeout is reached.
@@ -352,36 +338,24 @@ async function main(): Promise<void> {
     apiKey: process.env.BROWSERBASE_API_KEY as string,
   });
 
-  const extension = await uploadStagehandExtension(bb);
-  const session = await bb.sessions.create({ extensionId: extension.id });
-
-  // Initialize Stagehand with Browserbase for cloud-based browser automation
-  const browser = await browserbase.connect({
+  // V4's browser factory provisions and owns the Stagehand extension.
+  const browser = await browserbase.launch({
     apiKey: process.env.BROWSERBASE_API_KEY!,
-    sessionId: session.id,
-    extensionId: extension.id,
   });
+  const sessionId = browser.sessionId;
+  if (!sessionId) throw new Error("Browserbase launch did not return a session ID");
   const stagehand = await Stagehand.create({
     browser: browser,
     model: { modelName: "google/gemini-2.5-flash" },
     logging: { level: "info" },
   });
 
-  let sessionId: string | undefined;
-
   try {
     // Initialize browser session to start automation
 
     console.log("Stagehand initialized successfully!");
     const page = (await browser.context.pages())[0];
-    sessionId = session.id;
-
-    // Get live view URL for monitoring browser session in real-time
-    if (sessionId) {
-      const liveViewLinks = await bb.sessions.debug(sessionId);
-      console.log(`Live View Link: ${liveViewLinks.debuggerFullscreenUrl}`);
-      openInBrowser(liveViewLinks.debuggerFullscreenUrl);
-    }
+    console.log("Live View is available in the Browserbase Sessions dashboard");
 
     // Navigate to the expense portal where receipts are hosted
     console.log("\nNavigating to expense portal...");
@@ -394,6 +368,7 @@ async function main(): Promise<void> {
     const { data: downloadButtons } = await stagehand.observe(
       "Find all the small Download links on individual receipt cards.",
     );
+    if (downloadButtons.length === 0) throw new Error("No receipt download links were found");
 
     // Click each download button using observe → act pattern
     // Pass the observed action directly to act for precise element targeting
@@ -426,15 +401,17 @@ async function main(): Promise<void> {
     console.log(
       `\nDownload clicks completed! (${successCount}/${downloadButtons.length} successful)`,
     );
+    if (successCount !== downloadButtons.length) {
+      throw new Error(`${downloadButtons.length - successCount} receipt downloads failed`);
+    }
 
     // Retrieve all downloads triggered during this session from Browserbase API
     if (sessionId) {
       console.log("\nRetrieving downloads from Browserbase...");
 
       // Close the browser session before fetching downloads
-      await stagehand.close();
-      await browser.close();
-      await bb.extensions.delete(extension.id, { headers: { "Content-Type": null } });
+      await stagehand.close().catch((error) => console.warn("Stagehand cleanup warning:", error));
+      await browser.close().catch((error) => console.warn("Browser cleanup warning:", error));
 
       // Wait for session to finalize downloads before polling
       await new Promise((resolve) => setTimeout(resolve, 2000));
@@ -457,6 +434,7 @@ async function main(): Promise<void> {
         }
       } catch (downloadError) {
         console.error("Download retrieval failed:", downloadError);
+        throw downloadError;
       }
     }
 
@@ -464,9 +442,8 @@ async function main(): Promise<void> {
   } catch (error) {
     console.error("Error during automation:", error);
     try {
-      await stagehand.close();
-      await browser.close();
-      await bb.extensions.delete(extension.id, { headers: { "Content-Type": null } });
+      await stagehand.close().catch(() => undefined);
+      await browser.close().catch(() => undefined);
     } catch {
       // Ignore close errors during cleanup
     }

--- a/typescript/extend-browserbase/package.json
+++ b/typescript/extend-browserbase/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@browserbasehq/sdk": "^2.9.0",
-    "@browserbasehq/stagehand": "github:browserbase/stagehand#089f2aaeaea75696685949e0835aece95db54358&path:/packages/sdk-ts",
+    "@browserbasehq/stagehand": "github:browserbase/stagehand#4186c7d98d2f325b6fc85b3f760111e6c390d703&path:/packages/sdk-ts",
     "adm-zip": "^0.5.16",
     "dotenv": "^17.2.4",
     "extend-ai": "^1.0.2",

--- a/typescript/extend-browserbase/package.json
+++ b/typescript/extend-browserbase/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@browserbasehq/sdk": "^2.9.0",
-    "@browserbasehq/stagehand": "github:browserbase/stagehand#4186c7d98d2f325b6fc85b3f760111e6c390d703&path:/packages/sdk-ts",
+    "@browserbasehq/stagehand": "4.0.0",
     "adm-zip": "^0.5.16",
     "dotenv": "^17.2.4",
     "extend-ai": "^1.0.2",
@@ -21,7 +21,6 @@
     "typescript": "^5.9.3"
   },
   "packageManager": "pnpm@10.24.0",
-  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand@4.0.0 after it is published.",
   "engines": {
     "node": ">=22.18.0"
   }

--- a/typescript/extend-browserbase/package.json
+++ b/typescript/extend-browserbase/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@browserbasehq/sdk": "^2.9.0",
-    "@browserbasehq/stagehand": "latest",
+    "@browserbasehq/stagehand": "github:browserbase/stagehand#089f2aaeaea75696685949e0835aece95db54358&path:/packages/sdk-ts",
     "adm-zip": "^0.5.16",
     "dotenv": "^17.2.4",
     "extend-ai": "^1.0.2",
@@ -20,5 +20,9 @@
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   },
-  "packageManager": "pnpm@9.0.0"
+  "packageManager": "pnpm@10.24.0",
+  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand@4.0.0 after it is published.",
+  "engines": {
+    "node": ">=22.18.0"
+  }
 }

--- a/typescript/form-filling/README.md
+++ b/typescript/form-filling/README.md
@@ -4,32 +4,29 @@
 
 - Goal: showcase how to automate form filling with Stagehand and Browserbase.
 - Smart Form Automation: dynamically fill contact forms with variable-driven data.
-- Field Detection: analyze page structure with `observe` before interacting with fields.
-- AI-Powered Interaction: leverage Stagehand to map inputs to the right fields reliably.
+- Deterministic Mapping: fill the known contact-form field names with V4 page APIs.
+- Outcome Verification: read every input and dropdown value back from the browser before reporting success.
   Docs → https://docs.browserbase.com/fundamentals/create-browser-session
 
 ## GLOSSARY
 
-- act: perform UI actions from a prompt (type, click, fill forms)
-  Docs → https://docs.stagehand.dev/basics/act
-- observe: analyze a page and return selectors or action plans before executing
-  Docs → https://docs.stagehand.dev/basics/observe
-- variable substitution: inject dynamic values into actions using `%variable%` syntax
+- page APIs: use the V4 browser page directly for stable form fields
+  Docs → https://docs.stagehand.dev/v4/reference/page
 
 ## QUICKSTART
 
-1.  cd form-fill-template
-2.  npm install
-3.  cp .env.example .env
-4.  Add your Browserbase API key and Project ID to .env
-5.  npm start
+1. cd form-filling
+2. npm install
+3. cp .env.example .env
+4. Add your Browserbase API key and Project ID to .env
+5. npm start
 
 ## EXPECTED OUTPUT
 
 - Initializes Stagehand session with Browserbase
 - Navigates to contact form page
-- Analyzes available form fields using observe
-- Fills form with sample data using variable substitution
+- Fills the known form fields and help dropdown with sample data
+- Reads every value back to verify the browser retained it
 - Closes both the Stagehand instance and browser handle after the workflow
 - Closes session cleanly
 
@@ -37,8 +34,7 @@
 
 - "Cannot find module": ensure all dependencies are installed
 - Missing credentials: verify .env contains all required API keys
-- Form detection: ensure target page has fillable form fields
-- Variable mismatch: ensure variable names in action match variables object
+- Field mismatch: update the stable field-name mapping if the contact form changes
 - Network issues: check internet connection and website accessibility
 
 ## USE CASES
@@ -49,7 +45,7 @@
 
 ## NEXT STEPS
 
-• Wire in data sources: Load variables from CSV/JSON/CRM, map fields via observe, and support per-site field aliases.
+• Wire in data sources: Load variables from CSV/JSON/CRM and add per-site field mappings.
 • Submit & verify: Enable submit, capture success toasts/emails, take screenshots, and retry on validation errors.
 • Handle complex widgets: Add file uploads, multi-step flows, dropdown/radio/datepickers, and basic anti-bot tactics (delays/proxies).
 

--- a/typescript/form-filling/README.md
+++ b/typescript/form-filling/README.md
@@ -30,7 +30,7 @@
 - Navigates to contact form page
 - Analyzes available form fields using observe
 - Fills form with sample data using variable substitution
-- Displays session recording link for monitoring
+- Closes both the Stagehand instance and browser handle after the workflow
 - Closes session cleanly
 
 ## COMMON PITFALLS
@@ -55,7 +55,7 @@
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground
 🔧 Templates: https://www.browserbase.com/templates

--- a/typescript/form-filling/index.ts
+++ b/typescript/form-filling/index.ts
@@ -39,45 +39,69 @@ async function main() {
       timeout: 60000, // Extended timeout for reliable page loading.
     });
 
-    // Single observe call to plan all form filling
-    const { data: formFields } = await stagehand.observe(
-      "Find form fields for: first name, last name, company, job title, email, message",
-    );
+    // The form has stable names, so deterministic locators are the most reliable
+    // V4 choice. Reserve act/observe for pages whose structure is not known.
+    const fields = [
+      ["firstName", firstName],
+      ["lastName", lastName],
+      ["companyName", company],
+      ["jobTitle", jobTitle],
+      ["email", email],
+      ["project", message],
+    ] as const;
+    const formData = Object.fromEntries(fields);
+    await page.evaluate((values: Record<string, string>) => {
+      for (const [name, value] of Object.entries(values)) {
+        const field = document.querySelector<HTMLInputElement | HTMLTextAreaElement>(
+          `[name="${name}"]`,
+        );
+        if (!field) throw new Error(`Missing form field: ${name}`);
+        const prototype =
+          field instanceof HTMLTextAreaElement
+            ? HTMLTextAreaElement.prototype
+            : HTMLInputElement.prototype;
+        const setter = Object.getOwnPropertyDescriptor(prototype, "value")?.set;
+        setter?.call(field, value);
+        field.dispatchEvent(new Event("input", { bubbles: true }));
+        field.dispatchEvent(new Event("change", { bubbles: true }));
+      }
 
-    // Execute all actions without LLM calls
-    for (const field of formFields) {
-      // Match field to data based on description
-      let value = "";
-      const desc = field.description.toLowerCase();
+      const select = document.querySelector<HTMLSelectElement>('[name="helpOption"]');
+      if (!select) throw new Error("Missing form field: helpOption");
+      const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, "value")?.set;
+      setter?.call(select, "demo");
+      select.dispatchEvent(new Event("input", { bubbles: true }));
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    }, formData);
 
-      if (desc.includes("first name")) value = firstName;
-      else if (desc.includes("last name")) value = lastName;
-      else if (desc.includes("company")) value = company;
-      else if (desc.includes("job title")) value = jobTitle;
-      else if (desc.includes("email")) value = email;
-      else if (desc.includes("message")) value = message;
-
-      if (value) {
-        await stagehand.act({
-          ...field,
-          arguments: [value],
-        });
+    // Verify the browser's actual form state instead of treating action
+    // completion as proof that every value was entered.
+    for (const [name, expected] of fields) {
+      const actual = await page.evaluate(
+        (fieldName: string) =>
+          document.querySelector<HTMLInputElement | HTMLTextAreaElement>(`[name="${fieldName}"]`)
+            ?.value ?? "",
+        name,
+      );
+      if (actual !== expected) {
+        throw new Error(`Form verification failed for ${name}`);
       }
     }
-
-    // Language choice in Stagehand act() is crucial for reliable automation.
-    // Use "click" for dropdown interactions rather than "select"
-    await stagehand.act("Click on the How Can we help? dropdown");
-    await stagehand.act("Click on the first option from the dropdown");
-    // await stagehand.act("Select the first option from the dropdown"); // Less reliable than "click"
+    const helpOption = await page.evaluate(
+      () => document.querySelector<HTMLSelectElement>('[name="helpOption"]')?.value ?? "",
+    );
+    if (helpOption !== "demo") {
+      throw new Error("Form verification failed for helpOption");
+    }
 
     // Uncomment the line below if you want to submit the form
     // await stagehand.act("Click the submit button");
 
     console.log("Form filled successfully! Waiting 3 seconds...");
-    await page.waitForTimeout(30000);
+    await page.waitForTimeout(3000);
   } catch (error) {
     console.error(`Error during form filling: ${error}`);
+    throw error;
   } finally {
     // Always close session to release resources and clean up.
     await stagehand.close();

--- a/typescript/form-filling/index.ts
+++ b/typescript/form-filling/index.ts
@@ -1,7 +1,7 @@
 // Stagehand + Browserbase: Form Filling Automation - See README.md for full documentation
 
 import "dotenv/config";
-import { Stagehand } from "@browserbasehq/stagehand";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 
 // Form data variables - using random/fake data for testing
 // Set your own variables below to customize the form submission
@@ -17,21 +17,20 @@ async function main() {
   console.log("Starting Form Filling Example...");
 
   // Initialize Stagehand with Browserbase for cloud-based browser automation.
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    model: "openai/gpt-4.1",
-    verbose: 1,
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+  });
+  const stagehand = await Stagehand.create({
+    browser: browser,
+    model: { modelName: "openai/gpt-4.1" },
+    logging: { level: "info" },
   });
 
   try {
     // Initialize browser session to start automation.
-    await stagehand.init();
-    console.log("Stagehand initialized successfully!");
-    console.log(
-      `Live View Link: https://browserbase.com/sessions/${stagehand.browserbaseSessionID}`,
-    );
 
-    const page = stagehand.context.pages()[0];
+    console.log("Stagehand initialized successfully!");
+    const page = (await browser.context.pages())[0];
 
     // Navigate to contact page with extended timeout for slow-loading sites.
     console.log("Navigating to Browserbase contact page...");
@@ -41,7 +40,7 @@ async function main() {
     });
 
     // Single observe call to plan all form filling
-    const formFields = await stagehand.observe(
+    const { data: formFields } = await stagehand.observe(
       "Find form fields for: first name, last name, company, job title, email, message",
     );
 
@@ -82,6 +81,7 @@ async function main() {
   } finally {
     // Always close session to release resources and clean up.
     await stagehand.close();
+    await browser.close();
     console.log("Session closed successfully");
   }
 }
@@ -91,6 +91,6 @@ main().catch((err) => {
   console.error("Common issues:");
   console.error("  - Check .env file has BROWSERBASE_API_KEY");
   console.error("  - Ensure form fields are available on the contact page");
-  console.error("Docs: https://docs.stagehand.dev/v3/first-steps/introduction");
+  console.error("Docs: https://docs.stagehand.dev/v4/first-steps/introduction");
   process.exit(1);
 });

--- a/typescript/gemini-3-flash/README.md
+++ b/typescript/gemini-3-flash/README.md
@@ -1,53 +1,31 @@
-# Stagehand + Browserbase: Gemini 3 Flash Agent Example
+# Stagehand V4 + Browserbase: Gemini 3 Flash Research
 
 ## AT A GLANCE
 
-- Goal: demonstrate autonomous web browsing using Google's Gemini 3 Flash with Stagehand and Browserbase.
-- Uses Stagehand Agent to automate complex workflows with AI powered browser agents.
-- Leverages Gemini 3 Flash model for autonomous web interaction and decision-making.
-
-## GLOSSARY
-
-- agent: create an autonomous AI agent that can execute complex multi-step tasks
-  Docs → https://docs.stagehand.dev/basics/agent#what-is-agent
+- Goal: use Gemini 3 Flash through Browserbase Model Gateway for a Stagehand V4 research flow.
+- Application code navigates to search results and `extract()` returns the answer.
+- Stagehand V4 intentionally has no `agent()` API; multi-step control flow stays in the application.
 
 ## QUICKSTART
 
-1.  npm install
-2.  cp .env.example .env
-3.  Add your Browserbase API key to .env
-4.  npm start
+1. `pnpm install`
+2. `cp .env.example .env`
+3. Add `BROWSERBASE_API_KEY` to `.env`
+4. `pnpm start`
 
 ## EXPECTED OUTPUT
 
-- Initializes Stagehand session with Browserbase
-- Navigates to Google search engine
-- Executes autonomous search and data extraction task
-- Displays live session link for monitoring
-- Returns structured results or completion status
-- Closes session cleanly
-
-## COMMON PITFALLS
-
-- "Cannot find module": ensure all dependencies are installed
-- Missing credentials: verify .env contains BROWSERBASE_API_KEY
-
-## USE CASES
-
-• Autonomous research: Let AI agents independently research topics, gather information, and compile reports without manual intervention.
-• Complex web workflows: Automate multi-step processes that require decision-making, form filling, and data extraction across multiple pages.
-• Content discovery: Search for specific information, verify data accuracy, and cross-reference sources autonomously.
-
-## NEXT STEPS
-
-• Customize instructions: Modify the instruction variable to test different autonomous tasks and scenarios.
-• Add error handling: Implement retry logic, fallback strategies, and better error recovery for failed agent actions.
-• Extend capabilities: Add support for file downloads, form submissions, and more complex interaction patterns.
+- Launches a Browserbase browser
+- Creates Stagehand with `google/gemini-3-flash-preview`
+- Opens results for the configured research question
+- Prints the extracted answer
+- Closes Stagehand and the browser handle
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+📚 Stagehand V4 Docs: https://docs.stagehand.dev/v4/first-steps/introduction
+📚 Stagehand Extract: https://docs.stagehand.dev/v4/basics/extract
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground
 🔧 Templates: https://www.browserbase.com/templates
-📧 Need help? support@browserbase.com
+💬 Discord: http://stagehand.dev/discord

--- a/typescript/gemini-3-flash/README.md
+++ b/typescript/gemini-3-flash/README.md
@@ -1,31 +1,30 @@
-# Stagehand V4 + Browserbase: Gemini 3 Flash Research
+# Stagehand Code Mode + Vercel AI SDK: Gemini 3 Flash Agent
 
 ## AT A GLANCE
 
-- Goal: use Gemini 3 Flash through Browserbase Model Gateway for a Stagehand V4 research flow.
-- Application code navigates to search results and `extract()` returns the answer.
-- Stagehand V4 intentionally has no `agent()` API; multi-step control flow stays in the application.
+- Goal: run a Gemini 3 Flash research agent with a Browserbase browser.
+- Vercel AI SDK owns the agent loop; Stagehand code mode supplies `code_execute` over MCP.
+- `STAGEHAND_MODEL_NAME` is passed to the code-mode process so Stagehand AI primitives also use Gemini.
 
 ## QUICKSTART
 
-1. `pnpm install`
-2. `cp .env.example .env`
-3. Add `BROWSERBASE_API_KEY` to `.env`
+1. `cd gemini-3-flash`
+2. `pnpm install`
+3. Add `BROWSERBASE_API_KEY` and `AI_GATEWAY_API_KEY` to `.env`
 4. `pnpm start`
+
+Set `AGENT_MODEL` to override the outer agent's default `google/gemini-3-flash-preview` model.
 
 ## EXPECTED OUTPUT
 
-- Launches a Browserbase browser
-- Creates Stagehand with `google/gemini-3-flash-preview`
-- Opens results for the configured research question
-- Prints the extracted answer
-- Closes Stagehand and the browser handle
+- The agent uses `code_execute` to browse, research the configured question, and return cited findings.
+- Closing the MCP client closes Stagehand and its Browserbase browser.
 
-## HELPFUL RESOURCES
+## SAFETY
 
-📚 Stagehand V4 Docs: https://docs.stagehand.dev/v4/first-steps/introduction
-📚 Stagehand Extract: https://docs.stagehand.dev/v4/basics/extract
-🎮 Browserbase: https://www.browserbase.com
-💡 Try it out: https://www.browserbase.com/playground
-🔧 Templates: https://www.browserbase.com/templates
-💬 Discord: http://stagehand.dev/discord
+Code mode executes model-authored JavaScript and is not itself a security sandbox. Isolate it when browsing untrusted content.
+
+## RESOURCES
+
+- Stagehand: https://docs.stagehand.dev
+- Vercel AI SDK agents: https://ai-sdk.dev/docs/agents/building-agents

--- a/typescript/gemini-3-flash/index.ts
+++ b/typescript/gemini-3-flash/index.ts
@@ -5,7 +5,8 @@ import { createMCPClient } from "@ai-sdk/mcp";
 import { Experimental_StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
 import { ToolLoopAgent, stepCountIs } from "ai";
 
-const instruction = `Search for the next visible solar eclipse in North America and its expected date, and what about the one after that.`;
+const today = new Date().toISOString().slice(0, 10);
+const instruction = `As of ${today}, search live sources for the next visible solar eclipse in North America and its expected date, then the one after that. Cite the source URLs you actually opened.`;
 
 const childEnv = Object.fromEntries(
   Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
@@ -27,13 +28,31 @@ async function main() {
     const agent = new ToolLoopAgent({
       model: process.env.AGENT_MODEL ?? "google/gemini-3-flash-preview",
       instructions:
-        "You are a browser research agent powered by Gemini. Use code_execute for all browser work, prefer deterministic page APIs, and return source URLs for factual claims.",
+        "You are a browser research agent powered by Gemini. Use code_execute for all browser work, prefer deterministic page APIs, and return source URLs for factual claims. Never cite a URL unless you navigated directly to it in the browser.",
       tools,
-      stopWhen: stepCountIs(20),
+      prepareStep: ({ stepNumber }) =>
+        stepNumber >= 10
+          ? {
+              activeTools: [],
+              toolChoice: "none",
+              instructions:
+                "Return the evidence-backed answer now. Include only source URLs you opened directly. Do not call another tool.",
+            }
+          : undefined,
+      stopWhen: stepCountIs(12),
     });
 
     console.log("Executing instruction:", instruction);
     const result = await agent.generate({ prompt: instruction });
+    const sourceUrls = new Set(result.text.match(/https?:\/\/\S+/g) ?? []);
+    const futureYears = new Set(
+      [...result.text.matchAll(/\b20\d{2}\b/g)]
+        .map((match) => Number(match[0]))
+        .filter((year) => year >= Number(today.slice(0, 4))),
+    );
+    if (!result.text.trim() || sourceUrls.size < 2 || futureYears.size < 2) {
+      throw new Error("Agent did not return two future eclipse dates with opened source URLs");
+    }
     console.log(result.text);
   } finally {
     await mcpClient.close();

--- a/typescript/gemini-3-flash/index.ts
+++ b/typescript/gemini-3-flash/index.ts
@@ -1,6 +1,6 @@
 // Stagehand + Browserbase: Gemini 3 Flash Example - See README.md for full documentation
 
-import { Stagehand } from "@browserbasehq/stagehand";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 
 // ============================================================================
 // EXAMPLE INSTRUCTIONS - Choose one to test different scenarios
@@ -21,66 +21,46 @@ const instruction = `Search for the next visible solar eclipse in North America 
 // ============================================================================
 
 async function main() {
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    // model: "google/gemini-2.5-pro", // this is the model Stagehand uses for act, observe, extract (not agent)
-    verbose: 1,
-    // 0 = errors only, 1 = info, 2 = debug
-    // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
-    // https://docs.stagehand.dev/configuration/logging
-    browserbaseSessionCreateParams: {
-      proxies: true, // Using proxies will give the agent a better chance of success - requires Developer Plan or higher, comment out if you don't have access
-      region: "us-west-2",
-      browserSettings: {
-        blockAds: true,
-        viewport: {
-          width: 1288,
-          height: 711,
-        },
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+    proxies: true,
+    region: "us-west-2",
+    browserSettings: {
+      blockAds: true,
+      viewport: {
+        width: 1288,
+        height: 711,
       },
     },
+  });
+  const stagehand = await Stagehand.create({
+    browser,
+    model: { modelName: "google/gemini-3-flash-preview" },
+    logging: { level: "info" },
   });
 
   try {
     // Initialize browser session to start automation.
-    await stagehand.init();
-    console.log("Stagehand initialized successfully!");
-    console.log(
-      `Live View Link: https://browserbase.com/sessions/${stagehand.browserbaseSessionId}`,
-    );
 
-    const page = stagehand.context.pages()[0];
+    console.log("Stagehand initialized successfully!");
+    const page = (await browser.context.pages())[0];
 
     // Navigate to search engine with extended timeout for slow-loading sites.
-    await page.goto("https://www.google.com/", {
+    await page.goto(`https://www.google.com/search?q=${encodeURIComponent(instruction)}`, {
       waitUntil: "domcontentloaded",
     });
 
-    // Create agent with Gemini 3 Flash for autonomous web browsing.
-    const agent = stagehand.agent({
-      model: "google/gemini-3-flash-preview", // Routed through Model Gateway
-      systemPrompt: `You are a helpful assistant that can use a web browser.
-      You are currently on the following page: ${page.url()}.
-      Do not ask follow up questions, the user will trust your judgement. If you are getting blocked on google, try another search engine.`,
-    });
-
     console.log("Executing instruction:", instruction);
-    const result = await agent.execute({
-      instruction: instruction,
-      maxSteps: 30,
-      highlightCursor: true,
-    });
-
-    if (result.success === true) {
-      console.log("Task completed successfully!");
-      console.log("Result:", result);
-    } else {
-      console.log("Task failed or was incomplete");
-    }
+    const { data: result } = await stagehand.extract(
+      "Answer the research question using the visible search results and include source URLs",
+    );
+    console.log("Task completed successfully!");
+    console.log("Result:", result.extraction);
   } catch (error) {
     console.error("Error executing Gemini 3 Flash agent:", error);
   } finally {
     await stagehand.close();
+    await browser.close();
     console.log("Session closed successfully");
   }
 }
@@ -89,6 +69,6 @@ main().catch((err) => {
   console.error("Error in Gemini 3 Flash agent example:", err);
   console.error("Common issues:");
   console.error("  - Check .env file has BROWSERBASE_API_KEY");
-  console.error("Docs: https://docs.stagehand.dev/v3/first-steps/introduction");
+  console.error("Docs: https://docs.stagehand.dev/v4/first-steps/introduction");
   process.exit(1);
 });

--- a/typescript/gemini-3-flash/index.ts
+++ b/typescript/gemini-3-flash/index.ts
@@ -1,74 +1,47 @@
-// Stagehand + Browserbase: Gemini 3 Flash Example - See README.md for full documentation
+// Stagehand code mode + Vercel AI SDK: Gemini 3 Flash agent example
 
-import { browserbase, Stagehand } from "@browserbasehq/stagehand";
+import "dotenv/config";
+import { createMCPClient } from "@ai-sdk/mcp";
+import { Experimental_StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
+import { ToolLoopAgent, stepCountIs } from "ai";
 
-// ============================================================================
-// EXAMPLE INSTRUCTIONS - Choose one to test different scenarios
-// ============================================================================
-
-// Example 1: Learning Plan Creation
-// const instruction = `I want to learn more about Sourdough Bread Making. It's my first time learning about it, and want to get a good grasp by investing 1 hour a day for the next 2 months. Go find online courses/resources, create a plan cross-referencing the time I want to invest with the modules/timelines of the courses and return the plan`;
-
-// Example 2: Flight Search
-// const instruction = `Use flights.google.com to find the lowest fare from all eligible one-way flights for 1 adult from JFK to Heathrow in the next 30 days.`;
-
-// Example 3: Solar Eclipse Research
 const instruction = `Search for the next visible solar eclipse in North America and its expected date, and what about the one after that.`;
 
-// Example 4: GitHub PR Verification
-// const instruction = `Find the most recently opened non-draft PR on Github for Browserbase's Stagehand project and make sure the combination-evals in the PR validation passed.`;
-
-// ============================================================================
+const childEnv = Object.fromEntries(
+  Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+);
 
 async function main() {
-  const browser = await browserbase.launch({
-    apiKey: process.env.BROWSERBASE_API_KEY!,
-    proxies: true,
-    region: "us-west-2",
-    browserSettings: {
-      blockAds: true,
-      viewport: {
-        width: 1288,
-        height: 711,
-      },
-    },
-  });
-  const stagehand = await Stagehand.create({
-    browser,
-    model: { modelName: "google/gemini-3-flash-preview" },
-    logging: { level: "info" },
+  const mcpClient = await createMCPClient({
+    transport: new Experimental_StdioMCPTransport({
+      command: "stagehand-codemode",
+      env: { ...childEnv, STAGEHAND_MODEL_NAME: "google/gemini-3-flash-preview" },
+      stderr: "inherit",
+    }),
   });
 
   try {
-    // Initialize browser session to start automation.
+    const tools = await mcpClient.tools();
+    if (!tools.code_execute) throw new Error("Stagehand code mode did not expose code_execute");
 
-    console.log("Stagehand initialized successfully!");
-    const page = (await browser.context.pages())[0];
-
-    // Navigate to search engine with extended timeout for slow-loading sites.
-    await page.goto(`https://www.google.com/search?q=${encodeURIComponent(instruction)}`, {
-      waitUntil: "domcontentloaded",
+    const agent = new ToolLoopAgent({
+      model: process.env.AGENT_MODEL ?? "google/gemini-3-flash-preview",
+      instructions:
+        "You are a browser research agent powered by Gemini. Use code_execute for all browser work, prefer deterministic page APIs, and return source URLs for factual claims.",
+      tools,
+      stopWhen: stepCountIs(20),
     });
 
     console.log("Executing instruction:", instruction);
-    const { data: result } = await stagehand.extract(
-      "Answer the research question using the visible search results and include source URLs",
-    );
-    console.log("Task completed successfully!");
-    console.log("Result:", result.extraction);
-  } catch (error) {
-    console.error("Error executing Gemini 3 Flash agent:", error);
+    const result = await agent.generate({ prompt: instruction });
+    console.log(result.text);
   } finally {
-    await stagehand.close();
-    await browser.close();
-    console.log("Session closed successfully");
+    await mcpClient.close();
   }
 }
 
-main().catch((err) => {
-  console.error("Error in Gemini 3 Flash agent example:", err);
-  console.error("Common issues:");
-  console.error("  - Check .env file has BROWSERBASE_API_KEY");
-  console.error("Docs: https://docs.stagehand.dev/v4/first-steps/introduction");
+main().catch((error) => {
+  console.error("Error in Gemini 3 Flash agent example:", error);
+  console.error("Check BROWSERBASE_API_KEY and AI_GATEWAY_API_KEY in .env");
   process.exit(1);
 });

--- a/typescript/gemini-3-flash/package.json
+++ b/typescript/gemini-3-flash/package.json
@@ -1,9 +1,8 @@
 {
-  "name": "exa-browserbase",
+  "name": "gemini-3-flash-template",
   "version": "1.0.0",
-  "description": "Stagehand + Browserbase + Exa: AI-Powered Job Search and Application",
+  "private": true,
   "type": "module",
-  "main": "index.ts",
   "scripts": {
     "start": "tsx index.ts"
   },
@@ -11,13 +10,12 @@
     "@ai-sdk/mcp": "^2.0.29",
     "@browserbasehq/stagehand-codemode": "github:browserbase/stagehand#54302fc5f13be5ad8e717d8e1388502de22be2ed&path:/packages/integrations",
     "ai": "^7.0.58",
-    "dotenv": "latest",
-    "exa-js": "latest"
+    "dotenv": "^17.4.2"
   },
   "devDependencies": {
-    "@types/node": "latest",
-    "tsx": "latest",
-    "typescript": "latest"
+    "@types/node": "^25.5.0",
+    "tsx": "^4.23.1",
+    "typescript": "^5.9.3"
   },
   "//": "TODO: Replace this commit pin with @browserbasehq/stagehand-codemode@4.0.0 after it is published.",
   "engines": {

--- a/typescript/gemini-cua/README.md
+++ b/typescript/gemini-cua/README.md
@@ -1,36 +1,29 @@
-# Stagehand V4 + Browserbase: Gemini Research Workflow
+# Stagehand Code Mode + Vercel AI SDK: Gemini Browser Agent
 
 ## AT A GLANCE
 
-- Goal: demonstrate a Stagehand V4 research flow using explicit browser navigation and structured extraction.
-- Uses Browserbase Model Gateway with `google/gemini-3-flash-preview`.
-- Stagehand V4 intentionally has no `agent()` API; application code owns the multi-step workflow.
+- Goal: replace the former Stagehand CUA orchestration example with a bring-your-own Gemini agent.
+- Vercel AI SDK `ToolLoopAgent` owns reasoning and tool selection.
+- Stagehand code mode provides one stateful browser tool, `code_execute`.
 
 ## QUICKSTART
 
-1. `pnpm install`
-2. `cp .env.example .env`
-3. Add `BROWSERBASE_API_KEY` to `.env`
+1. `cd gemini-cua`
+2. `pnpm install`
+3. Add `BROWSERBASE_API_KEY` and `AI_GATEWAY_API_KEY` to `.env`
 4. `pnpm start`
 
 ## EXPECTED OUTPUT
 
-- Launches a Browserbase browser with `browserbase.launch()`
-- Creates Stagehand with `Stagehand.create({ browser })`
-- Opens Google results for the configured research question
-- Extracts an answer from the visible results
-- Closes both Stagehand and the browser handle
+- Gemini calls `code_execute` as needed to browse and research the configured question.
+- The final response includes source URLs.
+- Closing the MCP client closes Stagehand and the browser.
 
-## COMMON PITFALLS
+## SAFETY
 
-- Missing credentials: verify `.env` contains `BROWSERBASE_API_KEY`
-- A local browser cannot use Browserbase Model Gateway; configure a model explicitly for local runs
-- V4 primitives return `{ data, metadata }`; read the answer from `result.data`
+Code mode executes model-authored JavaScript and is not itself a security sandbox. Isolate it when prompts or pages are untrusted.
 
-## HELPFUL RESOURCES
+## RESOURCES
 
-📚 Stagehand V4 Docs: https://docs.stagehand.dev/v4/first-steps/introduction
-🎮 Browserbase: https://www.browserbase.com
-💡 Try it out: https://www.browserbase.com/playground
-🔧 Templates: https://www.browserbase.com/templates
-💬 Discord: http://stagehand.dev/discord
+- Stagehand: https://docs.stagehand.dev
+- Vercel AI SDK MCP tools: https://ai-sdk.dev/docs/ai-sdk-core/mcp-tools

--- a/typescript/gemini-cua/README.md
+++ b/typescript/gemini-cua/README.md
@@ -1,55 +1,36 @@
-# Stagehand + Browserbase: Computer Use Agent (CUA) Example
+# Stagehand V4 + Browserbase: Gemini Research Workflow
 
 ## AT A GLANCE
 
-- Goal: demonstrate autonomous web browsing using Google's Computer Use Agent with Stagehand and Browserbase.
-- Uses Stagehand Agent to automate complex workflows with AI powered browser agents
-- Leverages Google's computer-use-preview model for autonomous web interaction and decision-making.
-
-## GLOSSARY
-
-- agent: create an autonomous AI agent that can execute complex multi-step tasks
-  Docs → https://docs.stagehand.dev/basics/agent#what-is-agent
+- Goal: demonstrate a Stagehand V4 research flow using explicit browser navigation and structured extraction.
+- Uses Browserbase Model Gateway with `google/gemini-3-flash-preview`.
+- Stagehand V4 intentionally has no `agent()` API; application code owns the multi-step workflow.
 
 ## QUICKSTART
 
-1.  npm install
-2.  cp .env.example .env
-3.  Add your Browserbase API key and Google API key to .env
-4.  npm start
+1. `pnpm install`
+2. `cp .env.example .env`
+3. Add `BROWSERBASE_API_KEY` to `.env`
+4. `pnpm start`
 
 ## EXPECTED OUTPUT
 
-- Initializes Stagehand session with Browserbase
-- Navigates to Google search engine
-- Executes autonomous search and data extraction task
-- Displays live session link for monitoring
-- Returns structured results or completion status
-- Closes session cleanly
+- Launches a Browserbase browser with `browserbase.launch()`
+- Creates Stagehand with `Stagehand.create({ browser })`
+- Opens Google results for the configured research question
+- Extracts an answer from the visible results
+- Closes both Stagehand and the browser handle
 
 ## COMMON PITFALLS
 
-- "Cannot find module": ensure all dependencies are installed
-- Missing credentials: verify .env contains BROWSERBASE_API_KEY and GOOGLE_API_KEY
-- Google API access: ensure you have access to Google's computer-use-preview model
-
-## USE CASES
-
-• Autonomous research: Let AI agents independently research topics, gather information, and compile reports without manual intervention.
-• Complex web workflows: Automate multi-step processes that require decision-making, form filling, and data extraction across multiple pages.
-• Content discovery: Search for specific information, verify data accuracy, and cross-reference sources autonomously.
-
-## NEXT STEPS
-
-• Customize instructions: Modify the instruction variable to test different autonomous tasks and scenarios.
-• Add error handling: Implement retry logic, fallback strategies, and better error recovery for failed agent actions.
-• Extend capabilities: Add support for file downloads, form submissions, and more complex interaction patterns.
+- Missing credentials: verify `.env` contains `BROWSERBASE_API_KEY`
+- A local browser cannot use Browserbase Model Gateway; configure a model explicitly for local runs
+- V4 primitives return `{ data, metadata }`; read the answer from `result.data`
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+📚 Stagehand V4 Docs: https://docs.stagehand.dev/v4/first-steps/introduction
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground
 🔧 Templates: https://www.browserbase.com/templates
-📧 Need help? support@browserbase.com
 💬 Discord: http://stagehand.dev/discord

--- a/typescript/gemini-cua/index.ts
+++ b/typescript/gemini-cua/index.ts
@@ -5,7 +5,8 @@ import { createMCPClient } from "@ai-sdk/mcp";
 import { Experimental_StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
 import { ToolLoopAgent, stepCountIs } from "ai";
 
-const instruction = `Search for the next visible solar eclipse in North America and its expected date, and what about the one after that.`;
+const today = new Date().toISOString().slice(0, 10);
+const instruction = `As of ${today}, search live sources for the next visible solar eclipse in North America and its expected date, then the one after that. Cite the source URLs you actually opened.`;
 
 const childEnv = Object.fromEntries(
   Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
@@ -27,13 +28,31 @@ async function main() {
     const agent = new ToolLoopAgent({
       model: process.env.AGENT_MODEL ?? "google/gemini-3-flash-preview",
       instructions:
-        "You are a Gemini browser agent. Use code_execute for all browser work. Prefer deterministic Stagehand V4 page and locator methods, and use Stagehand AI primitives inside code_execute only when they add value.",
+        "You are a Gemini browser agent. Use code_execute for all browser work. Prefer deterministic Stagehand V4 page and locator methods, and use Stagehand AI primitives inside code_execute only when they add value. Never cite a URL unless you navigated directly to it in the browser.",
       tools,
-      stopWhen: stepCountIs(20),
+      prepareStep: ({ stepNumber }) =>
+        stepNumber >= 10
+          ? {
+              activeTools: [],
+              toolChoice: "none",
+              instructions:
+                "Return the evidence-backed answer now. Include only source URLs you opened directly. Do not call another tool.",
+            }
+          : undefined,
+      stopWhen: stepCountIs(12),
     });
 
     console.log("Executing instruction:", instruction);
     const result = await agent.generate({ prompt: instruction });
+    const sourceUrls = new Set(result.text.match(/https?:\/\/\S+/g) ?? []);
+    const futureYears = new Set(
+      [...result.text.matchAll(/\b20\d{2}\b/g)]
+        .map((match) => Number(match[0]))
+        .filter((year) => year >= Number(today.slice(0, 4))),
+    );
+    if (!result.text.trim() || sourceUrls.size < 2 || futureYears.size < 2) {
+      throw new Error("Agent did not return two future eclipse dates with opened source URLs");
+    }
     console.log(result.text);
   } finally {
     await mcpClient.close();

--- a/typescript/gemini-cua/index.ts
+++ b/typescript/gemini-cua/index.ts
@@ -1,74 +1,47 @@
-// Stagehand V4 + Browserbase: Gemini Research Workflow - See README.md for full documentation
+// Stagehand code mode + Vercel AI SDK: Gemini browser agent example
 
-import { browserbase, Stagehand } from "@browserbasehq/stagehand";
+import "dotenv/config";
+import { createMCPClient } from "@ai-sdk/mcp";
+import { Experimental_StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
+import { ToolLoopAgent, stepCountIs } from "ai";
 
-// ============================================================================
-// EXAMPLE INSTRUCTIONS - Choose one to test different scenarios
-// ============================================================================
-
-// Example 1: Learning Plan Creation
-// const instruction = `I want to learn more about Sourdough Bread Making. It's my first time learning about it, and want to get a good grasp by investing 1 hour a day for the next 2 months. Go find online courses/resources, create a plan cross-referencing the time I want to invest with the modules/timelines of the courses and return the plan`;
-
-// Example 2: Flight Search
-// const instruction = `Use flights.google.com to find the lowest fare from all eligible one-way flights for 1 adult from JFK to Heathrow in the next 30 days.`;
-
-// Example 3: Solar Eclipse Research
 const instruction = `Search for the next visible solar eclipse in North America and its expected date, and what about the one after that.`;
 
-// Example 4: GitHub PR Verification
-// const instruction = `Find the most recently opened non-draft PR on Github for Browserbase's Stagehand project and make sure the combination-evals in the PR validation passed.`;
-
-// ============================================================================
+const childEnv = Object.fromEntries(
+  Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+);
 
 async function main() {
-  const browser = await browserbase.launch({
-    apiKey: process.env.BROWSERBASE_API_KEY!,
-    proxies: true,
-    region: "us-west-2",
-    browserSettings: {
-      blockAds: true,
-      viewport: {
-        width: 1288,
-        height: 711,
-      },
-    },
-  });
-  const stagehand = await Stagehand.create({
-    browser,
-    model: { modelName: "google/gemini-3-flash-preview" },
-    logging: { level: "info" },
+  const mcpClient = await createMCPClient({
+    transport: new Experimental_StdioMCPTransport({
+      command: "stagehand-codemode",
+      env: { ...childEnv, STAGEHAND_MODEL_NAME: "google/gemini-3-flash-preview" },
+      stderr: "inherit",
+    }),
   });
 
   try {
-    // Initialize browser session to start automation.
+    const tools = await mcpClient.tools();
+    if (!tools.code_execute) throw new Error("Stagehand code mode did not expose code_execute");
 
-    console.log("Stagehand initialized successfully!");
-    const page = (await browser.context.pages())[0];
-
-    // Navigate to search engine with extended timeout for slow-loading sites.
-    await page.goto(`https://www.google.com/search?q=${encodeURIComponent(instruction)}`, {
-      waitUntil: "domcontentloaded",
+    const agent = new ToolLoopAgent({
+      model: process.env.AGENT_MODEL ?? "google/gemini-3-flash-preview",
+      instructions:
+        "You are a Gemini browser agent. Use code_execute for all browser work. Prefer deterministic Stagehand V4 page and locator methods, and use Stagehand AI primitives inside code_execute only when they add value.",
+      tools,
+      stopWhen: stepCountIs(20),
     });
 
     console.log("Executing instruction:", instruction);
-    const { data: result } = await stagehand.extract(
-      "Answer the research question using the visible search results and include source URLs",
-    );
-    console.log("Task completed successfully!");
-    console.log("Result:", result.extraction);
-  } catch (error) {
-    console.error("Error executing Gemini research workflow:", error);
+    const result = await agent.generate({ prompt: instruction });
+    console.log(result.text);
   } finally {
-    await stagehand.close();
-    await browser.close();
-    console.log("Session closed successfully");
+    await mcpClient.close();
   }
 }
 
-main().catch((err) => {
-  console.error("Error in Gemini research workflow:", err);
-  console.error("Common issues:");
-  console.error("  - Check .env file has BROWSERBASE_API_KEY");
-  console.error("Docs: https://docs.stagehand.dev/v4/first-steps/introduction");
+main().catch((error) => {
+  console.error("Error in Gemini browser agent example:", error);
+  console.error("Check BROWSERBASE_API_KEY and AI_GATEWAY_API_KEY in .env");
   process.exit(1);
 });

--- a/typescript/gemini-cua/index.ts
+++ b/typescript/gemini-cua/index.ts
@@ -1,6 +1,6 @@
-// Stagehand + Browserbase: Computer Use Agent (CUA) Example - See README.md for full documentation
+// Stagehand V4 + Browserbase: Gemini Research Workflow - See README.md for full documentation
 
-import { Stagehand } from "@browserbasehq/stagehand";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 
 // ============================================================================
 // EXAMPLE INSTRUCTIONS - Choose one to test different scenarios
@@ -21,79 +21,54 @@ const instruction = `Search for the next visible solar eclipse in North America 
 // ============================================================================
 
 async function main() {
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    // model: "google/gemini-2.5-pro", // this is the model stagehand uses in act, observe, extract (not agent)
-    verbose: 1,
-    // 0 = errors only, 1 = info, 2 = debug
-    // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
-    // https://docs.stagehand.dev/configuration/logging
-    browserbaseSessionCreateParams: {
-      proxies: true, // Using proxies will give the agent a better chance of success - requires Developer Plan or higher, comment out if you don't have access
-      region: "us-west-2",
-      browserSettings: {
-        blockAds: true,
-        viewport: {
-          width: 1288,
-          height: 711,
-        },
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+    proxies: true,
+    region: "us-west-2",
+    browserSettings: {
+      blockAds: true,
+      viewport: {
+        width: 1288,
+        height: 711,
       },
     },
+  });
+  const stagehand = await Stagehand.create({
+    browser,
+    model: { modelName: "google/gemini-3-flash-preview" },
+    logging: { level: "info" },
   });
 
   try {
     // Initialize browser session to start automation.
-    await stagehand.init();
-    console.log("Stagehand initialized successfully!");
-    console.log(
-      `Live View Link: https://browserbase.com/sessions/${stagehand.browserbaseSessionId}`,
-    );
 
-    const page = stagehand.context.pages()[0];
+    console.log("Stagehand initialized successfully!");
+    const page = (await browser.context.pages())[0];
 
     // Navigate to search engine with extended timeout for slow-loading sites.
-    await page.goto("https://www.google.com/", {
+    await page.goto(`https://www.google.com/search?q=${encodeURIComponent(instruction)}`, {
       waitUntil: "domcontentloaded",
     });
 
-    // Create agent with computer use capabilities for autonomous web browsing.
-    const agent = stagehand.agent({
-      cua: true,
-      model: {
-        modelName: "google/gemini-2.5-computer-use-preview-10-2025",
-        apiKey: process.env.GOOGLE_API_KEY,
-      },
-      systemPrompt: `You are a helpful assistant that can use a web browser.
-      You are currently on the following page: ${page.url()}.
-      Do not ask follow up questions, the user will trust your judgement. If you are getting blocked on google, try another search engine.`,
-    });
-
     console.log("Executing instruction:", instruction);
-    const result = await agent.execute({
-      instruction: instruction,
-      maxSteps: 30,
-      highlightCursor: true,
-    });
-
-    if (result.success === true) {
-      console.log("Task completed successfully!");
-      console.log("Result:", result);
-    } else {
-      console.log("Task failed or was incomplete");
-    }
+    const { data: result } = await stagehand.extract(
+      "Answer the research question using the visible search results and include source URLs",
+    );
+    console.log("Task completed successfully!");
+    console.log("Result:", result.extraction);
   } catch (error) {
-    console.error("Error executing computer use agent:", error);
+    console.error("Error executing Gemini research workflow:", error);
   } finally {
     await stagehand.close();
+    await browser.close();
     console.log("Session closed successfully");
   }
 }
 
 main().catch((err) => {
-  console.error("Error in computer use agent example:", err);
+  console.error("Error in Gemini research workflow:", err);
   console.error("Common issues:");
   console.error("  - Check .env file has BROWSERBASE_API_KEY");
-  console.error("  - Verify GOOGLE_API_KEY is set for the agent");
-  console.error("Docs: https://docs.stagehand.dev/v3/first-steps/introduction");
+  console.error("Docs: https://docs.stagehand.dev/v4/first-steps/introduction");
   process.exit(1);
 });

--- a/typescript/gemini-cua/package.json
+++ b/typescript/gemini-cua/package.json
@@ -1,9 +1,8 @@
 {
-  "name": "exa-browserbase",
+  "name": "gemini-browser-agent-template",
   "version": "1.0.0",
-  "description": "Stagehand + Browserbase + Exa: AI-Powered Job Search and Application",
+  "private": true,
   "type": "module",
-  "main": "index.ts",
   "scripts": {
     "start": "tsx index.ts"
   },
@@ -11,13 +10,12 @@
     "@ai-sdk/mcp": "^2.0.29",
     "@browserbasehq/stagehand-codemode": "github:browserbase/stagehand#54302fc5f13be5ad8e717d8e1388502de22be2ed&path:/packages/integrations",
     "ai": "^7.0.58",
-    "dotenv": "latest",
-    "exa-js": "latest"
+    "dotenv": "^17.4.2"
   },
   "devDependencies": {
-    "@types/node": "latest",
-    "tsx": "latest",
-    "typescript": "latest"
+    "@types/node": "^25.5.0",
+    "tsx": "^4.23.1",
+    "typescript": "^5.9.3"
   },
   "//": "TODO: Replace this commit pin with @browserbasehq/stagehand-codemode@4.0.0 after it is published.",
   "engines": {

--- a/typescript/gift-finder/README.md
+++ b/typescript/gift-finder/README.md
@@ -3,16 +3,15 @@
 ## AT A GLANCE
 
 - Goal: find personalized gift recommendations using AI-generated search queries and intelligent product scoring.
-- AI Integration: Stagehand for AI-generated search queries and score products based on recipient profile.
+- AI Integration: OpenAI generates and scores personalized search terms; Stagehand searches and extracts the live products.
 - Concurrent Sessions: runs multiple browser sessions simultaneously to search different queries in parallel.
-- Proxies: uses Browserbase proxies with UK geolocation for European website access (Firebox.eu).
 
 ## GLOSSARY
 
 - act: perform UI actions from a prompt (search, click, type)
-  Docs → https://docs.stagehand.dev/basics/act
+  Docs → https://docs.stagehand.dev/v4/basics/act
 - extract: pull structured data from pages using schemas
-  Docs → https://docs.stagehand.dev/basics/extract
+  Docs → https://docs.stagehand.dev/v4/basics/extract
 - concurrent sessions: run multiple browser sessions simultaneously for faster searching
   Docs → https://docs.browserbase.com/guides/concurrency-rate-limits
 - proxies: use geolocation-based routing for European website access (Firebox.eu)
@@ -20,16 +19,15 @@
 
 ## QUICKSTART
 
-1.  cd gift-finder-template
-2.  npm install
-3.  npm install inquirer openai
-4.  cp .env.example .env
-5.  Add your Browserbase API key and Project ID to .env
-6.  npm start
+1. cd gift-finder
+2. npm install
+3. cp .env.example .env
+4. Add `BROWSERBASE_API_KEY` and `OPENAI_API_KEY` to .env
+5. npm start
 
 ## EXPECTED OUTPUT
 
-- Prompts user for recipient and description
+- Reads the recipient and description from `CONFIG` in `index.ts`
 - Generates 3 search queries using OpenAI
 - Runs concurrent browser sessions to search Firebox.eu
 - Extracts product data using structured schemas
@@ -38,9 +36,8 @@
 
 ## COMMON PITFALLS
 
-- Browserbase Developer plan or higher is required to use proxies (they have been commented out in the code)
 - "Cannot find module": ensure all dependencies are installed
-- Missing credentials: verify .env contains all required API keys
+- Missing credentials: verify .env contains BROWSERBASE_API_KEY and OPENAI_API_KEY
 - Search failures: check internet connection and website accessibility
 
 ## USE CASES

--- a/typescript/gift-finder/README.md
+++ b/typescript/gift-finder/README.md
@@ -57,7 +57,7 @@
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground
 🔧 Templates: https://www.browserbase.com/templates

--- a/typescript/gift-finder/index.ts
+++ b/typescript/gift-finder/index.ts
@@ -33,14 +33,28 @@ interface SearchResult {
   products: Product[];
 }
 
-const client = new OpenAI();
+async function closeSession(
+  stagehand: Stagehand,
+  browser: Awaited<ReturnType<typeof browserbase.launch>>,
+) {
+  await stagehand.close().catch((error) => console.warn("Stagehand cleanup warning:", error));
+  await browser.close().catch((error) => console.warn("Browser cleanup warning:", error));
+}
+
+function openAIClient(): OpenAI {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error("OPENAI_API_KEY is not set");
+  }
+  return new OpenAI({ apiKey });
+}
 
 async function generateSearchQueries(recipient: string, description: string): Promise<string[]> {
   console.log(`Generating search queries for ${recipient}...`);
 
   // Use AI to generate search terms based on recipient profile
   // This avoids generic searches and focuses on thoughtful, complementary gifts
-  const response = await client.chat.completions.create({
+  const response = await openAIClient().chat.completions.create({
     model: "gpt-4.1",
     messages: [
       {
@@ -99,7 +113,7 @@ async function scoreProducts(
 
   console.log(`Scoring ${allProducts.length} products...`);
 
-  const response = await client.chat.completions.create({
+  const response = await openAIClient().chat.completions.create({
     model: "gpt-4.1",
     messages: [
       {
@@ -143,42 +157,36 @@ IMPORTANT:
     max_completion_tokens: 1000,
   });
 
-  try {
-    // Clean up AI response by removing markdown code blocks
-    let responseContent = response.choices[0]?.message?.content?.trim() || "[]";
+  // Clean up AI response by removing markdown code blocks
+  let responseContent = response.choices[0]?.message?.content?.trim() || "[]";
 
-    responseContent = responseContent.replace(/```json\n?/g, "").replace(/```\n?/g, "");
+  responseContent = responseContent.replace(/```json\n?/g, "").replace(/```\n?/g, "");
 
-    // Parse JSON response from AI scoring
-    const scoresData = JSON.parse(responseContent);
-
-    // Map AI scores back to products using index matching
-    const scoredProducts = allProducts.map((product, index) => {
-      const scoreInfo = scoresData.find(
-        (s: { productIndex: number; score: number; reason: string }) =>
-          s.productIndex === index + 1,
-      );
-      return {
-        ...product,
-        aiScore: scoreInfo?.score || 0,
-        aiReason: scoreInfo?.reason || "No scoring available",
-      };
-    });
-
-    // Sort by AI score descending to show best matches first
-    return scoredProducts.sort((a, b) => (b.aiScore || 0) - (a.aiScore || 0));
-  } catch (error) {
-    console.error("Error parsing AI scores:", error);
-    console.log("Using fallback scoring (all products scored as 5)");
-
-    // Fallback scoring ensures app continues working even if AI fails
-    // Neutral score of 5 allows products to still be ranked and displayed
-    return allProducts.map((product) => ({
-      ...product,
-      aiScore: 5,
-      aiReason: "Scoring failed - using neutral score",
-    }));
+  const ScoreSchema = z.object({
+    productIndex: z.number().int().min(1).max(allProducts.length),
+    score: z.number().min(1).max(10),
+    reason: z.string().min(1).max(100),
+  });
+  const scoresData = z
+    .array(ScoreSchema)
+    .length(allProducts.length)
+    .parse(JSON.parse(responseContent));
+  if (new Set(scoresData.map((score) => score.productIndex)).size !== allProducts.length) {
+    throw new Error("OpenAI scoring did not return one unique score per product");
   }
+
+  // Map AI scores back to products using index matching
+  const scoredProducts = allProducts.map((product, index) => {
+    const scoreInfo = scoresData.find((score) => score.productIndex === index + 1)!;
+    return {
+      ...product,
+      aiScore: scoreInfo.score,
+      aiReason: scoreInfo.reason,
+    };
+  });
+
+  // Sort by AI score descending to show best matches first
+  return scoredProducts.sort((a, b) => (b.aiScore || 0) - (a.aiScore || 0));
 }
 
 async function getUserInput(): Promise<GiftFinderAnswers> {
@@ -200,26 +208,23 @@ async function getUserInput(): Promise<GiftFinderAnswers> {
 async function main(): Promise<void> {
   console.log("Starting Gift Finder Application...");
 
+  if (!process.env.BROWSERBASE_API_KEY || !process.env.OPENAI_API_KEY) {
+    throw new Error("BROWSERBASE_API_KEY and OPENAI_API_KEY are required");
+  }
+
   const { recipient, description } = await getUserInput();
   console.log(`User input received: ${recipient} - ${description}`);
 
   console.log("\nGenerating intelligent search queries...");
 
-  // Generate search queries with fallback for reliability
-  let searchQueries: string[];
-  try {
-    searchQueries = await generateSearchQueries(recipient, description);
-
-    console.log("\nGenerated Search Queries:");
-    searchQueries.forEach((query, index) => {
-      console.log(`   ${index + 1}. ${query.replace(/['"]/g, "")}`);
-    });
-  } catch (error) {
-    console.error("Error generating search queries:", error);
-    // Fallback queries
-    searchQueries = ["gifts", "accessories", "items"];
-    console.log("Using fallback search queries");
+  const searchQueries = await generateSearchQueries(recipient, description);
+  if (searchQueries.length !== 3) {
+    throw new Error(`Expected 3 generated search queries, received ${searchQueries.length}`);
   }
+  console.log("\nGenerated Search Queries:");
+  searchQueries.forEach((query, index) => {
+    console.log(`   ${index + 1}. ${query.replace(/['"]/g, "")}`);
+  });
 
   console.log("\nStarting concurrent browser searches...");
 
@@ -285,8 +290,7 @@ async function main(): Promise<void> {
         `Session ${sessionIndex + 1}: Found ${productsData.products.length} products for "${query}"`,
       );
 
-      await sessionStagehand.close();
-      await sessionBrowser.close();
+      await closeSession(sessionStagehand, sessionBrowser);
 
       return {
         query,
@@ -296,12 +300,7 @@ async function main(): Promise<void> {
     } catch (error) {
       console.error(`Session ${sessionIndex + 1} failed:`, error);
 
-      try {
-        await sessionStagehand.close();
-        await sessionBrowser.close();
-      } catch (closeError) {
-        console.error(`Error closing session ${sessionIndex + 1}:`, closeError);
-      }
+      await closeSession(sessionStagehand, sessionBrowser);
 
       return {
         query,
@@ -318,6 +317,10 @@ async function main(): Promise<void> {
 
   // Wait for all concurrent searches to complete
   const allResults = await Promise.all(searchPromises);
+  const failedSearches = allResults.filter((result) => result.products.length === 0);
+  if (failedSearches.length > 0) {
+    throw new Error(`${failedSearches.length} of ${allResults.length} gift searches failed`);
+  }
 
   // Calculate total products found across all search sessions
   const totalProducts = allResults.reduce((sum, result) => sum + result.products.length, 0);
@@ -326,38 +329,30 @@ async function main(): Promise<void> {
   // Flatten all products into single array for AI scoring
   const allProductsFlat = allResults.flatMap((result) => result.products);
 
-  if (allProductsFlat.length > 0) {
-    try {
-      // AI scores all products and ranks them by relevance to recipient
-      const scoredProducts = await scoreProducts(allProductsFlat, recipient, description);
-      const top3Products = scoredProducts.slice(0, 3);
-
-      console.log("\nTOP 3 RECOMMENDED GIFTS:");
-
-      // Display top 3 products with AI reasoning for transparency
-      top3Products.forEach((product, index) => {
-        const rank = `#${index + 1}`;
-        console.log(`\n${rank} - ${product.title}`);
-        console.log(`Price: ${product.price}`);
-        console.log(`Rating: ${product.rating}`);
-        console.log(`Score: ${product.aiScore}/10`);
-        console.log(`Why: ${product.aiReason}`);
-        console.log(`Link: ${product.url}`);
-      });
-
-      console.log(
-        `\nGift finding complete! Found ${totalProducts} products, analyzed ${scoredProducts.length} with AI.`,
-      );
-    } catch (error) {
-      console.error("Error scoring products:", error);
-      console.log(`Target: ${recipient}`);
-      console.log(`Profile: ${description}`);
-    }
-  } else {
-    // Handle case where no products were found across all searches
-    console.log("No products found to score");
-    console.log("Try adjusting your recipient description or check if the website is accessible");
+  if (allProductsFlat.length < 3) {
+    throw new Error(`Expected at least 3 products to rank, received ${allProductsFlat.length}`);
   }
+
+  // AI scores all products and ranks them by relevance to recipient
+  const scoredProducts = await scoreProducts(allProductsFlat, recipient, description);
+  const top3Products = scoredProducts.slice(0, 3);
+
+  console.log("\nTOP 3 RECOMMENDED GIFTS:");
+
+  // Display top 3 products with AI reasoning for transparency
+  top3Products.forEach((product, index) => {
+    const rank = `#${index + 1}`;
+    console.log(`\n${rank} - ${product.title}`);
+    console.log(`Price: ${product.price}`);
+    console.log(`Rating: ${product.rating}`);
+    console.log(`Score: ${product.aiScore}/10`);
+    console.log(`Why: ${product.aiReason}`);
+    console.log(`Link: ${product.url}`);
+  });
+
+  console.log(
+    `\nGift finding complete! Found ${totalProducts} products, analyzed ${scoredProducts.length} with AI.`,
+  );
 
   console.log("\nThank you for using Gift Finder!");
 }

--- a/typescript/gift-finder/index.ts
+++ b/typescript/gift-finder/index.ts
@@ -1,9 +1,9 @@
 // Stagehand + Browserbase: AI-Powered Gift Finder - See README.md for full documentation
 
 import "dotenv/config";
-import { Stagehand } from "@browserbasehq/stagehand";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 import OpenAI from "openai";
-import { z } from "zod";
+import { z } from "zod/v4";
 
 // ============= CONFIGURATION =============
 // Update these values to customize your gift search
@@ -228,45 +228,25 @@ async function main(): Promise<void> {
 
     // Create separate Stagehand instance for each search to run concurrently
     // Each session searches independently to maximize speed
-    const sessionStagehand = new Stagehand({
-      env: "BROWSERBASE",
-      verbose: 1,
-      // 0 = errors only, 1 = info, 2 = debug
-      // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
-      // https://docs.stagehand.dev/configuration/logging
-      model: "openai/gpt-4.1",
-      browserbaseSessionCreateParams: {
-        // Proxies require Developer Plan or higher - comment in if you have a Developer Plan or higher
-        //   proxies: [
-        //     {
-        //       "type": "browserbase",
-        //       "geolocation": {
-        //         "city": "LONDON",
-        //         "country": "GB"
-        //       }
-        //     }
-        //   ],
-        region: "us-east-1",
-        timeout: 900,
-        browserSettings: {
-          viewport: {
-            width: 1920,
-            height: 1080,
-          },
+    const sessionBrowser = await browserbase.launch({
+      apiKey: process.env.BROWSERBASE_API_KEY!,
+      region: "us-east-1",
+      timeout: 900,
+      browserSettings: {
+        viewport: {
+          width: 1920,
+          height: 1080,
         },
       },
     });
+    const sessionStagehand = await Stagehand.create({
+      browser: sessionBrowser,
+      model: { modelName: "openai/gpt-4.1" },
+      logging: { level: "info" },
+    });
 
     try {
-      await sessionStagehand.init();
-      const sessionPage = sessionStagehand.context.pages()[0];
-
-      // Display live view URL for debugging and monitoring
-      const sessionId = sessionStagehand.browserbaseSessionID;
-      if (sessionId) {
-        const liveViewUrl = `https://www.browserbase.com/sessions/${sessionId}`;
-        console.log(`Session ${sessionIndex + 1} Live View: ${liveViewUrl}`);
-      }
+      const sessionPage = (await sessionBrowser.context.pages())[0];
 
       // Navigate to European gift site - proxies help with regional access
       console.log(`Session ${sessionIndex + 1}: Navigating to Firebox.eu...`);
@@ -280,7 +260,7 @@ async function main(): Promise<void> {
 
       // Extract structured product data using Zod schema for type safety
       console.log(`Session ${sessionIndex + 1}: Extracting product data...`);
-      const productsData = await sessionStagehand.extract(
+      const { data: productsData } = await sessionStagehand.extract(
         "Extract the first 3 products from the search results",
         z.object({
           products: z
@@ -306,6 +286,7 @@ async function main(): Promise<void> {
       );
 
       await sessionStagehand.close();
+      await sessionBrowser.close();
 
       return {
         query,
@@ -317,6 +298,7 @@ async function main(): Promise<void> {
 
       try {
         await sessionStagehand.close();
+        await sessionBrowser.close();
       } catch (closeError) {
         console.error(`Error closing session ${sessionIndex + 1}:`, closeError);
       }
@@ -332,7 +314,7 @@ async function main(): Promise<void> {
   const searchPromises = searchQueries.map((query, index) => runSingleSearch(query, index));
 
   console.log("\nBrowser Sessions Starting...");
-  console.log("Live view links will appear as each session initializes");
+  console.log("Search sessions are running concurrently");
 
   // Wait for all concurrent searches to complete
   const allResults = await Promise.all(searchPromises);

--- a/typescript/google-trends/README.md
+++ b/typescript/google-trends/README.md
@@ -24,7 +24,7 @@
 ## EXPECTED OUTPUT
 
 - Initializes Stagehand session with Browserbase
-- Displays live session link for monitoring
+- Closes both the Stagehand instance and browser handle after extraction
 - Navigates to Google Trends trending page with configured country/language
 - Dismisses any consent dialogs if present
 - Extracts trending keywords with rank positions
@@ -53,7 +53,7 @@
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground
 🔧 Templates: https://www.browserbase.com/templates

--- a/typescript/google-trends/README.md
+++ b/typescript/google-trends/README.md
@@ -5,14 +5,14 @@
 - Goal: Extract trending search keywords from Google Trends for any country with structured JSON output.
 - Configurable by country code (US, GB, IN, DE, etc.) and language preference.
 - Uses Zod schema validation for consistent, typed data extraction.
-- Docs → https://docs.stagehand.dev/basics/extract
+- Docs → https://docs.stagehand.dev/v4/basics/extract
 
 ## GLOSSARY
 
 - extract: extract structured data from web pages using natural language instructions and Zod schemas
-  Docs → https://docs.stagehand.dev/basics/extract
+  Docs → https://docs.stagehand.dev/v4/basics/extract
 - act: perform UI actions from a prompt (click, type, dismiss dialogs)
-  Docs → https://docs.stagehand.dev/basics/act
+  Docs → https://docs.stagehand.dev/v4/basics/act
 
 ## QUICKSTART
 

--- a/typescript/google-trends/index.ts
+++ b/typescript/google-trends/index.ts
@@ -1,8 +1,8 @@
 // Stagehand + Browserbase: Google Trends Keywords Extractor - See README.md for full documentation
 
 import "dotenv/config";
-import { Stagehand } from "@browserbasehq/stagehand";
-import { z } from "zod";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
+import { z } from "zod/v4";
 
 // Configuration variables
 const countryCode = "US"; // Two-letter ISO code (US, GB, IN, DE, FR, BR)
@@ -22,24 +22,21 @@ async function main() {
   console.log(`Limit: ${limit} keywords`);
 
   // Initialize Stagehand with Browserbase for cloud-based browser automation.
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 1,
-    // 0 = errors only, 1 = info, 2 = debug
-    // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
-    // https://docs.stagehand.dev/configuration/logging
-    model: "google/gemini-2.5-flash",
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+  });
+  const stagehand = await Stagehand.create({
+    browser: browser,
+    model: { modelName: "google/gemini-2.5-flash" },
+    logging: { level: "info" },
   });
 
   try {
     // Initialize browser session to start data extraction process.
-    await stagehand.init();
+
     console.log("Stagehand initialized successfully");
 
-    // Provide live session URL for debugging and monitoring extraction process.
-    console.log(`Watch live: https://browserbase.com/sessions/${stagehand.browserbaseSessionID}`);
-
-    const page = stagehand.context.pages()[0];
+    const page = (await browser.context.pages())[0];
 
     // Build and navigate to Google Trends URL with country code and language.
     const trendsUrl = `https://trends.google.com/trending?geo=${countryCode.toUpperCase()}&hl=${language}`;
@@ -62,7 +59,7 @@ async function main() {
 
     // Extract trending keywords using Stagehand's structured extraction with Zod schema.
     console.log("Extracting trending keywords from table...");
-    const extractResult = await stagehand.extract(
+    const { data: extractResult } = await stagehand.extract(
       `Extract the trending search keywords from the Google Trends table. Each row has a trending topic/keyword shown as a button (like "catherine ohara", "don lemon arrested", "fed chair", etc.). For each trend, extract the main keyword text and assign a rank starting from 1 for the first trend. Return up to ${limit} items.`,
       z.array(TrendingKeywordSchema),
     );
@@ -97,6 +94,7 @@ async function main() {
     // Always close session to release resources and clean up.
     console.log("Closing browser session...");
     await stagehand.close();
+    await browser.close();
     console.log("Session closed successfully");
   }
 }
@@ -106,6 +104,6 @@ main().catch((err) => {
   console.error("Common issues:");
   console.error("  - Check .env file has BROWSERBASE_API_KEY");
   console.error("  - Verify country code is a valid 2-letter ISO code (US, GB, IN, DE, etc.)");
-  console.error("Docs: https://docs.stagehand.dev/v3/first-steps/introduction");
+  console.error("Docs: https://docs.stagehand.dev/v4/first-steps/introduction");
   process.exit(1);
 });

--- a/typescript/google-trends/package.json
+++ b/typescript/google-trends/package.json
@@ -2,6 +2,7 @@
   "name": "google-trends-template",
   "version": "1.0.0",
   "description": "Stagehand + Browserbase: Google Trends Keywords Extractor",
+  "type": "module",
   "main": "index.ts",
   "scripts": {
     "start": "tsx index.ts",

--- a/typescript/google-trends/package.json
+++ b/typescript/google-trends/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@browserbasehq/stagehand": "github:browserbase/stagehand#4186c7d98d2f325b6fc85b3f760111e6c390d703&path:/packages/sdk-ts",
+    "@browserbasehq/stagehand": "4.0.0",
     "dotenv": "^16.0.0",
     "zod": "^4.4.3"
   },
@@ -28,7 +28,6 @@
     "tsx": "^4.7.0",
     "typescript": "^5.3.0"
   },
-  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand@4.0.0 after it is published.",
   "engines": {
     "node": ">=22.18.0"
   },

--- a/typescript/google-trends/package.json
+++ b/typescript/google-trends/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@browserbasehq/stagehand": "github:browserbase/stagehand#089f2aaeaea75696685949e0835aece95db54358&path:/packages/sdk-ts",
+    "@browserbasehq/stagehand": "github:browserbase/stagehand#4186c7d98d2f325b6fc85b3f760111e6c390d703&path:/packages/sdk-ts",
     "dotenv": "^16.0.0",
     "zod": "^4.4.3"
   },

--- a/typescript/google-trends/package.json
+++ b/typescript/google-trends/package.json
@@ -19,13 +19,18 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@browserbasehq/stagehand": "latest",
+    "@browserbasehq/stagehand": "github:browserbase/stagehand#089f2aaeaea75696685949e0835aece95db54358&path:/packages/sdk-ts",
     "dotenv": "^16.0.0",
-    "zod": "^3.22.0"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
     "tsx": "^4.7.0",
     "typescript": "^5.3.0"
-  }
+  },
+  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand@4.0.0 after it is published.",
+  "engines": {
+    "node": ">=22.18.0"
+  },
+  "packageManager": "pnpm@10.24.0"
 }

--- a/typescript/image-url-download/README.md
+++ b/typescript/image-url-download/README.md
@@ -4,17 +4,15 @@
 
 - Goal: extract all image URLs from a page with Stagehand and download each image through the browser's direct connection.
 - Browser-context downloads: `fetch()` runs inside the browser via `page.evaluate()` — no special proxy configuration needed. It automatically inherits any active Browserbase proxy and session cookies, so you get the same image the browser sees, even for auth-gated or same-origin-only URLs.
-- AI-powered URL extraction: uses `extract()` with a typed Zod schema to reliably pull `<img>` src attributes and background image URLs from any page.
+- Deterministic URL discovery: reads rendered `<img>` sources and inline background images with V4 page APIs.
 - Format-agnostic: uses `FileReader.readAsDataURL()` inside the browser to encode image bytes and detect the real MIME type — files are saved with the correct extension (`.jpg`, `.png`, `.svg`, `.webp`, etc.).
 - Organized output: images are saved to `./images/<hostname>/` so runs against different sites never mix.
-  Docs → https://docs.stagehand.dev/basics/extract
+  Docs → https://docs.stagehand.dev/v4/reference/page
 
 ## GLOSSARY
 
-- extract: pull structured data from a page using a natural language instruction and a Zod schema.
-  Docs → https://docs.stagehand.dev/basics/extract
-- page.evaluate: run a JavaScript function directly inside the browser context — inherits proxy, cookies, and headers.
-  Docs → https://playwright.dev/docs/evaluating
+- page.evaluate: read rendered image URLs and fetch same-session assets inside the browser context; it inherits the active proxy, cookies, and headers.
+  Docs → https://docs.stagehand.dev/v4/reference/page
 - MAX_IMAGES: configurable cap (default: 10) on how many images to download per run. Set via the `MAX_IMAGES` env var or the constant at the top of `index.ts`.
 
 ## QUICKSTART
@@ -29,7 +27,7 @@
 
 - Initializes Stagehand session with Browserbase
 - Navigates to the target URL
-- Extracts all image URLs from the page using `extract()`
+- Reads rendered image and inline background-image URLs from the page
 - Deduplicates URLs and caps at `MAX_IMAGES` (default: 10)
 - Downloads each image via `fetch()` inside `page.evaluate()` — runs in the browser context so it automatically picks up any proxy or cookies without extra configuration — encoded via `FileReader.readAsDataURL()`
 - Saves images to `./images/<hostname>/`, named `<url-segment>-<timestamp>.<ext>` with the extension derived from the real MIME type
@@ -41,10 +39,10 @@
 - "Cannot find module": ensure all dependencies are installed with `npm install`
 - Missing credentials: verify .env contains BROWSERBASE_API_KEY
 - Empty images folder: some pages load images lazily — try scrolling the page before extraction, or increase the page load wait
-- Zero images found: the page may use CSS background images not captured by `<img>` tags — adjust the extract instruction to target specific selectors
+- Zero images found: the page may lazy-load media or use stylesheet-only backgrounds; scroll or add target-specific selectors
 - CORS / auth-gated images: images behind login walls or strict CORS policies may fail in `page.evaluate()` — ensure you are authenticated before running the script
 - MAX_IMAGES cap: if you need more than 10 images, set `MAX_IMAGES=50` in your .env or edit the constant at the top of `index.ts`
-- Large pages: pages with hundreds of images may slow down `extract()` — use MAX_IMAGES to limit the download set
+- Large pages: use `MAX_IMAGES` to cap the download set
 
 ## USE CASES
 
@@ -55,7 +53,7 @@
 
 ## NEXT STEPS
 
-• Scroll before extracting: call `page.evaluate(() => window.scrollTo(0, document.body.scrollHeight))` before `extract()` to trigger lazy-loaded images.
+• Scroll before discovery: call `page.evaluate(() => window.scrollTo(0, document.body.scrollHeight))` to trigger lazy-loaded images.
 • Concurrent downloads: fan out the `page.evaluate` fetch calls with `Promise.allSettled` for faster bulk downloads.
 • Metadata CSV: write a `manifest.csv` alongside the images recording original URL, filename, MIME type, byte size, and download timestamp.
 • Extend MIME support: add entries to the `MIME_TO_EXT` map at the top of `index.ts` for any formats not already covered.

--- a/typescript/image-url-download/README.md
+++ b/typescript/image-url-download/README.md
@@ -62,7 +62,7 @@
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground
 🔧 Templates: https://www.browserbase.com/templates

--- a/typescript/image-url-download/index.ts
+++ b/typescript/image-url-download/index.ts
@@ -6,7 +6,6 @@
 
 import "dotenv/config";
 import { browserbase, Stagehand } from "@browserbasehq/stagehand";
-import { z } from "zod/v4";
 import fs from "fs";
 import path from "path";
 
@@ -80,30 +79,45 @@ async function main(): Promise<void> {
     console.log("Stagehand initialized successfully!");
     const page = (await browser.context.pages())[0];
 
-    // Navigate and wait for network activity to settle so JS-injected images are in the DOM.
+    // Many modern sites keep analytics and streaming requests open indefinitely, so
+    // wait for DOM readiness and then allow client-rendered images a short settle period.
     console.log(`\nNavigating to ${targetUrl}...`);
     await page.goto(targetUrl, {
-      waitUntil: "networkidle", // Wait for network to settle so JS-injected images are in the DOM.
+      waitUntil: "domcontentloaded",
       timeout: 60000, // Extended timeout for reliable page loading.
     });
+    await page.waitForTimeout(3000);
 
-    // Use extract() with a URL schema so Stagehand knows to look for image URLs.
+    // Image URLs are a known DOM shape, so use a deterministic page read. This
+    // avoids a model mistaking accessibility references for relative URLs.
     console.log("Extracting image URLs from page...");
-    const {
-      data: { urls: allUrls },
-    } = await stagehand.extract(
-      "extract all image URLs on this page, including src attributes from <img> tags and any background image URLs",
-      z.object({ urls: z.array(z.string().url()) }),
-    );
-
-    // Deduplicate and filter out any empty/malformed URLs before applying the limit.
-    const uniqueUrls = [...new Set(allUrls)].filter((u) => {
-      try {
-        const { protocol } = new URL(u);
-        return protocol === "https:" || protocol === "http:";
-      } catch {
-        return false;
+    const allUrls = (await page.evaluate(() => {
+      const urls = new Set<string>();
+      for (const image of Array.from(document.images)) {
+        if (image.currentSrc) urls.add(image.currentSrc);
+        if (image.src) urls.add(image.src);
       }
+      for (const element of Array.from(document.querySelectorAll<HTMLElement>("[style]"))) {
+        const background = getComputedStyle(element).backgroundImage;
+        for (const match of background.matchAll(/url\(["']?(.*?)["']?\)/g)) {
+          if (match[1]) urls.add(new URL(match[1], document.baseURI).href);
+        }
+      }
+      return [...urls];
+    })) as string[];
+
+    // Normalize root-relative paths against the target page, then deduplicate
+    // and filter unsupported URL schemes before applying the limit.
+    const normalizedUrls = allUrls.flatMap((url) => {
+      try {
+        return [new URL(url, targetUrl).href];
+      } catch {
+        return [];
+      }
+    });
+    const uniqueUrls = [...new Set(normalizedUrls)].filter((url) => {
+      const { protocol } = new URL(url);
+      return protocol === "https:" || protocol === "http:";
     });
     console.log(`Found ${uniqueUrls.length} unique image URL(s)`);
 
@@ -147,6 +161,7 @@ async function main(): Promise<void> {
             const res = await fetch(imgUrl);
             if (!res.ok) return null;
             const blob = await res.blob();
+            if (!blob.type.startsWith("image/")) return null;
             return await new Promise<{ base64: string; mimeType: string } | null>((resolve) => {
               const reader = new FileReader();
               reader.onload = () => {
@@ -174,6 +189,23 @@ async function main(): Promise<void> {
         continue;
       }
 
+      // Browser fetch obeys CORS. Public CDN images sometimes omit CORS headers,
+      // so fall back to a server-side fetch when no authenticated browser state is needed.
+      if (!result) {
+        try {
+          const response = await fetch(url);
+          const mimeType = response.headers.get("content-type")?.split(";")[0] ?? "";
+          if (response.ok && mimeType.startsWith("image/")) {
+            result = {
+              base64: Buffer.from(await response.arrayBuffer()).toString("base64"),
+              mimeType,
+            };
+          }
+        } catch {
+          // The common failure path below records this URL as skipped.
+        }
+      }
+
       if (!result) {
         console.log("FAILED (skipping)");
         failed++;
@@ -194,6 +226,9 @@ async function main(): Promise<void> {
       saved++;
     }
 
+    if (saved === 0) {
+      throw new Error(`No images were downloaded (${failed} failed)`);
+    }
     console.log(`\nDone! ${saved} saved, ${failed} failed → ${outputDir}/`);
   } catch (error) {
     console.error("Error during image download:", error);

--- a/typescript/image-url-download/index.ts
+++ b/typescript/image-url-download/index.ts
@@ -5,8 +5,8 @@
 // and the Browserbase proxy. Works for any image format (JPG, PNG, WebP, etc.).
 
 import "dotenv/config";
-import { Stagehand } from "@browserbasehq/stagehand";
-import { z } from "zod";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
+import { z } from "zod/v4";
 import fs from "fs";
 import path from "path";
 
@@ -65,32 +65,33 @@ async function main(): Promise<void> {
   console.log(`Max images: ${MAX_IMAGES} | Output: ${OUTPUT_DIR}/<hostname>/\n`);
 
   // Initialize Stagehand with Browserbase for cloud-based browser automation.
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    model: "google/gemini-2.5-flash",
-    verbose: 1,
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+  });
+  const stagehand = await Stagehand.create({
+    browser: browser,
+    model: { modelName: "google/gemini-2.5-flash" },
+    logging: { level: "info" },
   });
 
   try {
     // Initialize browser session to start automation.
-    await stagehand.init();
-    console.log("Stagehand initialized successfully!");
-    console.log(
-      `Live View Link: https://browserbase.com/sessions/${stagehand.browserbaseSessionID}`,
-    );
 
-    const page = stagehand.context.pages()[0];
+    console.log("Stagehand initialized successfully!");
+    const page = (await browser.context.pages())[0];
 
     // Navigate and wait for network activity to settle so JS-injected images are in the DOM.
     console.log(`\nNavigating to ${targetUrl}...`);
     await page.goto(targetUrl, {
       waitUntil: "networkidle", // Wait for network to settle so JS-injected images are in the DOM.
-      timeoutMs: 60000, // Extended timeout for reliable page loading.
+      timeout: 60000, // Extended timeout for reliable page loading.
     });
 
     // Use extract() with a URL schema so Stagehand knows to look for image URLs.
     console.log("Extracting image URLs from page...");
-    const { urls: allUrls } = await stagehand.extract(
+    const {
+      data: { urls: allUrls },
+    } = await stagehand.extract(
       "extract all image URLs on this page, including src attributes from <img> tags and any background image URLs",
       z.object({ urls: z.array(z.string().url()) }),
     );
@@ -200,6 +201,7 @@ async function main(): Promise<void> {
   } finally {
     // Always close session to release resources and clean up.
     await stagehand.close();
+    await browser.close();
     console.log("Session closed successfully");
   }
 }
@@ -209,6 +211,6 @@ main().catch((err) => {
   console.error("Common issues:");
   console.error("  - Check .env file has BROWSERBASE_API_KEY");
   console.error("  - Verify the target URL is accessible");
-  console.error("Docs: https://docs.stagehand.dev/v3/first-steps/introduction");
+  console.error("Docs: https://docs.stagehand.dev/v4/first-steps/introduction");
   process.exit(1);
 });

--- a/typescript/image-url-download/package.json
+++ b/typescript/image-url-download/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch index.ts"
   },
   "dependencies": {
-    "@browserbasehq/stagehand": "github:browserbase/stagehand#089f2aaeaea75696685949e0835aece95db54358&path:/packages/sdk-ts",
+    "@browserbasehq/stagehand": "github:browserbase/stagehand#4186c7d98d2f325b6fc85b3f760111e6c390d703&path:/packages/sdk-ts",
     "dotenv": "^16.4.5",
     "zod": "^4.4.3"
   },

--- a/typescript/image-url-download/package.json
+++ b/typescript/image-url-download/package.json
@@ -9,13 +9,18 @@
     "dev": "tsx watch index.ts"
   },
   "dependencies": {
-    "@browserbasehq/stagehand": "latest",
+    "@browserbasehq/stagehand": "github:browserbase/stagehand#089f2aaeaea75696685949e0835aece95db54358&path:/packages/sdk-ts",
     "dotenv": "^16.4.5",
-    "zod": "^3.23.8"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^20.14.0",
     "tsx": "^4.16.0",
     "typescript": "^5.5.0"
-  }
+  },
+  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand@4.0.0 after it is published.",
+  "engines": {
+    "node": ">=22.18.0"
+  },
+  "packageManager": "pnpm@10.24.0"
 }

--- a/typescript/image-url-download/package.json
+++ b/typescript/image-url-download/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch index.ts"
   },
   "dependencies": {
-    "@browserbasehq/stagehand": "github:browserbase/stagehand#4186c7d98d2f325b6fc85b3f760111e6c390d703&path:/packages/sdk-ts",
+    "@browserbasehq/stagehand": "4.0.0",
     "dotenv": "^16.4.5",
     "zod": "^4.4.3"
   },
@@ -18,7 +18,6 @@
     "tsx": "^4.16.0",
     "typescript": "^5.5.0"
   },
-  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand@4.0.0 after it is published.",
   "engines": {
     "node": ">=22.18.0"
   },

--- a/typescript/job-application/README.md
+++ b/typescript/job-application/README.md
@@ -1,4 +1,4 @@
-# Stagehand + Browserbase: Automated Job Application Agent
+# Stagehand V4 + Browserbase: Automated Job Application Workflow
 
 ## AT A GLANCE
 
@@ -6,32 +6,29 @@
 - Concurrent Processing: applies to multiple jobs in parallel with configurable concurrency limits based on Browserbase project settings.
 - Dynamic Data Generation: generates unique agent IDs and email addresses for each application.
 - File Upload Support: automatically uploads resume PDF from a remote URL during the application process.
-- Docs → https://docs.stagehand.dev/basics/agent
+- Docs → https://docs.stagehand.dev/v4/basics/act
 
 ## GLOSSARY
 
-- agent: create an autonomous AI agent that can execute complex multi-step tasks
-  Docs → https://docs.stagehand.dev/basics/agent#what-is-agent
 - act: perform UI actions from a prompt (click, type, fill forms)
-  Docs → https://docs.stagehand.dev/basics/act
+  Docs → https://docs.stagehand.dev/v4/basics/act
 - extract: extract structured data from web pages using natural language instructions
-  Docs → https://docs.stagehand.dev/basics/extract
+  Docs → https://docs.stagehand.dev/v4/basics/extract
 - observe: analyze a page and return selectors or action plans before executing
-  Docs → https://docs.stagehand.dev/basics/observe
+  Docs → https://docs.stagehand.dev/v4/basics/observe
 - semaphore: concurrency control mechanism to limit parallel job applications based on project limits
 
 ## QUICKSTART
 
-1. npm install
+1. pnpm install
 2. cp .env.example .env
 3. Add your Browserbase API key and Project ID to .env (BROWSERBASE_API_KEY, BROWSERBASE_PROJECT_ID)
-4. npm start
+4. pnpm start
 
 ## EXPECTED OUTPUT
 
 - Fetches project concurrency limit from Browserbase (maxed at 5)
 - Initializes main Stagehand session with Browserbase
-- Displays live session link for monitoring
 - Navigates to agent job board
 - Clicks "View Jobs" button
 - Extracts all job listings with titles and URLs using structured schema
@@ -78,7 +75,7 @@
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground
 🔧 Templates: https://www.browserbase.com/templates

--- a/typescript/job-application/index.ts
+++ b/typescript/job-application/index.ts
@@ -1,9 +1,9 @@
 // Stagehand + Browserbase: Job Application Automation - See README.md for full documentation
 
 import "dotenv/config";
-import { Stagehand } from "@browserbasehq/stagehand";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 import Browserbase from "@browserbasehq/sdk";
-import { z } from "zod/v3";
+import { z } from "zod/v4";
 
 // Define Zod schema for structured data extraction
 // Using schemas ensures consistent data extraction even if page layout changes
@@ -70,21 +70,19 @@ async function applyToJob(jobInfo: JobInfo, semaphore: () => Promise<void>, rele
   await semaphore();
 
   // Initialize Stagehand with Browserbase for cloud-based browser automation
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    model: "google/gemini-2.5-flash", // Routed through Model Gateway
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+  });
+  const stagehand = await Stagehand.create({
+    browser: browser,
+    model: { modelName: "google/gemini-2.5-flash" },
   });
 
   try {
     // Initialize browser session to start automation
-    await stagehand.init();
 
     console.log(`[${jobInfo.title}] Session Started`);
-    console.log(
-      `[${jobInfo.title}] Watch live: https://browserbase.com/sessions/${stagehand.browserbaseSessionId}`,
-    );
-
-    const page = stagehand.context.pages()[0];
+    const page = (await browser.context.pages())[0];
 
     // Navigate to job URL
     await page.goto(jobInfo.url);
@@ -111,7 +109,9 @@ async function applyToJob(jobInfo: JobInfo, semaphore: () => Promise<void>, rele
 
     // Upload agent profile/resume file
     // Using observe() to find the upload button, then setting files programmatically
-    const [uploadAction] = await stagehand.observe("find the file upload button for agent profile");
+    const {
+      data: [uploadAction],
+    } = await stagehand.observe("find the file upload button for agent profile");
     if (uploadAction) {
       const uploadSelector = uploadAction.selector;
       if (uploadSelector) {
@@ -145,9 +145,11 @@ async function applyToJob(jobInfo: JobInfo, semaphore: () => Promise<void>, rele
     console.log(`[${jobInfo.title}] Application submitted successfully!`);
 
     await stagehand.close();
+    await browser.close();
   } catch (error) {
     console.error(`[${jobInfo.title}] Error:`, error);
     await stagehand.close();
+    await browser.close();
     throw error;
   } finally {
     // Always release semaphore slot to allow next job application to proceed
@@ -163,18 +165,18 @@ async function main() {
   console.log(`Executing with concurrency limit: ${maxConcurrency}`);
 
   // Initialize Stagehand with Browserbase for cloud-based browser automation
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    model: "google/gemini-2.5-flash", // Routed through Model Gateway
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+  });
+  const stagehand = await Stagehand.create({
+    browser: browser,
+    model: { modelName: "google/gemini-2.5-flash" },
   });
 
   // Initialize browser session to start automation
-  await stagehand.init();
 
   console.log(`Main Stagehand Session Started`);
-  console.log(`Watch live: https://browserbase.com/sessions/${stagehand.browserbaseSessionId}`);
-
-  const page = stagehand.context.pages()[0];
+  const page = (await browser.context.pages())[0];
 
   // Navigate to agent job board homepage
   await page.goto("https://agent-job-board.vercel.app/");
@@ -186,7 +188,7 @@ async function main() {
 
   // Extract all job listings with titles and URLs using structured schema
   // Using extract() with Zod schema ensures consistent data extraction
-  const jobsData = await stagehand.extract(
+  const { data: jobsData } = await stagehand.extract(
     "extract all job listings with their titles and URLs",
     z.array(JobInfoSchema),
   );
@@ -194,6 +196,7 @@ async function main() {
   console.log(`Found ${jobsData.length} jobs`);
 
   await stagehand.close();
+  await browser.close();
 
   // Create semaphore with concurrency limit to control parallel job applications
   // Semaphore ensures we don't exceed Browserbase project limits
@@ -217,6 +220,6 @@ main().catch((err) => {
   console.error("Error in job application automation:", err);
   console.error("Common issues:");
   console.error("  - Check .env file has BROWSERBASE_PROJECT_ID and BROWSERBASE_API_KEY");
-  console.error("Docs: https://docs.stagehand.dev/v3/first-steps/introduction");
+  console.error("Docs: https://docs.stagehand.dev/v4/first-steps/introduction");
   process.exit(1);
 });

--- a/typescript/job-application/index.ts
+++ b/typescript/job-application/index.ts
@@ -14,6 +14,14 @@ const JobInfoSchema = z.object({
 
 type JobInfo = z.infer<typeof JobInfoSchema>;
 
+async function closeSession(
+  stagehand: Stagehand,
+  browser: Awaited<ReturnType<typeof browserbase.launch>>,
+) {
+  await stagehand.close().catch((error) => console.warn("Stagehand cleanup warning:", error));
+  await browser.close().catch((error) => console.warn("Browser cleanup warning:", error));
+}
+
 export async function getProjectConcurrency(): Promise<number> {
   // Fetch project concurrency limit from Browserbase SDK
   // Capped at 5 to prevent overwhelming the system with too many parallel requests
@@ -142,14 +150,18 @@ async function applyToJob(jobInfo: JobInfo, semaphore: () => Promise<void>, rele
     // Submit the application form
     await stagehand.act(`click deploy agent button`);
 
+    await page.waitForTimeout(500);
+    const confirmationText = await page.locator("body").innerText();
+    if (!/success|submitted|deployed|received/i.test(confirmationText)) {
+      throw new Error("Application submission did not produce a confirmation message");
+    }
+
     console.log(`[${jobInfo.title}] Application submitted successfully!`);
 
-    await stagehand.close();
-    await browser.close();
+    await closeSession(stagehand, browser);
   } catch (error) {
     console.error(`[${jobInfo.title}] Error:`, error);
-    await stagehand.close();
-    await browser.close();
+    await closeSession(stagehand, browser);
     throw error;
   } finally {
     // Always release semaphore slot to allow next job application to proceed
@@ -195,8 +207,7 @@ async function main() {
 
   console.log(`Found ${jobsData.length} jobs`);
 
-  await stagehand.close();
-  await browser.close();
+  await closeSession(stagehand, browser);
 
   // Create semaphore with concurrency limit to control parallel job applications
   // Semaphore ensures we don't exceed Browserbase project limits
@@ -210,8 +221,13 @@ async function main() {
 
   const applicationPromises = jobsData.map((job) => applyToJob(job, semaphore, release));
 
-  // Wait for all applications to complete
-  await Promise.all(applicationPromises);
+  // Attempt every application even if an earlier one fails, then report the
+  // complete business outcome instead of stopping on the first rejection.
+  const applicationResults = await Promise.allSettled(applicationPromises);
+  const failures = applicationResults.filter((result) => result.status === "rejected");
+  if (failures.length > 0) {
+    throw new Error(`${failures.length} of ${jobsData.length} applications failed`);
+  }
 
   console.log("All applications completed!");
 }

--- a/typescript/license-verification/README.md
+++ b/typescript/license-verification/README.md
@@ -54,7 +54,7 @@
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground
 🔧 Templates: https://www.browserbase.com/templates

--- a/typescript/license-verification/README.md
+++ b/typescript/license-verification/README.md
@@ -10,9 +10,9 @@
 ## GLOSSARY
 
 - act: perform UI actions from a prompt (type, click, navigate).
-  Docs → https://docs.stagehand.dev/basics/act
+  Docs → https://docs.stagehand.dev/v4/basics/act
 - extract: pull structured data from web pages into validated objects.
-  Docs → https://docs.stagehand.dev/basics/extract
+  Docs → https://docs.stagehand.dev/v4/basics/extract
 - schema: a Zod definition that enforces data types, optional fields, and validation rules.
   Docs → https://zod.dev/
 - form automation: filling and submitting inputs to trigger results before extraction.

--- a/typescript/license-verification/index.ts
+++ b/typescript/license-verification/index.ts
@@ -1,8 +1,8 @@
 // Real Estate License Verification - See README.md for full documentation
 
 import "dotenv/config";
-import { Stagehand } from "@browserbasehq/stagehand";
-import { z } from "zod";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
+import { z } from "zod/v4";
 
 // License verification variables
 const variables = {
@@ -11,23 +11,20 @@ const variables = {
 
 async function main() {
   // Initialize Stagehand with Browserbase for cloud-based browser automation.
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE", // Use Browserbase cloud browsers for reliable automation.
-    verbose: 1,
-    model: "openai/gpt-4.1",
-    // 0 = errors only, 1 = info, 2 = debug
-    // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
-    // https://docs.stagehand.dev/configuration/logging
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+  });
+  const stagehand = await Stagehand.create({
+    browser: browser,
+    model: { modelName: "openai/gpt-4.1" },
+    logging: { level: "info" },
   });
 
   // Initialize browser session to start data extraction process.
-  await stagehand.init();
+
   console.log(`Stagehand Session Started`);
 
-  // Provide live session URL for debugging and monitoring extraction process.
-  console.log(`Watch live: https://browserbase.com/sessions/${stagehand.browserbaseSessionID}`);
-
-  const page = stagehand.context.pages()[0];
+  const page = (await browser.context.pages())[0];
 
   // Navigate to California DRE license verification website for data extraction.
   console.log("Navigating to: https://www2.dre.ca.gov/publicasp/pplinfo.asp");
@@ -43,7 +40,7 @@ async function main() {
 
   // Extract structured license data using Zod schema for type safety and validation.
   console.log(`Extracting: extract all the license verification details for DRE#02237476`);
-  const extractedData4 = await stagehand.extract(
+  const { data: extractedData4 } = await stagehand.extract(
     `extract all the license verification details for DRE#02237476`,
     z.object({
       licenseType: z.string().optional(), // Type of real estate license
@@ -65,6 +62,7 @@ async function main() {
 
   // Always close session to release resources and clean up.
   await stagehand.close();
+  await browser.close();
 }
 
 main().catch((err) => {

--- a/typescript/manual-mfa-with-contexts/README.md
+++ b/typescript/manual-mfa-with-contexts/README.md
@@ -26,11 +26,11 @@
 
 - Creates a new Browserbase context
 - First session: navigates to GitHub login, fills credentials, detects MFA prompt
-- Pauses and displays Browserbase session link for manual MFA completion
+- Pauses and directs the user to the newest session in the Browserbase Sessions dashboard for manual MFA completion
 - Waits for MFA completion (2 minute timeout)
 - Saves authentication state to context
 - Second session: reuses context, navigates to GitHub (already logged in, no MFA)
-- Extracts logged-in username to verify authentication
+- Reads GitHub's authenticated-user metadata to verify the reused context
 - Cleans up context
 
 ## COMMON PITFALLS

--- a/typescript/manual-mfa-with-contexts/README.md
+++ b/typescript/manual-mfa-with-contexts/README.md
@@ -56,7 +56,7 @@
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
 🎮 Browserbase: https://www.browserbase.com
 📚 Contexts Docs: https://docs.browserbase.com/features/contexts
 💡 Try it out: https://www.browserbase.com/playground

--- a/typescript/manual-mfa-with-contexts/index.ts
+++ b/typescript/manual-mfa-with-contexts/index.ts
@@ -1,13 +1,20 @@
 // Manual MFA with Browserbase Contexts - See README.md for full documentation
 
 import "dotenv/config";
-import { Stagehand } from "@browserbasehq/stagehand";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 import { Browserbase } from "@browserbasehq/sdk";
-import { z } from "zod";
+import { z } from "zod/v4";
+import fs from "fs";
 
 const bb = new Browserbase({
   apiKey: process.env.BROWSERBASE_API_KEY,
 });
+
+async function uploadStagehandExtension(): Promise<{ id: string }> {
+  const stagehandEntry = import.meta.resolve("@browserbasehq/stagehand");
+  const archive = new URL("./assets/stagehand-extension.zip", stagehandEntry);
+  return bb.extensions.create({ file: fs.createReadStream(archive) });
+}
 
 /**
  * First session: Create context and login (with MFA)
@@ -15,32 +22,35 @@ const bb = new Browserbase({
 async function createSessionWithContext() {
   console.log("Creating new Browserbase context...");
 
-  const context = await bb.createContext();
+  const context = await bb.contexts.create();
 
   console.log(`Context created: ${context.id}`);
   console.log("First session: Performing login with MFA...");
 
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 0,
-    // 0 = errors only, 1 = info, 2 = debug
-    // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
-    // https://docs.stagehand.dev/configuration/logging
-    model: "openai/gpt-4.1-mini",
-    browserbaseSessionCreateParams: {
-      browserSettings: {
-        context: {
-          id: context.id,
-          persist: true, // Save authentication state including MFA
-        },
+  const extension = await uploadStagehandExtension();
+  const session = await bb.sessions.create({
+    extensionId: extension.id,
+    browserSettings: {
+      context: {
+        id: context.id,
+        persist: true, // Save authentication state including MFA
       },
     },
   });
+  const browser = await browserbase.connect({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+    sessionId: session.id,
+    extensionId: extension.id,
+  });
+  const stagehand = await Stagehand.create({
+    browser: browser,
+    model: { modelName: "openai/gpt-4.1-mini" },
+    logging: { level: "error" },
+  });
 
-  await stagehand.init();
-  console.log(`Watch live: https://browserbase.com/sessions/${stagehand.browserbaseSessionID}`);
+  console.log(`Watch live: https://browserbase.com/sessions/${session.id}`);
 
-  const page = stagehand.context.pages()[0];
+  const page = (await browser.context.pages())[0];
 
   // Navigate to GitHub login
   console.log("Navigating to GitHub login...");
@@ -60,7 +70,7 @@ async function createSessionWithContext() {
   await page.waitForLoadState("networkidle");
 
   // Check if MFA is required
-  const mfaRequired = await stagehand.extract(
+  const { data: mfaRequired } = await stagehand.extract(
     "Is there a two-factor authentication or verification code prompt on the page?",
     z.boolean(),
   );
@@ -71,7 +81,7 @@ async function createSessionWithContext() {
     console.log("PAUSED: Please complete MFA in the browser");
     console.log("═══════════════════════════════════════════════════════════");
     console.log(
-      `1. Open the Browserbase session in your browser: https://browserbase.com/sessions/${stagehand.browserbaseSessionID}`,
+      `1. Open the Browserbase session in your browser: https://browserbase.com/sessions/${session.id}`,
     );
     console.log("2. Enter your 2FA code from authenticator app");
     console.log("3. Click 'Verify' or submit");
@@ -86,7 +96,7 @@ async function createSessionWithContext() {
     while (!loginComplete && Date.now() - startTime < timeout) {
       await new Promise((resolve) => setTimeout(resolve, 3000)); // Check every 3 seconds
 
-      const currentUrl = page.url();
+      const currentUrl = await page.url();
       if (!currentUrl.includes("/login") && !currentUrl.includes("/sessions/two-factor")) {
         loginComplete = true;
       }
@@ -107,6 +117,8 @@ async function createSessionWithContext() {
   console.log("   - All authentication data\n");
 
   await stagehand.close();
+  await browser.close();
+  await bb.extensions.delete(extension.id, { headers: { "Content-Type": null } });
 
   return context.id;
 }
@@ -118,27 +130,30 @@ async function reuseContext(contextId: string) {
   console.log(`Second session: Reusing context ${contextId}`);
   console.log("   (No login, no MFA required - auth state persisted)\n");
 
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 0,
-    // 0 = errors only, 1 = info, 2 = debug
-    // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
-    // https://docs.stagehand.dev/configuration/logging
-    model: "openai/gpt-4.1-mini",
-    browserbaseSessionCreateParams: {
-      browserSettings: {
-        context: {
-          id: contextId,
-          persist: true,
-        },
+  const extension = await uploadStagehandExtension();
+  const session = await bb.sessions.create({
+    extensionId: extension.id,
+    browserSettings: {
+      context: {
+        id: contextId,
+        persist: true,
       },
     },
   });
+  const browser = await browserbase.connect({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+    sessionId: session.id,
+    extensionId: extension.id,
+  });
+  const stagehand = await Stagehand.create({
+    browser: browser,
+    model: { modelName: "openai/gpt-4.1-mini" },
+    logging: { level: "error" },
+  });
 
-  await stagehand.init();
-  console.log(`Watch live: https://browserbase.com/sessions/${stagehand.browserbaseSessionID}`);
+  console.log(`Watch live: https://browserbase.com/sessions/${session.id}`);
 
-  const page = stagehand.context.pages()[0];
+  const page = (await browser.context.pages())[0];
 
   // Navigate directly to GitHub (should already be logged in)
   console.log("Navigating to GitHub...");
@@ -146,7 +161,7 @@ async function reuseContext(contextId: string) {
   await page.waitForLoadState("networkidle");
 
   // Check if we're logged in
-  const username = await stagehand.extract(
+  const { data: username } = await stagehand.extract(
     "Extract the logged-in username or check if we're authenticated",
     z.string(),
   );
@@ -159,6 +174,8 @@ async function reuseContext(contextId: string) {
   console.log("   - All future sessions: No MFA required\n");
 
   await stagehand.close();
+  await browser.close();
+  await bb.extensions.delete(extension.id, { headers: { "Content-Type": null } });
 }
 
 /**

--- a/typescript/manual-mfa-with-contexts/index.ts
+++ b/typescript/manual-mfa-with-contexts/index.ts
@@ -4,17 +4,10 @@ import "dotenv/config";
 import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 import { Browserbase } from "@browserbasehq/sdk";
 import { z } from "zod/v4";
-import fs from "fs";
 
 const bb = new Browserbase({
   apiKey: process.env.BROWSERBASE_API_KEY,
 });
-
-async function uploadStagehandExtension(): Promise<{ id: string }> {
-  const stagehandEntry = import.meta.resolve("@browserbasehq/stagehand");
-  const archive = new URL("./assets/stagehand-extension.zip", stagehandEntry);
-  return bb.extensions.create({ file: fs.createReadStream(archive) });
-}
 
 /**
  * First session: Create context and login (with MFA)
@@ -24,12 +17,11 @@ async function createSessionWithContext() {
 
   const context = await bb.contexts.create();
 
-  console.log(`Context created: ${context.id}`);
+  console.log("Browserbase context created");
   console.log("First session: Performing login with MFA...");
 
-  const extension = await uploadStagehandExtension();
-  const session = await bb.sessions.create({
-    extensionId: extension.id,
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
     browserSettings: {
       context: {
         id: context.id,
@@ -37,18 +29,13 @@ async function createSessionWithContext() {
       },
     },
   });
-  const browser = await browserbase.connect({
-    apiKey: process.env.BROWSERBASE_API_KEY!,
-    sessionId: session.id,
-    extensionId: extension.id,
-  });
   const stagehand = await Stagehand.create({
     browser: browser,
     model: { modelName: "openai/gpt-4.1-mini" },
     logging: { level: "error" },
   });
 
-  console.log(`Watch live: https://browserbase.com/sessions/${session.id}`);
+  console.log("Live View is available in the Browserbase Sessions dashboard");
 
   const page = (await browser.context.pages())[0];
 
@@ -80,9 +67,7 @@ async function createSessionWithContext() {
     console.log("═══════════════════════════════════════════════════════════");
     console.log("PAUSED: Please complete MFA in the browser");
     console.log("═══════════════════════════════════════════════════════════");
-    console.log(
-      `1. Open the Browserbase session in your browser: https://browserbase.com/sessions/${session.id}`,
-    );
+    console.log("1. Open the newest running session in the Browserbase Sessions dashboard");
     console.log("2. Enter your 2FA code from authenticator app");
     console.log("3. Click 'Verify' or submit");
     console.log("4. Wait for login to complete");
@@ -111,14 +96,13 @@ async function createSessionWithContext() {
     console.log("Login successful (no MFA required)\n");
   }
 
-  console.log(`Context ${context.id} now contains:`);
+  console.log("The Browserbase context now contains:");
   console.log("   - Session cookies");
   console.log("   - MFA trust/remember device state");
   console.log("   - All authentication data\n");
 
-  await stagehand.close();
-  await browser.close();
-  await bb.extensions.delete(extension.id, { headers: { "Content-Type": null } });
+  await stagehand.close().catch((error) => console.warn("Stagehand cleanup warning:", error));
+  await browser.close().catch((error) => console.warn("Browser cleanup warning:", error));
 
   return context.id;
 }
@@ -127,12 +111,11 @@ async function createSessionWithContext() {
  * Second session: Reuse context - NO MFA needed!
  */
 async function reuseContext(contextId: string) {
-  console.log(`Second session: Reusing context ${contextId}`);
+  console.log("Second session: Reusing the saved context");
   console.log("   (No login, no MFA required - auth state persisted)\n");
 
-  const extension = await uploadStagehandExtension();
-  const session = await bb.sessions.create({
-    extensionId: extension.id,
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
     browserSettings: {
       context: {
         id: contextId,
@@ -140,18 +123,13 @@ async function reuseContext(contextId: string) {
       },
     },
   });
-  const browser = await browserbase.connect({
-    apiKey: process.env.BROWSERBASE_API_KEY!,
-    sessionId: session.id,
-    extensionId: extension.id,
-  });
   const stagehand = await Stagehand.create({
     browser: browser,
     model: { modelName: "openai/gpt-4.1-mini" },
     logging: { level: "error" },
   });
 
-  console.log(`Watch live: https://browserbase.com/sessions/${session.id}`);
+  console.log("Live View is available in the Browserbase Sessions dashboard");
 
   const page = (await browser.context.pages())[0];
 
@@ -160,11 +138,14 @@ async function reuseContext(contextId: string) {
   await page.goto("https://github.com");
   await page.waitForLoadState("networkidle");
 
-  // Check if we're logged in
-  const { data: username } = await stagehand.extract(
-    "Extract the logged-in username or check if we're authenticated",
-    z.string(),
+  // GitHub exposes the authenticated login in page metadata. Verify that the
+  // second session inherited real authentication instead of trusting navigation.
+  const username = await page.evaluate(
+    () => document.querySelector<HTMLMetaElement>('meta[name="user-login"]')?.content ?? "",
   );
+  if (!username) {
+    throw new Error("The reused context was not authenticated to GitHub");
+  }
 
   console.log("\nSUCCESS! Already logged in without MFA!");
   console.log(`   Username: ${username}`);
@@ -173,16 +154,15 @@ async function reuseContext(contextId: string) {
   console.log("   - Context saves trusted device state");
   console.log("   - All future sessions: No MFA required\n");
 
-  await stagehand.close();
-  await browser.close();
-  await bb.extensions.delete(extension.id, { headers: { "Content-Type": null } });
+  await stagehand.close().catch((error) => console.warn("Stagehand cleanup warning:", error));
+  await browser.close().catch((error) => console.warn("Browser cleanup warning:", error));
 }
 
 /**
  * Clean up context
  */
 async function deleteContext(contextId: string) {
-  console.log(`Deleting context: ${contextId}`);
+  console.log("Deleting Browserbase context");
   try {
     // Delete via API (SDK doesn't have delete method)
     const response = await fetch(`https://api.browserbase.com/v1/contexts/${contextId}`, {

--- a/typescript/manual-mfa-with-contexts/package.json
+++ b/typescript/manual-mfa-with-contexts/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@browserbasehq/sdk": "^2.9.0",
-    "@browserbasehq/stagehand": "github:browserbase/stagehand#4186c7d98d2f325b6fc85b3f760111e6c390d703&path:/packages/sdk-ts",
+    "@browserbasehq/stagehand": "4.0.0",
     "dotenv": "^16.4.5",
     "zod": "^4.4.3"
   },
@@ -19,7 +19,6 @@
     "tsx": "^4.16.0",
     "typescript": "^5.5.0"
   },
-  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand@4.0.0 after it is published.",
   "engines": {
     "node": ">=22.18.0"
   },

--- a/typescript/manual-mfa-with-contexts/package.json
+++ b/typescript/manual-mfa-with-contexts/package.json
@@ -10,13 +10,18 @@
   },
   "dependencies": {
     "@browserbasehq/sdk": "^2.9.0",
-    "@browserbasehq/stagehand": "latest",
+    "@browserbasehq/stagehand": "github:browserbase/stagehand#089f2aaeaea75696685949e0835aece95db54358&path:/packages/sdk-ts",
     "dotenv": "^16.4.5",
-    "zod": "^3.23.8"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^20.14.0",
     "tsx": "^4.16.0",
     "typescript": "^5.5.0"
-  }
+  },
+  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand@4.0.0 after it is published.",
+  "engines": {
+    "node": ">=22.18.0"
+  },
+  "packageManager": "pnpm@10.24.0"
 }

--- a/typescript/manual-mfa-with-contexts/package.json
+++ b/typescript/manual-mfa-with-contexts/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@browserbasehq/sdk": "^2.9.0",
-    "@browserbasehq/stagehand": "github:browserbase/stagehand#089f2aaeaea75696685949e0835aece95db54358&path:/packages/sdk-ts",
+    "@browserbasehq/stagehand": "github:browserbase/stagehand#4186c7d98d2f325b6fc85b3f760111e6c390d703&path:/packages/sdk-ts",
     "dotenv": "^16.4.5",
     "zod": "^4.4.3"
   },

--- a/typescript/mfa-handling/README.md
+++ b/typescript/mfa-handling/README.md
@@ -6,14 +6,14 @@
 - TOTP Generation: Implements RFC 6238 compliant algorithm to generate time-based authentication codes programmatically.
 - Automatic Form Filling: Extracts TOTP secrets from pages and automatically fills MFA forms without user interaction.
 - Retry Logic: Handles time window edge cases by regenerating codes and retrying authentication when needed.
-- Docs → https://docs.stagehand.dev/basics/act
+- Docs → https://docs.stagehand.dev/v4/basics/act
 
 ## GLOSSARY
 
 - act: perform UI actions from a prompt (type, click, fill forms)
-  Docs → https://docs.stagehand.dev/basics/act
+  Docs → https://docs.stagehand.dev/v4/basics/act
 - extract: extract structured data from web pages using natural language instructions
-  Docs → https://docs.stagehand.dev/basics/extract
+  Docs → https://docs.stagehand.dev/v4/basics/extract
 - TOTP: Time-based One-Time Password - a 6-digit code that changes every 30 seconds, generated using HMAC-SHA1 algorithm
 - RFC 6238: Standard specification for TOTP authentication codes used by Google Authenticator, Authy, and other authenticator apps
 

--- a/typescript/mfa-handling/README.md
+++ b/typescript/mfa-handling/README.md
@@ -27,7 +27,7 @@
 ## EXPECTED OUTPUT
 
 - Initializes Stagehand session with Browserbase
-- Displays live session link for monitoring
+- Retries with a fresh TOTP code when the first authentication attempt fails
 - Navigates to TOTP challenge demo page (authenticationtest.com/totpChallenge/)
 - Extracts test credentials (email, password) and TOTP secret from the page
 - Generates TOTP code using RFC 6238 algorithm
@@ -65,7 +65,7 @@
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground
 🔧 Templates: https://www.browserbase.com/templates

--- a/typescript/mfa-handling/index.ts
+++ b/typescript/mfa-handling/index.ts
@@ -91,25 +91,34 @@ async function main() {
 
     console.log(`Credentials extracted - Email: ${credentials.email}`);
 
+    // Leave enough time for deterministic form filling and submit.
+    // Starting close to the end of a 30-second window can expire an otherwise
+    // valid code before the browser sends it.
+    let secondsLeft = 30 - (Math.floor(Date.now() / 1000) % 30);
+    if (secondsLeft < 8) {
+      console.log(`Waiting ${secondsLeft + 1} seconds for a fresh TOTP window...`);
+      await page.waitForTimeout((secondsLeft + 1) * 1000);
+    }
+
     // Generate TOTP code using RFC 6238 algorithm
     const totpCode = generateTOTP(credentials.totpSecret);
-    const secondsLeft = 30 - (Math.floor(Date.now() / 1000) % 30);
+    secondsLeft = 30 - (Math.floor(Date.now() / 1000) % 30);
     console.log(`Generated TOTP code: ${totpCode} (valid for ${secondsLeft} seconds)`);
 
     // Fill in login form with email and password
     console.log("Filling in email...");
-    await stagehand.act(`Type '${credentials.email}' into the email field`);
+    await page.locator("#email").fill(credentials.email);
 
     console.log("Filling in password...");
-    await stagehand.act(`Type '${credentials.password}' into the password field`);
+    await page.locator("#password").fill(credentials.password);
 
     // Fill in TOTP code
     console.log("Filling in TOTP code...");
-    await stagehand.act(`Type '${totpCode}' into the TOTP code field`);
+    await page.locator("#totpmfa").fill(totpCode);
 
     // Submit the form
     console.log("Submitting form...");
-    await stagehand.act("Click the submit or login button");
+    await page.locator('input[type="submit"]').click();
 
     // Wait for response - be tolerant of sites that never reach full "networkidle"
     try {
@@ -140,12 +149,23 @@ async function main() {
       console.log("Retrying with a fresh TOTP code...");
 
       // Regenerate and retry with new code (handles time window edge cases)
+      // A failed submission navigates to a separate failure page, so return to
+      // the challenge before filling and submitting a fresh code.
+      await page.goto(DEMO_URL, { waitUntil: "domcontentloaded" });
+
+      secondsLeft = 30 - (Math.floor(Date.now() / 1000) % 30);
+      if (secondsLeft < 8) {
+        console.log(`Waiting ${secondsLeft + 1} seconds for a fresh TOTP window...`);
+        await page.waitForTimeout((secondsLeft + 1) * 1000);
+      }
+
       const newCode = generateTOTP(credentials.totpSecret);
       console.log(`New TOTP code: ${newCode}`);
 
-      await stagehand.act("Clear the TOTP code field");
-      await stagehand.act(`Type '${newCode}' into the TOTP code field`);
-      await stagehand.act("Click the submit or login button");
+      await page.locator("#email").fill(credentials.email);
+      await page.locator("#password").fill(credentials.password);
+      await page.locator("#totpmfa").fill(newCode);
+      await page.locator('input[type="submit"]').click();
 
       try {
         console.log("Waiting for page to finish loading after retry submit...");

--- a/typescript/mfa-handling/index.ts
+++ b/typescript/mfa-handling/index.ts
@@ -1,8 +1,8 @@
 // Stagehand + Browserbase: MFA Handling - TOTP Automation - See README.md for full documentation
 
 import "dotenv/config";
-import { Stagehand } from "@browserbasehq/stagehand";
-import { z } from "zod";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
+import { z } from "zod/v4";
 import crypto from "crypto";
 
 // Demo site URL for TOTP challenge testing
@@ -57,24 +57,20 @@ async function main() {
   console.log("Starting MFA Handling - TOTP Automation...");
 
   // Initialize Stagehand with Browserbase for cloud-based browser automation
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 0,
-    // 0 = errors only, 1 = info, 2 = debug
-    // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
-    // https://docs.stagehand.dev/configuration/logging
-    model: "google/gemini-2.5-flash", // Routed through Model Gateway
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+  });
+  const stagehand = await Stagehand.create({
+    browser: browser,
+    model: { modelName: "google/gemini-2.5-flash" },
+    logging: { level: "error" },
   });
 
   try {
     // Initialize browser session to start automation
-    await stagehand.init();
-    console.log("Stagehand initialized successfully!");
-    console.log(
-      `Live View Link: https://browserbase.com/sessions/${stagehand.browserbaseSessionId}`,
-    );
 
-    const page = stagehand.context.pages()[0];
+    console.log("Stagehand initialized successfully!");
+    const page = (await browser.context.pages())[0];
 
     // Navigate to TOTP challenge demo page
     console.log("Navigating to TOTP Challenge page...");
@@ -84,7 +80,7 @@ async function main() {
 
     // Extract test credentials and TOTP secret from the page
     console.log("Extracting test credentials and TOTP secret...");
-    const credentials = await stagehand.extract(
+    const { data: credentials } = await stagehand.extract(
       "Extract the test email, password, and TOTP secret key shown on the page",
       z.object({
         email: z.string(),
@@ -118,7 +114,7 @@ async function main() {
     // Wait for response - be tolerant of sites that never reach full "networkidle"
     try {
       console.log("Waiting for page to finish loading after submit...");
-      await page.waitForLoadState("networkidle", { timeout: 15000 });
+      await page.waitForLoadState("networkidle", 15000);
     } catch (err) {
       console.warn(
         "Timed out waiting for 'networkidle' after submit; continuing because the login likely succeeded.",
@@ -128,7 +124,7 @@ async function main() {
 
     // Check if login succeeded
     console.log("Checking authentication result...");
-    const result = await stagehand.extract(
+    const { data: result } = await stagehand.extract(
       "Check if the login was successful or if there's an error message",
       z.object({
         success: z.boolean(),
@@ -153,7 +149,7 @@ async function main() {
 
       try {
         console.log("Waiting for page to finish loading after retry submit...");
-        await page.waitForLoadState("networkidle", { timeout: 15000 });
+        await page.waitForLoadState("networkidle", 15000);
       } catch (err) {
         console.warn(
           "Timed out waiting for 'networkidle' after retry submit; continuing because the login likely succeeded.",
@@ -161,7 +157,10 @@ async function main() {
         );
       }
 
-      const retryResult = await stagehand.extract("Check if the login was successful", z.boolean());
+      const { data: retryResult } = await stagehand.extract(
+        "Check if the login was successful",
+        z.boolean(),
+      );
 
       if (retryResult) {
         console.log("Success on retry!");
@@ -174,6 +173,7 @@ async function main() {
   } finally {
     // Always close session to release resources and clean up
     await stagehand.close();
+    await browser.close();
     console.log("Session closed successfully");
   }
 }
@@ -184,6 +184,6 @@ main().catch((err) => {
   console.error("  - Check .env file has BROWSERBASE_API_KEY");
   console.error("  - TOTP code may have expired (try running again)");
   console.error("  - Page structure may have changed");
-  console.error("Docs: https://docs.stagehand.dev/v3/first-steps/introduction");
+  console.error("Docs: https://docs.stagehand.dev/v4/first-steps/introduction");
   process.exit(1);
 });

--- a/typescript/mfa-handling/package.json
+++ b/typescript/mfa-handling/package.json
@@ -2,6 +2,7 @@
   "name": "mfa-handling-template",
   "version": "1.0.0",
   "description": "Stagehand + Browserbase: MFA Handling - TOTP Automation",
+  "type": "module",
   "main": "index.ts",
   "scripts": {
     "start": "tsx index.ts",

--- a/typescript/mfa-handling/package.json
+++ b/typescript/mfa-handling/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@browserbasehq/stagehand": "github:browserbase/stagehand#089f2aaeaea75696685949e0835aece95db54358&path:/packages/sdk-ts",
+    "@browserbasehq/stagehand": "github:browserbase/stagehand#4186c7d98d2f325b6fc85b3f760111e6c390d703&path:/packages/sdk-ts",
     "dotenv": "^16.0.0",
     "zod": "^4.4.3"
   },

--- a/typescript/mfa-handling/package.json
+++ b/typescript/mfa-handling/package.json
@@ -18,13 +18,18 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@browserbasehq/stagehand": "latest",
+    "@browserbasehq/stagehand": "github:browserbase/stagehand#089f2aaeaea75696685949e0835aece95db54358&path:/packages/sdk-ts",
     "dotenv": "^16.0.0",
-    "zod": "^3.22.0"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
     "tsx": "^4.7.0",
     "typescript": "^5.3.0"
-  }
+  },
+  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand@4.0.0 after it is published.",
+  "engines": {
+    "node": ">=22.18.0"
+  },
+  "packageManager": "pnpm@10.24.0"
 }

--- a/typescript/mfa-handling/package.json
+++ b/typescript/mfa-handling/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@browserbasehq/stagehand": "github:browserbase/stagehand#4186c7d98d2f325b6fc85b3f760111e6c390d703&path:/packages/sdk-ts",
+    "@browserbasehq/stagehand": "4.0.0",
     "dotenv": "^16.0.0",
     "zod": "^4.4.3"
   },
@@ -27,7 +27,6 @@
     "tsx": "^4.7.0",
     "typescript": "^5.3.0"
   },
-  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand@4.0.0 after it is published.",
   "engines": {
     "node": ">=22.18.0"
   },

--- a/typescript/microsoft-cua/README.md
+++ b/typescript/microsoft-cua/README.md
@@ -1,55 +1,37 @@
-# Stagehand + Browserbase: Computer Use Agent (CUA) Example
+# Stagehand V4 + Browserbase: Research Workflow
 
 ## AT A GLANCE
 
-- Goal: demonstrate autonomous web browsing using Microsoft's Computer Use Agent with Stagehand and Browserbase.
-- Uses Stagehand Agent to automate complex workflows with AI powered browser agents
-- Leverages Microsoft's fara-7b model for autonomous web interaction and decision-making.
-
-## GLOSSARY
-
-- agent: create an autonomous AI agent that can execute complex multi-step tasks
-  Docs → https://docs.stagehand.dev/basics/agent#what-is-agent
+- Goal: demonstrate the Stagehand V4 replacement for the former computer-use-agent example.
+- Uses explicit browser navigation and `extract()` through Browserbase Model Gateway.
+- Stagehand V4 intentionally has no `agent()` or CUA orchestration API; application code owns the steps.
 
 ## QUICKSTART
 
-1.  npm install
-2.  cp .env.example .env
-3.  Add your Browserbase API key, Azure API key, and Azure endpoint to .env
-4.  npm start
+1. `pnpm install`
+2. `cp .env.example .env`
+3. Add `BROWSERBASE_API_KEY` to `.env`
+4. `pnpm start`
 
 ## EXPECTED OUTPUT
 
-- Initializes Stagehand session with Browserbase
-- Navigates to Google search engine
-- Executes autonomous search and data extraction task
-- Displays live session link for monitoring
-- Returns structured results or completion status
-- Closes session cleanly
+- Launches a Browserbase browser with `browserbase.launch()`
+- Creates Stagehand with `Stagehand.create({ browser })`
+- Opens search results for the configured question
+- Extracts and prints an answer from the visible results
+- Closes both Stagehand and the browser handle
 
 ## COMMON PITFALLS
 
-- "Cannot find module": ensure all dependencies are installed
-- Missing credentials: verify .env contains BROWSERBASE_API_KEY, AZURE_API_KEY, and AZURE_ENDPOINT
-- Microsoft API access: ensure you have access to Microsoft's fara-7b model via Azure or Fireworks
-
-## USE CASES
-
-• Autonomous research: Let AI agents independently research topics, gather information, and compile reports without manual intervention.
-• Complex web workflows: Automate multi-step processes that require decision-making, form filling, and data extraction across multiple pages.
-• Content discovery: Search for specific information, verify data accuracy, and cross-reference sources autonomously.
-
-## NEXT STEPS
-
-• Customize instructions: Modify the instruction variable to test different autonomous tasks and scenarios.
-• Add error handling: Implement retry logic, fallback strategies, and better error recovery for failed agent actions.
-• Extend capabilities: Add support for file downloads, form submissions, and more complex interaction patterns.
+- Missing credentials: verify `.env` contains `BROWSERBASE_API_KEY`
+- V4 primitives return `{ data, metadata }`; read the answer from `result.data`
+- For autonomous runtime orchestration, expose V4 browser methods to your agent framework as tools
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+📚 Stagehand V4 Migration: https://docs.stagehand.dev/v4/migrations/v3
+📚 Stagehand V4 Docs: https://docs.stagehand.dev/v4/first-steps/introduction
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground
 🔧 Templates: https://www.browserbase.com/templates
-📧 Need help? support@browserbase.com
 💬 Discord: http://stagehand.dev/discord

--- a/typescript/microsoft-cua/README.md
+++ b/typescript/microsoft-cua/README.md
@@ -1,37 +1,30 @@
-# Stagehand V4 + Browserbase: Research Workflow
+# Stagehand Code Mode + Vercel AI SDK: Browser Agent
 
 ## AT A GLANCE
 
-- Goal: demonstrate the Stagehand V4 replacement for the former computer-use-agent example.
-- Uses explicit browser navigation and `extract()` through Browserbase Model Gateway.
-- Stagehand V4 intentionally has no `agent()` or CUA orchestration API; application code owns the steps.
+- Goal: replace the former computer-use orchestration example with a bring-your-own agent.
+- Vercel AI SDK `ToolLoopAgent` owns the agent loop.
+- Stagehand code mode supplies the stateful `code_execute` MCP browser tool.
 
 ## QUICKSTART
 
-1. `pnpm install`
-2. `cp .env.example .env`
-3. Add `BROWSERBASE_API_KEY` to `.env`
+1. `cd microsoft-cua`
+2. `pnpm install`
+3. Add `BROWSERBASE_API_KEY` and `AI_GATEWAY_API_KEY` to `.env`
 4. `pnpm start`
+
+Set `AGENT_MODEL` to select another AI Gateway model; the default is `openai/gpt-5.4`.
 
 ## EXPECTED OUTPUT
 
-- Launches a Browserbase browser with `browserbase.launch()`
-- Creates Stagehand with `Stagehand.create({ browser })`
-- Opens search results for the configured question
-- Extracts and prints an answer from the visible results
-- Closes both Stagehand and the browser handle
+- The agent browses with `code_execute` and returns cited research findings.
+- Closing the MCP client closes Stagehand and its Browserbase browser.
 
-## COMMON PITFALLS
+## SAFETY
 
-- Missing credentials: verify `.env` contains `BROWSERBASE_API_KEY`
-- V4 primitives return `{ data, metadata }`; read the answer from `result.data`
-- For autonomous runtime orchestration, expose V4 browser methods to your agent framework as tools
+Code mode executes model-authored JavaScript and is not itself a security sandbox. Isolate it for untrusted content.
 
-## HELPFUL RESOURCES
+## RESOURCES
 
-📚 Stagehand V4 Migration: https://docs.stagehand.dev/v4/migrations/v3
-📚 Stagehand V4 Docs: https://docs.stagehand.dev/v4/first-steps/introduction
-🎮 Browserbase: https://www.browserbase.com
-💡 Try it out: https://www.browserbase.com/playground
-🔧 Templates: https://www.browserbase.com/templates
-💬 Discord: http://stagehand.dev/discord
+- Stagehand: https://docs.stagehand.dev
+- Vercel AI SDK agents: https://ai-sdk.dev/docs/agents/building-agents

--- a/typescript/microsoft-cua/index.ts
+++ b/typescript/microsoft-cua/index.ts
@@ -5,12 +5,18 @@ import { createMCPClient } from "@ai-sdk/mcp";
 import { Experimental_StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
 import { ToolLoopAgent, stepCountIs } from "ai";
 
-const instruction = `Search for the next visible solar eclipse in North America and its expected date, and what about the one after that.`;
+const childEnv = Object.fromEntries(
+  Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+);
+
+const today = new Date().toISOString().slice(0, 10);
+const instruction = `As of ${today}, search live sources for the next visible solar eclipse in North America and its expected date, then the one after that. Cite the source URLs you actually opened.`;
 
 async function main() {
   const mcpClient = await createMCPClient({
     transport: new Experimental_StdioMCPTransport({
       command: "stagehand-codemode",
+      env: childEnv,
       stderr: "inherit",
     }),
   });
@@ -22,13 +28,31 @@ async function main() {
     const agent = new ToolLoopAgent({
       model: process.env.AGENT_MODEL ?? "openai/gpt-5.4",
       instructions:
-        "You are a browser research agent. Use code_execute for every browser operation. Prefer deterministic Stagehand V4 page and locator methods and include source URLs in the final answer.",
+        "You are a browser research agent. Use code_execute for every browser operation. Prefer deterministic Stagehand V4 page and locator methods and include source URLs in the final answer. Never cite a URL unless you navigated directly to it in the browser.",
       tools,
-      stopWhen: stepCountIs(20),
+      prepareStep: ({ stepNumber }) =>
+        stepNumber >= 10
+          ? {
+              activeTools: [],
+              toolChoice: "none",
+              instructions:
+                "Return the evidence-backed answer now. Include only source URLs you opened directly. Do not call another tool.",
+            }
+          : undefined,
+      stopWhen: stepCountIs(12),
     });
 
     console.log("Executing instruction:", instruction);
     const result = await agent.generate({ prompt: instruction });
+    const sourceUrls = new Set(result.text.match(/https?:\/\/\S+/g) ?? []);
+    const futureYears = new Set(
+      [...result.text.matchAll(/\b20\d{2}\b/g)]
+        .map((match) => Number(match[0]))
+        .filter((year) => year >= Number(today.slice(0, 4))),
+    );
+    if (!result.text.trim() || sourceUrls.size < 2 || futureYears.size < 2) {
+      throw new Error("Agent did not return two future eclipse dates with opened source URLs");
+    }
     console.log(result.text);
   } finally {
     await mcpClient.close();

--- a/typescript/microsoft-cua/index.ts
+++ b/typescript/microsoft-cua/index.ts
@@ -1,6 +1,6 @@
-// Stagehand + Browserbase: Computer Use Agent (CUA) Example - See README.md for full documentation
+// Stagehand V4 + Browserbase: Research Workflow - See README.md for full documentation
 
-import { Stagehand } from "@browserbasehq/stagehand";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 
 // ============================================================================
 // EXAMPLE INSTRUCTIONS - Choose one to test different scenarios
@@ -21,85 +21,50 @@ const instruction = `Search for the next visible solar eclipse in North America 
 // ============================================================================
 
 async function main() {
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    // model: "google/gemini-2.5-pro", // this is the model stagehand uses in act, observe, extract (not agent)
-    verbose: 1,
-    // 0 = errors only, 1 = info, 2 = debug
-    // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
-    // https://docs.stagehand.dev/configuration/logging
-    browserbaseSessionCreateParams: {
-      proxies: true, // Using proxies will give the agent a better chance of success - requires Developer Plan or higher, comment out if you don't have access
-      region: "us-west-2",
-      browserSettings: {
-        blockAds: true,
-        viewport: {
-          width: 1288,
-          height: 711,
-        },
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+    proxies: true,
+    region: "us-west-2",
+    browserSettings: {
+      blockAds: true,
+      viewport: {
+        width: 1288,
+        height: 711,
       },
     },
   });
+  const stagehand = await Stagehand.create({ browser, logging: { level: "info" } });
 
   try {
     // Initialize browser session to start automation.
-    await stagehand.init();
-    console.log("Stagehand initialized successfully!");
-    console.log(
-      `Live View Link: https://browserbase.com/sessions/${stagehand.browserbaseSessionId}`,
-    );
 
-    const page = stagehand.context.pages()[0];
+    console.log("Stagehand initialized successfully!");
+    const page = (await browser.context.pages())[0];
 
     // Navigate to search engine with extended timeout for slow-loading sites.
-    await page.goto("https://www.google.com/", {
+    await page.goto(`https://www.google.com/search?q=${encodeURIComponent(instruction)}`, {
       waitUntil: "domcontentloaded",
     });
 
-    // Create agent with computer use capabilities for autonomous web browsing.
-    const agent = stagehand.agent({
-      cua: true,
-      model: {
-        modelName: "microsoft/fara-7b",
-        apiKey: process.env.AZURE_API_KEY,
-        baseURL: process.env.AZURE_ENDPOINT,
-        /** Alternative model configuration for Fireworks Deployments */
-        // modelName: "accounts/...",
-        // apiKey: process.env.FIREWORKS_API_KEY,
-        // baseURL: "https://api.fireworks.ai/inference/v1",
-        // provider: "microsoft", // Important: this routes to the MicrosoftCUAClient
-      },
-      systemPrompt: `You are a helpful assistant that can use a web browser.
-      You are currently on the following page: ${page.url()}.
-      Do not ask follow up questions, the user will trust your judgement. If you are getting blocked on google, try another search engine.`,
-    });
-
     console.log("Executing instruction:", instruction);
-    const result = await agent.execute({
-      instruction: instruction,
-      maxSteps: 30,
-      highlightCursor: true,
-    });
-
-    if (result.success === true) {
-      console.log("Task completed successfully!");
-      console.log("Result:", result);
-    } else {
-      console.log("Task failed or was incomplete");
-    }
+    const { data: result } = await stagehand.extract(
+      "Answer the research question using the visible search results and include source URLs",
+    );
+    console.log("Task completed successfully!");
+    console.log("Result:", result.extraction);
   } catch (error) {
-    console.error("Error executing computer use agent:", error);
+    console.error("Error executing research workflow:", error);
   } finally {
     await stagehand.close();
+    await browser.close();
     console.log("Session closed successfully");
   }
 }
 
 main().catch((err) => {
-  console.error("Error in computer use agent example:", err);
+  console.error("Error in research workflow:", err);
   console.error("Common issues:");
   console.error("  - Check .env file has BROWSERBASE_API_KEY");
-  console.error("  - Verify AZURE_API_KEY is set for the agent");
-  console.error("Docs: https://docs.stagehand.dev/v3/first-steps/introduction");
+  console.error("Docs: https://docs.stagehand.dev/v4/first-steps/introduction");
   process.exit(1);
 });

--- a/typescript/microsoft-cua/index.ts
+++ b/typescript/microsoft-cua/index.ts
@@ -1,70 +1,42 @@
-// Stagehand V4 + Browserbase: Research Workflow - See README.md for full documentation
+// Stagehand code mode + Vercel AI SDK: browser agent example
 
-import { browserbase, Stagehand } from "@browserbasehq/stagehand";
+import "dotenv/config";
+import { createMCPClient } from "@ai-sdk/mcp";
+import { Experimental_StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
+import { ToolLoopAgent, stepCountIs } from "ai";
 
-// ============================================================================
-// EXAMPLE INSTRUCTIONS - Choose one to test different scenarios
-// ============================================================================
-
-// Example 1: Learning Plan Creation
-// const instruction = `I want to learn more about Sourdough Bread Making. It's my first time learning about it, and want to get a good grasp by investing 1 hour a day for the next 2 months. Go find online courses/resources, create a plan cross-referencing the time I want to invest with the modules/timelines of the courses and return the plan`;
-
-// Example 2: Flight Search
-// const instruction = `Use flights.google.com to find the lowest fare from all eligible one-way flights for 1 adult from JFK to Heathrow in the next 30 days.`;
-
-// Example 3: Solar Eclipse Research
 const instruction = `Search for the next visible solar eclipse in North America and its expected date, and what about the one after that.`;
 
-// Example 4: GitHub PR Verification
-// const instruction = `Find the most recently opened non-draft PR on Github for Browserbase's Stagehand project and make sure the combination-evals in the PR validation passed.`;
-
-// ============================================================================
-
 async function main() {
-  const browser = await browserbase.launch({
-    apiKey: process.env.BROWSERBASE_API_KEY!,
-    proxies: true,
-    region: "us-west-2",
-    browserSettings: {
-      blockAds: true,
-      viewport: {
-        width: 1288,
-        height: 711,
-      },
-    },
+  const mcpClient = await createMCPClient({
+    transport: new Experimental_StdioMCPTransport({
+      command: "stagehand-codemode",
+      stderr: "inherit",
+    }),
   });
-  const stagehand = await Stagehand.create({ browser, logging: { level: "info" } });
 
   try {
-    // Initialize browser session to start automation.
+    const tools = await mcpClient.tools();
+    if (!tools.code_execute) throw new Error("Stagehand code mode did not expose code_execute");
 
-    console.log("Stagehand initialized successfully!");
-    const page = (await browser.context.pages())[0];
-
-    // Navigate to search engine with extended timeout for slow-loading sites.
-    await page.goto(`https://www.google.com/search?q=${encodeURIComponent(instruction)}`, {
-      waitUntil: "domcontentloaded",
+    const agent = new ToolLoopAgent({
+      model: process.env.AGENT_MODEL ?? "openai/gpt-5.4",
+      instructions:
+        "You are a browser research agent. Use code_execute for every browser operation. Prefer deterministic Stagehand V4 page and locator methods and include source URLs in the final answer.",
+      tools,
+      stopWhen: stepCountIs(20),
     });
 
     console.log("Executing instruction:", instruction);
-    const { data: result } = await stagehand.extract(
-      "Answer the research question using the visible search results and include source URLs",
-    );
-    console.log("Task completed successfully!");
-    console.log("Result:", result.extraction);
-  } catch (error) {
-    console.error("Error executing research workflow:", error);
+    const result = await agent.generate({ prompt: instruction });
+    console.log(result.text);
   } finally {
-    await stagehand.close();
-    await browser.close();
-    console.log("Session closed successfully");
+    await mcpClient.close();
   }
 }
 
-main().catch((err) => {
-  console.error("Error in research workflow:", err);
-  console.error("Common issues:");
-  console.error("  - Check .env file has BROWSERBASE_API_KEY");
-  console.error("Docs: https://docs.stagehand.dev/v4/first-steps/introduction");
+main().catch((error) => {
+  console.error("Error in browser agent example:", error);
+  console.error("Check BROWSERBASE_API_KEY and AI_GATEWAY_API_KEY in .env");
   process.exit(1);
 });

--- a/typescript/microsoft-cua/package.json
+++ b/typescript/microsoft-cua/package.json
@@ -1,9 +1,8 @@
 {
-  "name": "exa-browserbase",
+  "name": "microsoft-browser-agent-template",
   "version": "1.0.0",
-  "description": "Stagehand + Browserbase + Exa: AI-Powered Job Search and Application",
+  "private": true,
   "type": "module",
-  "main": "index.ts",
   "scripts": {
     "start": "tsx index.ts"
   },
@@ -11,13 +10,12 @@
     "@ai-sdk/mcp": "^2.0.29",
     "@browserbasehq/stagehand-codemode": "github:browserbase/stagehand#54302fc5f13be5ad8e717d8e1388502de22be2ed&path:/packages/integrations",
     "ai": "^7.0.58",
-    "dotenv": "latest",
-    "exa-js": "latest"
+    "dotenv": "^17.4.2"
   },
   "devDependencies": {
-    "@types/node": "latest",
-    "tsx": "latest",
-    "typescript": "latest"
+    "@types/node": "^25.5.0",
+    "tsx": "^4.23.1",
+    "typescript": "^5.9.3"
   },
   "//": "TODO: Replace this commit pin with @browserbasehq/stagehand-codemode@4.0.0 after it is published.",
   "engines": {

--- a/typescript/nurse-verification/README.md
+++ b/typescript/nurse-verification/README.md
@@ -5,14 +5,14 @@
 - Goal: automate verification of nurse licenses by filling forms and extracting structured results from verification sites.
 - Flow: loop through license records → navigate to verification site → fill form → search → extract verification results.
 - Benefits: quickly verify multiple licenses without manual form filling, structured data ready for compliance tracking or HR systems.
-  Docs → https://docs.stagehand.dev/basics/act
+  Docs → https://docs.stagehand.dev/v4/basics/act
 
 ## GLOSSARY
 
 - act: perform UI actions from a prompt (type, click, fill forms).
-  Docs → https://docs.stagehand.dev/basics/act
+  Docs → https://docs.stagehand.dev/v4/basics/act
 - extract: pull structured data from a page using AI and Zod schemas.
-  Docs → https://docs.stagehand.dev/basics/extract
+  Docs → https://docs.stagehand.dev/v4/basics/extract
 - schema: a Zod definition that enforces data types, optional fields, and validation rules.
   Docs → https://zod.dev/
 - license verification: process of confirming the validity and status of professional licenses.

--- a/typescript/nurse-verification/README.md
+++ b/typescript/nurse-verification/README.md
@@ -32,7 +32,7 @@
 - For each record: navigates to verification site, fills form, searches
 - Extracts verification results: name, license number, status, info URL
 - Displays structured JSON output with all verification results
-- Provides live session URL for monitoring
+- Closes both the Stagehand instance and browser handle after verification
 - Closes session cleanly
 
 ## COMMON PITFALLS
@@ -57,7 +57,7 @@
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
 🎮 Browserbase: https://www.browserbase.com
 📧 Need help? support@browserbase.com
 💬 Discord: http://stagehand.dev/discord

--- a/typescript/nurse-verification/index.ts
+++ b/typescript/nurse-verification/index.ts
@@ -1,8 +1,8 @@
 // Stagehand + Browserbase: Automated Nurse License Verification - See README.md for full documentation
 
 import "dotenv/config";
-import { Stagehand } from "@browserbasehq/stagehand";
-import { z } from "zod";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
+import { z } from "zod/v4";
 
 // License records to verify - add more records as needed
 const LicenseRecords = [
@@ -18,25 +18,22 @@ async function main() {
   console.log("Starting Nurse License Verification Automation...");
 
   // Initialize Stagehand with Browserbase for cloud-based browser automation
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 1,
-    // 0 = errors only, 1 = info, 2 = debug
-    // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
-    // https://docs.stagehand.dev/configuration/logging
-    model: "openai/gpt-4.1",
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+  });
+  const stagehand = await Stagehand.create({
+    browser: browser,
+    model: { modelName: "openai/gpt-4.1" },
+    logging: { level: "info" },
   });
 
   try {
     // Initialize browser session
     console.log("Initializing browser session...");
-    await stagehand.init();
+
     console.log("Stagehand session started successfully");
 
-    // Provide live session URL for debugging and monitoring
-    console.log(`Watch live: https://browserbase.com/sessions/${stagehand.browserbaseSessionID}`);
-
-    const page = stagehand.context.pages()[0];
+    const page = (await browser.context.pages())[0];
 
     // Process each license record sequentially
     for (const LicenseRecord of LicenseRecords) {
@@ -62,7 +59,7 @@ async function main() {
 
       // Extract license verification results
       console.log("Extracting license verification results...");
-      const results = await stagehand.extract(
+      const { data: results } = await stagehand.extract(
         "Extract ALL the license verification results from the page, including name, license number and status",
         z.object({
           list_of_licenses: z.array(
@@ -93,6 +90,7 @@ async function main() {
     // Clean up browser session
     console.log("Closing browser session...");
     await stagehand.close();
+    await browser.close();
     console.log("Session closed successfully");
   }
 }

--- a/typescript/pickleball/README.md
+++ b/typescript/pickleball/README.md
@@ -73,7 +73,7 @@
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground
 🔧 Templates: https://www.browserbase.com/templates

--- a/typescript/pickleball/README.md
+++ b/typescript/pickleball/README.md
@@ -11,11 +11,11 @@
 ## GLOSSARY
 
 - act: perform UI actions from a prompt (click, type, select)
-  Docs → https://docs.stagehand.dev/basics/act
+  Docs → https://docs.stagehand.dev/v4/basics/act
 - extract: pull structured data from pages using schemas
-  Docs → https://docs.stagehand.dev/basics/extract
+  Docs → https://docs.stagehand.dev/v4/basics/extract
 - observe: plan actions and get selectors before executing
-  Docs → https://docs.stagehand.dev/basics/observe
+  Docs → https://docs.stagehand.dev/v4/basics/observe
 - browser automation: automated interaction with web applications for booking systems
   Docs → https://docs.browserbase.com/fundamentals/create-browser-session
 - form validation: ensure user input meets booking system requirements

--- a/typescript/pickleball/index.ts
+++ b/typescript/pickleball/index.ts
@@ -1,8 +1,8 @@
 // SF Court Booking Automation - See README.md for full documentation
 import "dotenv/config";
-import { Stagehand } from "@browserbasehq/stagehand";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 import inquirer from "inquirer";
-import { z } from "zod";
+import { z } from "zod/v4";
 
 async function loginToSite(stagehand: Stagehand, email: string, password: string): Promise<void> {
   console.log("Logging in...");
@@ -63,13 +63,13 @@ async function checkAndExtractCourts(stagehand: Stagehand, timeOfDay: string): P
   console.log("Checking for available courts...");
 
   // First observe the page to find all available court booking options.
-  const availableCourts = await stagehand.observe(
+  const { data: availableCourts } = await stagehand.observe(
     "Find all available court booking slots, time slots, or court reservation options",
   );
   console.log(`Found ${availableCourts.length} available court options`);
 
   // Extract structured court data using Zod schema for type safety and validation.
-  const courtData = await stagehand.extract(
+  const { data: courtData } = await stagehand.extract(
     "Extract all available court booking information including court names, time slots, locations, and any other relevant details",
     z.object({
       courts: z.array(
@@ -113,13 +113,13 @@ async function checkAndExtractCourts(stagehand: Stagehand, timeOfDay: string): P
       await stagehand.act(`Select ${altTime} from the time period options`);
       await stagehand.act(`Click the Done button`);
 
-      const altAvailableCourts = await stagehand.observe(
+      const { data: altAvailableCourts } = await stagehand.observe(
         "Find all available court booking slots, time slots, or court reservation options",
       );
       console.log(`Found ${altAvailableCourts.length} available court options for ${altTime}`);
 
       if (altAvailableCourts.length > 0) {
-        const altCourtData = await stagehand.extract(
+        const { data: altCourtData } = await stagehand.extract(
           "Extract all available court booking information including court names, time slots, locations, and any other relevant details",
           z.object({
             courts: z.array(
@@ -161,7 +161,7 @@ async function checkAndExtractCourts(stagehand: Stagehand, timeOfDay: string): P
   // If still no available courts found, extract final court data for display.
   if (!hasAvailableCourts) {
     console.log("Extracting final court information...");
-    const finalCourtData = await stagehand.extract(
+    const { data: finalCourtData } = await stagehand.extract(
       "Extract all available court booking information including court names, time slots, locations, and any other relevant details",
       z.object({
         courts: z.array(
@@ -253,7 +253,7 @@ async function bookCourt(stagehand: Stagehand): Promise<void> {
 
     // Extract booking confirmation details to verify successful reservation.
     console.log("Checking for booking confirmation...");
-    const confirmation = await stagehand.extract(
+    const { data: confirmation } = await stagehand.extract(
       "Extract any booking confirmation message, success notification, or reservation details",
       z.object({
         confirmationMessage: z.string().nullable().describe("any confirmation or success message"),
@@ -393,27 +393,22 @@ async function bookTennisPaddleCourt() {
 
   // Initialize Stagehand with Browserbase for AI-powered browser automation.
   console.log("Initializing Stagehand with Browserbase");
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 1,
-    // 0 = errors only, 1 = info, 2 = debug
-    // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
-    // https://docs.stagehand.dev/configuration/logging
-    model: "openai/gpt-4.1",
-    browserbaseSessionCreateParams: {
-      timeout: 900,
-      region: "us-west-2",
-    },
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+    timeout: 900,
+    region: "us-west-2",
+  });
+  const stagehand = await Stagehand.create({
+    browser: browser,
+    model: { modelName: "openai/gpt-4.1" },
+    logging: { level: "info" },
   });
 
   try {
     // Start browser session and connect to SF Rec & Parks booking system.
-    await stagehand.init();
 
     console.log("Browserbase Session Started");
-    console.log(`Watch live: https://browserbase.com/sessions/${stagehand.browserbaseSessionID}`);
-
-    const page = stagehand.context.pages()[0];
+    const page = (await browser.context.pages())[0];
 
     // Navigate to SF Rec & Parks booking site with extended timeout for slow loading.
     console.log("Navigating to court booking site...");
@@ -433,6 +428,7 @@ async function bookTennisPaddleCourt() {
   } finally {
     // Always close browser session to release resources and clean up.
     await stagehand.close();
+    await browser.close();
     console.log("\nBrowser session closed");
   }
 }

--- a/typescript/polymarket-research/README.md
+++ b/typescript/polymarket-research/README.md
@@ -57,7 +57,7 @@
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
 🎮 Browserbase: https://www.browserbase.com
 📧 Need help? support@browserbase.com
 💬 Discord: http://stagehand.dev/discord

--- a/typescript/polymarket-research/README.md
+++ b/typescript/polymarket-research/README.md
@@ -3,19 +3,17 @@
 ## AT A GLANCE
 
 - Goal: demonstrate how to automate market research on prediction markets using Stagehand.
-- Navigation & Search: automate website navigation, search interactions, and result selection.
+- Deterministic Navigation: opens the intended market URL directly so result ordering cannot select a different market.
 - Data Extraction: extract structured market data with validated output using Zod schemas.
 - Practical Example: research and extract current odds from Polymarket prediction markets.
 
 ## GLOSSARY
 
-- act: perform UI actions from a natural language prompt (type, click, navigate).
-  Docs → https://docs.stagehand.dev/basics/act
 - extract: pull structured data from web pages into validated objects.
-  Docs → https://docs.stagehand.dev/basics/extract
+  Docs → https://docs.stagehand.dev/v4/basics/extract
 - schema: a Zod definition that enforces data types, optional fields, and validation rules.
   Docs → https://zod.dev/
-- market research automation: navigate to prediction markets, search for specific topics, and extract current odds.
+- market research automation: navigate to a specific prediction market and extract current odds.
 - structured data extraction: convert unstructured web content into typed, validated objects.
 
 ## QUICKSTART
@@ -29,8 +27,7 @@
 ## EXPECTED OUTPUT
 
 - Navigates to Polymarket prediction market website
-- Searches for specified market query
-- Selects the first search result
+- Opens the configured market URL directly
 - Extracts structured market data including odds, prices, and volume
 - Returns typed object with market information
 
@@ -38,7 +35,7 @@
 
 - "Cannot find module 'dotenv'": ensure npm install ran successfully
 - Missing API key: verify .env is loaded and file is not committed
-- Search results not found: check if the market exists or if website structure has changed
+- Market not found: check whether the configured market URL still exists
 - Schema validation errors: ensure extracted data matches Zod schema structure
 
 ## USE CASES
@@ -50,7 +47,7 @@
 
 ## NEXT STEPS
 
-• Parameterize search queries: make the search term configurable via environment variables or prompts.
+• Parameterize market URLs: make the target market configurable via environment variables or CLI input.
 • Multi-market extraction: extend the flow to search and extract data from multiple markets in parallel.
 • Historical tracking: persist extracted data over time to track market movement and trends.
 • Price alerts: add logic to monitor specific price thresholds and send notifications.

--- a/typescript/polymarket-research/index.ts
+++ b/typescript/polymarket-research/index.ts
@@ -40,13 +40,15 @@ async function main() {
     await stagehand.act("click the search box at the top of the page");
 
     // Type search query
-    const searchQuery = "Elon Musk unfollow Trump";
+    const searchQuery = "Elon Musk rejoin Trump Administration";
     console.log(`Typing '${searchQuery}' into the search box`);
     await stagehand.act(`type '${searchQuery}' into the search box`);
 
-    // Click the first market result from the search dropdown
-    console.log("Selecting first market result from search dropdown");
-    await stagehand.act("click the first market result from the search dropdown");
+    // Select the intended market explicitly so a change in result ordering cannot
+    // send the extraction to an unrelated Trump or Elon Musk market.
+    const marketTitle = "Will Elon Musk rejoin the Trump Administration in 2026?";
+    console.log(`Selecting market: ${marketTitle}`);
+    await stagehand.act(`click the market titled '${marketTitle}' in the search results`);
     console.log("Market page loaded");
 
     // Extract market data using AI to parse the structured information

--- a/typescript/polymarket-research/index.ts
+++ b/typescript/polymarket-research/index.ts
@@ -1,8 +1,8 @@
 // Stagehand + Browserbase: Polymarket prediction market research - See README.md for full documentation
 
 import "dotenv/config";
-import { Stagehand } from "@browserbasehq/stagehand";
-import { z } from "zod";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
+import { z } from "zod/v4";
 
 /**
  * Searches Polymarket for a prediction market and extracts current odds, pricing, and volume data.
@@ -13,25 +13,22 @@ async function main() {
 
   // Initialize Stagehand with Browserbase for cloud-based browser automation
   // Using BROWSERBASE environment to run in cloud rather than locally
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 1,
-    // 0 = errors only, 1 = info, 2 = debug
-    // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
-    // https://docs.stagehand.dev/configuration/logging
-    model: "openai/gpt-4.1",
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+  });
+  const stagehand = await Stagehand.create({
+    browser: browser,
+    model: { modelName: "openai/gpt-4.1" },
+    logging: { level: "info" },
   });
 
   try {
     // Initialize browser session
     console.log("Initializing browser session...");
-    await stagehand.init();
+
     console.log("Stagehand session started successfully");
 
-    // Provide live session URL for debugging and monitoring
-    console.log(`Watch live: https://browserbase.com/sessions/${stagehand.browserbaseSessionID}`);
-
-    const page = stagehand.context.pages()[0];
+    const page = (await browser.context.pages())[0];
 
     // Navigate to Polymarket
     console.log("Navigating to: https://polymarket.com/");
@@ -54,7 +51,7 @@ async function main() {
 
     // Extract market data using AI to parse the structured information
     console.log("Extracting market information...");
-    const marketData = await stagehand.extract(
+    const { data: marketData } = await stagehand.extract(
       "Extract the current odds and market information for the prediction market",
       z.object({
         marketTitle: z.string().optional().describe("the title of the market"),
@@ -82,6 +79,7 @@ async function main() {
     // Clean up browser session
     console.log("Closing browser session...");
     await stagehand.close();
+    await browser.close();
     console.log("Session closed successfully");
   }
 }

--- a/typescript/polymarket-research/index.ts
+++ b/typescript/polymarket-research/index.ts
@@ -30,40 +30,35 @@ async function main() {
 
     const page = (await browser.context.pages())[0];
 
-    // Navigate to Polymarket
-    console.log("Navigating to: https://polymarket.com/");
-    await page.goto("https://polymarket.com/");
+    const marketUrl =
+      "https://polymarket.com/event/will-elon-musk-rejoin-the-trump-administration-in-2026";
+
+    // Navigate directly to the intended market so homepage search UI changes
+    // cannot silently send extraction to an unrelated page.
+    console.log(`Navigating to: ${marketUrl}`);
+    await page.goto(marketUrl, { waitUntil: "domcontentloaded", timeout: 60000 });
     console.log("Page loaded successfully");
-
-    // Click the search box to trigger search dropdown
-    console.log("Clicking the search box at the top of the page");
-    await stagehand.act("click the search box at the top of the page");
-
-    // Type search query
-    const searchQuery = "Elon Musk rejoin Trump Administration";
-    console.log(`Typing '${searchQuery}' into the search box`);
-    await stagehand.act(`type '${searchQuery}' into the search box`);
-
-    // Select the intended market explicitly so a change in result ordering cannot
-    // send the extraction to an unrelated Trump or Elon Musk market.
-    const marketTitle = "Will Elon Musk rejoin the Trump Administration in 2026?";
-    console.log(`Selecting market: ${marketTitle}`);
-    await stagehand.act(`click the market titled '${marketTitle}' in the search results`);
-    console.log("Market page loaded");
 
     // Extract market data using AI to parse the structured information
     console.log("Extracting market information...");
     const { data: marketData } = await stagehand.extract(
       "Extract the current odds and market information for the prediction market",
       z.object({
-        marketTitle: z.string().optional().describe("the title of the market"),
-        currentOdds: z.string().optional().describe("the current odds or probability"),
-        yesPrice: z.string().optional().describe("the yes price"),
-        noPrice: z.string().optional().describe("the no price"),
-        totalVolume: z.string().optional().describe("the total trading volume"),
-        priceChange: z.string().optional().describe("the recent price change"),
+        marketTitle: z.string().describe("the title of the market"),
+        currentOdds: z.string().nullable().describe("the current odds or probability"),
+        yesPrice: z.string().nullable().describe("the yes price"),
+        noPrice: z.string().nullable().describe("the no price"),
+        totalVolume: z.string().nullable().describe("the total trading volume"),
+        priceChange: z.string().nullable().describe("the recent price change"),
       }),
     );
+
+    if (!marketData.marketTitle.toLowerCase().includes("elon musk")) {
+      throw new Error(`Unexpected market title: ${marketData.marketTitle || "empty"}`);
+    }
+    if (!marketData.currentOdds && !marketData.yesPrice && !marketData.noPrice) {
+      throw new Error("Market extraction returned no live odds or prices");
+    }
 
     console.log("Market data extracted successfully:");
     console.log(JSON.stringify(marketData, null, 2));

--- a/typescript/proxies-weather/README.md
+++ b/typescript/proxies-weather/README.md
@@ -21,15 +21,14 @@
 
 1. cd proxies-weather-template
 2. pnpm install
-3. pnpm install @browserbasehq/sdk @browserbasehq/stagehand zod
-4. cp .env.example .env
-5. Add your Browserbase API key to .env
-6. pnpm start
+3. cp .env.example .env
+4. Add your Browserbase API key to .env
+5. pnpm start
 
 ## EXPECTED OUTPUT
 
 - Creates Browserbase sessions with geolocation proxies for each location (New York, London, Tokyo, São Paulo)
-- Displays session URLs for each location for monitoring
+- Closes each Stagehand instance and Browserbase browser handle after extraction
 - Navigates to weather service (windy.com) through location-specific proxies
 - Extracts temperature and unit for each location
 - Displays formatted results showing different weather data based on proxy location
@@ -46,7 +45,7 @@
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground
 🔧 Templates: https://www.browserbase.com/templates

--- a/typescript/proxies-weather/README.md
+++ b/typescript/proxies-weather/README.md
@@ -4,7 +4,7 @@
 
 - Goal: demonstrate geolocation proxies by fetching location-specific weather data from multiple cities using Browserbase's proxy infrastructure.
 - Uses geolocation proxies to route traffic through specific geographic locations (New York, London, Tokyo, São Paulo).
-- Extracts structured weather data using Stagehand's extraction capabilities with Zod schema validation.
+- Reads current `wttr.in` JSON through each proxied browser and verifies that the service reports the expected country.
 - Sequential processing shows how different proxy locations return different weather data from the same website.
 - Docs → https://docs.browserbase.com/features/proxies
 
@@ -12,14 +12,14 @@
 
 - geolocation proxies: route traffic through specific geographic locations (city, country, state) to access location-specific content
   Docs → https://docs.browserbase.com/features/proxies#set-proxy-geolocation
-- extract: extract structured data from web pages using natural language instructions and Zod schemas
-  Docs → https://docs.stagehand.dev/basics/extract
+- page APIs: read a known machine-readable response directly through the V4 browser page
+  Docs → https://docs.stagehand.dev/v4/reference/page
 - proxies: Browserbase's managed proxy infrastructure supporting 201+ countries for geolocation-based routing
   Docs → https://docs.browserbase.com/features/proxies
 
 ## QUICKSTART
 
-1. cd proxies-weather-template
+1. cd proxies-weather
 2. pnpm install
 3. cp .env.example .env
 4. Add your Browserbase API key to .env
@@ -29,15 +29,15 @@
 
 - Creates Browserbase sessions with geolocation proxies for each location (New York, London, Tokyo, São Paulo)
 - Closes each Stagehand instance and Browserbase browser handle after extraction
-- Navigates to weather service (windy.com) through location-specific proxies
-- Extracts temperature and unit for each location
+- Navigates to `wttr.in` through location-specific proxies
+- Validates temperature, conditions, nearest reported location, and country for every proxy
 - Displays formatted results showing different weather data based on proxy location
 - Demonstrates how geolocation proxies enable location-specific content access
 
 ## COMMON PITFALLS
 
 - Browserbase Developer plan or higher is required to use proxies
-- "Cannot find module": ensure all dependencies are installed (@browserbasehq/sdk, @browserbasehq/stagehand, zod)
+- "Cannot find module": install the template dependencies with `pnpm install`
 - Missing credentials: verify .env contains BROWSERBASE_API_KEY
 - Geolocation fields are case-insensitive (city, country, state can be any case)
 - State is required for US locations to ensure accurate geolocation

--- a/typescript/proxies-weather/index.ts
+++ b/typescript/proxies-weather/index.ts
@@ -2,7 +2,6 @@
 
 import "dotenv/config";
 import { browserbase, Stagehand } from "@browserbasehq/stagehand";
-import { z } from "zod/v4";
 
 interface GeolocationConfig {
   city: string;
@@ -15,7 +14,36 @@ interface WeatherResult {
   country: string;
   temperature: number;
   unit: string;
+  conditions: string;
+  reportedLocation: string;
+  reportedCountry: string;
   error?: string;
+}
+
+interface WttrResponse {
+  current_condition?: Array<{
+    temp_C?: string;
+    weatherDesc?: Array<{ value?: string }>;
+  }>;
+  nearest_area?: Array<{
+    areaName?: Array<{ value?: string }>;
+    country?: Array<{ value?: string }>;
+  }>;
+}
+
+const EXPECTED_COUNTRIES: Record<string, string> = {
+  US: "United States",
+  GB: "United Kingdom",
+  JP: "Japan",
+  BR: "Brazil",
+};
+
+async function closeSession(
+  stagehand: Stagehand,
+  browser: Awaited<ReturnType<typeof browserbase.launch>>,
+) {
+  await stagehand.close().catch((error) => console.warn("Stagehand cleanup warning:", error));
+  await browser.close().catch((error) => console.warn("Browser cleanup warning:", error));
 }
 
 // Fetches weather data for a specific location using geolocation proxies
@@ -52,47 +80,63 @@ async function getWeatherForLocation(geolocation: GeolocationConfig): Promise<We
 
     // Navigate to weather service - geolocation proxy ensures location-specific weather data
     console.log(`Navigating to weather service for ${cityName}...`);
-    await page.goto("https://www.windy.com/", {
-      waitUntil: "networkidle", // Wait for network to be idle to ensure weather data is loaded
+    await page.goto("https://wttr.in/?format=j1", {
+      waitUntil: "domcontentloaded",
+      timeout: 60000,
     });
     console.log(`Page loaded for ${cityName}`);
 
-    // Wait a bit for weather data to render
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+    // wttr.in derives the location from the proxied IP and returns current conditions as JSON.
+    console.log(`Reading current weather data for ${cityName}...`);
+    const body = await page.evaluate(() => document.body.textContent ?? "");
+    const weather = JSON.parse(body) as WttrResponse;
+    const current = weather.current_condition?.[0];
+    const nearestArea = weather.nearest_area?.[0];
+    const temperature = Number.parseFloat(current?.temp_C ?? "");
+    const conditions = current?.weatherDesc?.[0]?.value?.trim() ?? "";
+    const reportedLocation = nearestArea?.areaName?.[0]?.value?.trim() ?? "";
+    const reportedCountry = nearestArea?.country?.[0]?.value?.trim() ?? "";
+    if (!Number.isFinite(temperature)) {
+      throw new Error("Weather service did not return a numeric current temperature");
+    }
+    if (!conditions || !reportedLocation || !reportedCountry) {
+      throw new Error("Weather service returned incomplete current conditions");
+    }
 
-    // Extract structured temperature data using Stagehand and Zod schema for type safety
-    console.log(`Extracting temperature data for ${cityName}...`);
-    const { data: extractResult } = await stagehand.extract(
-      "Extract the current temperature and its unit",
-      z.object({
-        temperature: z.number().describe("The current temperature value"),
-        unit: z.string().describe("The temperature unit)"),
-      }),
-    );
+    const expectedCountry = EXPECTED_COUNTRIES[geolocation.country];
+    if (!reportedCountry.toLowerCase().includes(expectedCountry.toLowerCase())) {
+      throw new Error(
+        `Proxy location mismatch: expected ${expectedCountry}, received ${reportedCountry}`,
+      );
+    }
 
     console.log(
-      `Successfully extracted weather data for ${cityName}: ${extractResult.temperature} ${extractResult.unit}`,
+      `Successfully read weather near ${reportedLocation}, ${reportedCountry}: ${temperature} °C, ${conditions}`,
     );
 
     // Close Stagehand session to release resources
-    await stagehand.close();
-    await browser.close();
+    await closeSession(stagehand, browser);
 
     return {
       city: cityName,
       country: geolocation.country,
-      temperature: extractResult.temperature,
-      unit: extractResult.unit,
+      temperature,
+      unit: "°C",
+      conditions,
+      reportedLocation,
+      reportedCountry,
     };
   } catch (error) {
-    await stagehand.close();
-    await browser.close();
+    await closeSession(stagehand, browser);
     console.error(`Error getting weather for ${cityName}:`, error);
     return {
       city: cityName,
       country: geolocation.country,
       temperature: 0,
       unit: "",
+      conditions: "",
+      reportedLocation: "",
+      reportedCountry: "",
       error: error instanceof Error ? error.message : String(error),
     };
   }
@@ -107,7 +151,9 @@ function displayResults(results: WeatherResult[]) {
     if (result.error) {
       console.log(`${result.city}, ${result.country}: Error - ${result.error}`);
     } else {
-      console.log(`${result.city}, ${result.country}: ${result.temperature} ${result.unit}`);
+      console.log(
+        `${result.city}, ${result.country}: ${result.temperature} ${result.unit}, ${result.conditions} (reported near ${result.reportedLocation}, ${result.reportedCountry})`,
+      );
     }
   }
 }
@@ -158,6 +204,13 @@ async function main() {
 
   // Display all results in formatted summary
   displayResults(results);
+
+  const failures = results.filter((result) => result.error);
+  if (failures.length > 0) {
+    throw new Error(
+      `Weather extraction failed for ${failures.length} of ${results.length} locations`,
+    );
+  }
 
   console.log("\n=== All locations completed ===");
 }

--- a/typescript/proxies-weather/index.ts
+++ b/typescript/proxies-weather/index.ts
@@ -1,8 +1,8 @@
 // Stagehand + Browserbase: Weather Proxy Demo - See README.md for full documentation
 
 import "dotenv/config";
-import { Stagehand } from "@browserbasehq/stagehand";
-import { z } from "zod";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
+import { z } from "zod/v4";
 
 interface GeolocationConfig {
   city: string;
@@ -27,33 +27,28 @@ async function getWeatherForLocation(geolocation: GeolocationConfig): Promise<We
 
   // Initialize Stagehand with geolocation proxy configuration
   // This ensures all browser traffic routes through the specified geographic location
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 0,
-    // 0 = errors only, 1 = info, 2 = debug
-    // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
-    // https://docs.stagehand.dev/configuration/logging
-    browserbaseSessionCreateParams: {
-      proxies: [
-        {
-          type: "browserbase", // Use Browserbase's managed proxy infrastructure for reliable geolocation routing
-          geolocation: {
-            city: geolocation.city, // City name (case-insensitive, e.g., "NEW_YORK", "new_york", "New York" all work)
-            country: geolocation.country, // ISO country code (case-insensitive, e.g., "US", "us", "gb", "GB" all work)
-            ...(geolocation.state && { state: geolocation.state }), // State required for US locations (case-insensitive)
-          },
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+    proxies: [
+      {
+        type: "browserbase", // Use Browserbase's managed proxy infrastructure for reliable geolocation routing
+        geolocation: {
+          city: geolocation.city, // City name (case-insensitive, e.g., "NEW_YORK", "new_york", "New York" all work)
+          country: geolocation.country, // ISO country code (case-insensitive, e.g., "US", "us", "gb", "GB" all work)
+          ...(geolocation.state && { state: geolocation.state }), // State required for US locations (case-insensitive)
         },
-      ],
-    },
+      },
+    ],
   });
+  const stagehand = await Stagehand.create({ browser: browser, logging: { level: "error" } });
 
   try {
     // Initialize browser session to start automation
     console.log(`Initializing Stagehand for ${cityName}...`);
-    await stagehand.init();
+
     console.log(`Stagehand initialized successfully for ${cityName}`);
 
-    const page = stagehand.context.pages()[0];
+    const page = (await browser.context.pages())[0];
 
     // Navigate to weather service - geolocation proxy ensures location-specific weather data
     console.log(`Navigating to weather service for ${cityName}...`);
@@ -67,7 +62,7 @@ async function getWeatherForLocation(geolocation: GeolocationConfig): Promise<We
 
     // Extract structured temperature data using Stagehand and Zod schema for type safety
     console.log(`Extracting temperature data for ${cityName}...`);
-    const extractResult = await stagehand.extract(
+    const { data: extractResult } = await stagehand.extract(
       "Extract the current temperature and its unit",
       z.object({
         temperature: z.number().describe("The current temperature value"),
@@ -81,6 +76,7 @@ async function getWeatherForLocation(geolocation: GeolocationConfig): Promise<We
 
     // Close Stagehand session to release resources
     await stagehand.close();
+    await browser.close();
 
     return {
       city: cityName,
@@ -90,6 +86,7 @@ async function getWeatherForLocation(geolocation: GeolocationConfig): Promise<We
     };
   } catch (error) {
     await stagehand.close();
+    await browser.close();
     console.error(`Error getting weather for ${cityName}:`, error);
     return {
       city: cityName,
@@ -173,6 +170,6 @@ main().catch((err) => {
     "  - Verify geolocation proxy locations are valid (see https://docs.browserbase.com/features/proxies)",
   );
   console.error("  - Ensure locations array is properly configured");
-  console.error("Docs: https://docs.stagehand.dev/v3/first-steps/introduction");
+  console.error("Docs: https://docs.stagehand.dev/v4/first-steps/introduction");
   process.exit(1);
 });

--- a/typescript/proxies-weather/package.json
+++ b/typescript/proxies-weather/package.json
@@ -2,16 +2,22 @@
   "name": "proxies-weather-template",
   "type": "module",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --noEmit --skipLibCheck --target ES2022 --module NodeNext --moduleResolution NodeNext index.ts",
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@browserbasehq/stagehand": "latest",
+    "@browserbasehq/stagehand": "github:browserbase/stagehand#089f2aaeaea75696685949e0835aece95db54358&path:/packages/sdk-ts",
     "dotenv": "^16.4.7",
-    "zod": "latest"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@types/node": "^22.18.0",
     "tsx": "^4.19.2",
     "typescript": "^5.0.0"
-  }
+  },
+  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand@4.0.0 after it is published.",
+  "engines": {
+    "node": ">=22.18.0"
+  },
+  "packageManager": "pnpm@10.24.0"
 }

--- a/typescript/proxies-weather/package.json
+++ b/typescript/proxies-weather/package.json
@@ -6,7 +6,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@browserbasehq/stagehand": "github:browserbase/stagehand#4186c7d98d2f325b6fc85b3f760111e6c390d703&path:/packages/sdk-ts",
+    "@browserbasehq/stagehand": "4.0.0",
     "dotenv": "^16.4.7",
     "zod": "^4.4.3"
   },
@@ -15,7 +15,6 @@
     "tsx": "^4.19.2",
     "typescript": "^5.0.0"
   },
-  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand@4.0.0 after it is published.",
   "engines": {
     "node": ">=22.18.0"
   },

--- a/typescript/proxies-weather/package.json
+++ b/typescript/proxies-weather/package.json
@@ -6,7 +6,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@browserbasehq/stagehand": "github:browserbase/stagehand#089f2aaeaea75696685949e0835aece95db54358&path:/packages/sdk-ts",
+    "@browserbasehq/stagehand": "github:browserbase/stagehand#4186c7d98d2f325b6fc85b3f760111e6c390d703&path:/packages/sdk-ts",
     "dotenv": "^16.4.7",
     "zod": "^4.4.3"
   },

--- a/typescript/proxies/README.md
+++ b/typescript/proxies/README.md
@@ -11,33 +11,30 @@
 
 ## QUICKSTART
 
-1.  cd proxies-template
-2.  npm install
-3.  npm install @browserbasehq/sdk playwright-core
-4.  cp .env.example .env
-5.  Add your Browserbase API key to .env
-6.  npm start
+1. cd proxies
+2. Install the template dependencies
+3. cp .env.example .env
+4. Add your Browserbase API key to .env
+5. Run the template entrypoint
 
 ## EXPECTED OUTPUT
 
 - Tests built-in proxy rotation
 - Tests geolocation-specific proxies (New York)
-- Tests custom external proxies (commented out by default)
 - Displays IP information and geolocation data for each test
-- Shows how different proxy configurations affect your apparent location
+- Verifies that the New York session reports the expected region/country/timezone and a different IP
 
 ## COMMON PITFALLS
 
 - Browserbase Developer plan or higher is required to use proxies
 - "Cannot find module": ensure all dependencies are installed
 - Missing credentials: verify .env contains BROWSERBASE_API_KEY
-- Custom proxy errors: verify external proxy server credentials and availability
 
 ## USE CASES
 
 • Geo-testing: Verify location-specific content, pricing, or compliance banners.
 • Scraping at scale: Rotate IPs to reduce blocks and increase CAPTCHA success rates.
-• Custom routing: Mix built-in and external proxies, or apply domain-based rules for compliance.
+• Custom routing: Add external proxies or domain-based rules for compliance.
 
 ## NEXT STEPS
 

--- a/typescript/proxies/README.md
+++ b/typescript/proxies/README.md
@@ -47,7 +47,7 @@
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground
 🔧 Templates: https://www.browserbase.com/templates

--- a/typescript/proxies/index.ts
+++ b/typescript/proxies/index.ts
@@ -1,26 +1,28 @@
 // Browserbase Proxy Testing Script - See README.md for full documentation
 
-import { chromium } from "playwright-core";
 import { Browserbase } from "@browserbasehq/sdk";
-import { Stagehand } from "@browserbasehq/stagehand";
-import { z } from "zod";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
+import { z } from "zod/v4";
 import dotenv from "dotenv";
+import fs from "fs";
 
 dotenv.config();
 
 const bb = new Browserbase({ apiKey: process.env.BROWSERBASE_API_KEY! });
 
-async function createSessionWithBuiltInProxies() {
+async function createSessionWithBuiltInProxies(extensionId: string) {
   // Use Browserbase's default proxy rotation for enhanced privacy and IP diversity.
   const session = await bb.sessions.create({
+    extensionId,
     proxies: true, // Enables automatic proxy rotation across different IP addresses.
   });
   return session;
 }
 
-async function createSessionWithGeoLocation() {
+async function createSessionWithGeoLocation(extensionId: string) {
   // Route traffic through specific geographic location to test location-based restrictions.
   const session = await bb.sessions.create({
+    extensionId,
     proxies: [
       {
         type: "browserbase", // Use Browserbase's managed proxy infrastructure.
@@ -35,9 +37,10 @@ async function createSessionWithGeoLocation() {
   return session;
 }
 
-async function createSessionWithCustomProxies() {
+async function _createSessionWithCustomProxies(extensionId: string) {
   // Use external proxy servers for custom routing or specific proxy requirements.
   const session = await bb.sessions.create({
+    extensionId,
     proxies: [
       {
         type: "external", // Connect to your own proxy server infrastructure.
@@ -51,42 +54,35 @@ async function createSessionWithCustomProxies() {
 }
 
 async function testSession(
-  sessionFunction: () => Promise<{ id: string; connectUrl: string }>,
+  sessionFunction: (extensionId: string) => Promise<{ id: string; connectUrl: string }>,
   sessionName: string,
 ) {
   console.log(`\n=== Testing ${sessionName} ===`);
 
-  // Create session with specific proxy configuration to test different routing scenarios.
-  const session = await sessionFunction();
-  console.log("Session URL: https://browserbase.com/sessions/" + session.id);
-
-  // Connect to browser via CDP to control the session programmatically.
-  const browser = await chromium.connectOverCDP(session.connectUrl);
-  const defaultContext = browser.contexts()[0];
-  if (!defaultContext) {
-    throw new Error("No default context found");
-  }
-  const page = defaultContext.pages()[0];
-  if (!page) {
-    throw new Error("No page found in default context");
-  }
-
-  // Initialize Stagehand for structured data extraction
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 1,
-    // 0 = errors only, 1 = info, 2 = debug
-    // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
-    // https://docs.stagehand.dev/configuration/logging
-    model: "openai/gpt-4.1",
-    browserbaseSessionID: session.id, // Use the existing Browserbase session
+  const stagehandEntry = import.meta.resolve("@browserbasehq/stagehand");
+  const extension = await bb.extensions.create({
+    file: fs.createReadStream(new URL("./assets/stagehand-extension.zip", stagehandEntry)),
   });
+  let browser: Awaited<ReturnType<typeof browserbase.connect>> | undefined;
+  let stagehand: Stagehand | undefined;
 
   try {
-    // Initialize Stagehand
-    await stagehand.init();
+    // Create session with specific proxy configuration and preload Stagehand's V4 extension.
+    const session = await sessionFunction(extension.id);
+    console.log("Session URL: https://browserbase.com/sessions/" + session.id);
 
-    const stagehandPage = stagehand.context.pages()[0];
+    browser = await browserbase.connect({
+      apiKey: process.env.BROWSERBASE_API_KEY!,
+      sessionId: session.id,
+      extensionId: extension.id,
+    });
+    stagehand = await Stagehand.create({
+      browser,
+      model: { modelName: "openai/gpt-4.1" },
+      logging: { level: "info" },
+    });
+
+    const stagehandPage = (await browser.context.pages())[0];
 
     // Navigate to IP info service to verify proxy location and IP address.
     await stagehandPage.goto("https://ipinfo.io/json", {
@@ -94,7 +90,7 @@ async function testSession(
     });
 
     // Extract structured IP and location data using Stagehand and Zod schema
-    const geoInfo = await stagehand.extract(
+    const { data: geoInfo } = await stagehand.extract(
       "Extract all IP information and geolocation data from the JSON response",
       z.object({
         ip: z.string().optional().describe("The IP address"),
@@ -110,15 +106,16 @@ async function testSession(
     );
 
     console.log("Geo Info:", JSON.stringify(geoInfo, null, 2));
-
-    // Close Stagehand session
-    await stagehand.close();
   } catch (error) {
     console.error("Error during Stagehand extraction:", error);
+  } finally {
+    await stagehand?.close().catch(() => undefined);
+    await browser?.close().catch(() => undefined);
+    await bb.extensions
+      .delete(extension.id, { headers: { "Content-Type": null } })
+      .catch(() => undefined);
   }
 
-  // Close browser to release resources and end the test session.
-  await browser.close();
   console.log(`${sessionName} test completed`);
 }
 
@@ -130,7 +127,7 @@ async function main() {
   await testSession(createSessionWithGeoLocation, "Geolocation Proxies (New York)");
 
   // Test 3: Custom external proxies - Enable if you have a custom proxy server set up.
-  // await testSession(createSessionWithCustomProxies, "Custom External Proxies");
+  // await testSession(_createSessionWithCustomProxies, "Custom External Proxies");
   console.log("\n=== All tests completed ===");
 }
 

--- a/typescript/proxies/index.ts
+++ b/typescript/proxies/index.ts
@@ -1,134 +1,86 @@
 // Browserbase Proxy Testing Script - See README.md for full documentation
 
-import { Browserbase } from "@browserbasehq/sdk";
-import { browserbase, Stagehand } from "@browserbasehq/stagehand";
+import { browserbase, Stagehand, type BrowserbaseLaunchOptions } from "@browserbasehq/stagehand";
 import { z } from "zod/v4";
-import dotenv from "dotenv";
-import fs from "fs";
+import "dotenv/config";
 
-dotenv.config();
+const GeoInfoSchema = z.object({
+  ip: z.string().min(1),
+  city: z.string().min(1),
+  region: z.string().min(1),
+  country: z.string().min(1),
+  loc: z.string().min(1),
+  timezone: z.string().min(1),
+  org: z.string().min(1),
+  postal: z.string().optional(),
+  hostname: z.string().optional(),
+});
 
-const bb = new Browserbase({ apiKey: process.env.BROWSERBASE_API_KEY! });
-
-async function createSessionWithBuiltInProxies(extensionId: string) {
-  // Use Browserbase's default proxy rotation for enhanced privacy and IP diversity.
-  const session = await bb.sessions.create({
-    extensionId,
-    proxies: true, // Enables automatic proxy rotation across different IP addresses.
-  });
-  return session;
-}
-
-async function createSessionWithGeoLocation(extensionId: string) {
-  // Route traffic through specific geographic location to test location-based restrictions.
-  const session = await bb.sessions.create({
-    extensionId,
-    proxies: [
-      {
-        type: "browserbase", // Use Browserbase's managed proxy infrastructure.
-        geolocation: {
-          city: "NEW_YORK", // Simulate traffic from New York for testing geo-specific content.
-          state: "NY", // See https://docs.browserbase.com/features/proxies for more geolocation options.
-          country: "US",
-        },
-      },
-    ],
-  });
-  return session;
-}
-
-async function _createSessionWithCustomProxies(extensionId: string) {
-  // Use external proxy servers for custom routing or specific proxy requirements.
-  const session = await bb.sessions.create({
-    extensionId,
-    proxies: [
-      {
-        type: "external", // Connect to your own proxy server infrastructure.
-        server: "http://...", // Your proxy server endpoint.
-        username: "user", // Authentication credentials for proxy access.
-        password: "pass",
-      },
-    ],
-  });
-  return session;
-}
+type GeoInfo = z.infer<typeof GeoInfoSchema>;
 
 async function testSession(
-  sessionFunction: (extensionId: string) => Promise<{ id: string; connectUrl: string }>,
+  proxies: BrowserbaseLaunchOptions["proxies"],
   sessionName: string,
-) {
+): Promise<GeoInfo> {
   console.log(`\n=== Testing ${sessionName} ===`);
 
-  const stagehandEntry = import.meta.resolve("@browserbasehq/stagehand");
-  const extension = await bb.extensions.create({
-    file: fs.createReadStream(new URL("./assets/stagehand-extension.zip", stagehandEntry)),
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+    proxies,
   });
-  let browser: Awaited<ReturnType<typeof browserbase.connect>> | undefined;
-  let stagehand: Stagehand | undefined;
+  const stagehand = await Stagehand.create({
+    browser,
+    logging: { level: "error" },
+  });
 
   try {
-    // Create session with specific proxy configuration and preload Stagehand's V4 extension.
-    const session = await sessionFunction(extension.id);
-    console.log("Session URL: https://browserbase.com/sessions/" + session.id);
+    console.log("Browserbase session launched");
+    const page = (await browser.context.pages())[0];
 
-    browser = await browserbase.connect({
-      apiKey: process.env.BROWSERBASE_API_KEY!,
-      sessionId: session.id,
-      extensionId: extension.id,
-    });
-    stagehand = await Stagehand.create({
-      browser,
-      model: { modelName: "openai/gpt-4.1" },
-      logging: { level: "info" },
-    });
-
-    const stagehandPage = (await browser.context.pages())[0];
-
-    // Navigate to IP info service to verify proxy location and IP address.
-    await stagehandPage.goto("https://ipinfo.io/json", {
-      waitUntil: "domcontentloaded",
-    });
-
-    // Extract structured IP and location data using Stagehand and Zod schema
-    const { data: geoInfo } = await stagehand.extract(
-      "Extract all IP information and geolocation data from the JSON response",
-      z.object({
-        ip: z.string().optional().describe("The IP address"),
-        city: z.string().optional().describe("The city name"),
-        region: z.string().optional().describe("The state or region"),
-        country: z.string().optional().describe("The country code"),
-        loc: z.string().optional().describe("The latitude and longitude coordinates"),
-        timezone: z.string().optional().describe("The timezone"),
-        org: z.string().optional().describe("The organization or ISP"),
-        postal: z.string().optional().describe("The postal code"),
-        hostname: z.string().optional().describe("The hostname if available"),
-      }),
-    );
+    // ipinfo reports the public IP observed after Browserbase applies the proxy.
+    await page.goto("https://ipinfo.io/json", { waitUntil: "domcontentloaded" });
+    const body = await page.evaluate(() => document.body.textContent ?? "");
+    const geoInfo = GeoInfoSchema.parse(JSON.parse(body));
 
     console.log("Geo Info:", JSON.stringify(geoInfo, null, 2));
-  } catch (error) {
-    console.error("Error during Stagehand extraction:", error);
+    console.log(`${sessionName} test completed`);
+    return geoInfo;
   } finally {
-    await stagehand?.close().catch(() => undefined);
-    await browser?.close().catch(() => undefined);
-    await bb.extensions
-      .delete(extension.id, { headers: { "Content-Type": null } })
-      .catch(() => undefined);
+    await stagehand.close().catch((error) => console.warn("Stagehand cleanup warning:", error));
+    await browser.close().catch((error) => console.warn("Browser cleanup warning:", error));
   }
-
-  console.log(`${sessionName} test completed`);
 }
 
 async function main() {
-  // Test 1: Built-in proxies - Verify default proxy rotation works and shows different IPs.
-  await testSession(createSessionWithBuiltInProxies, "Built-in Proxies");
+  const builtIn = await testSession(true, "Built-in Proxies");
 
-  // Test 2: Geolocation proxies - Confirm traffic routes through specified location (New York).
-  await testSession(createSessionWithGeoLocation, "Geolocation Proxies (New York)");
+  const newYork = await testSession(
+    [
+      {
+        type: "browserbase",
+        geolocation: { city: "NEW_YORK", state: "NY", country: "US" },
+      },
+    ],
+    "Geolocation Proxies (New York)",
+  );
 
-  // Test 3: Custom external proxies - Enable if you have a custom proxy server set up.
-  // await testSession(_createSessionWithCustomProxies, "Custom External Proxies");
-  console.log("\n=== All tests completed ===");
+  if (
+    newYork.country !== "US" ||
+    !/new york/i.test(newYork.region) ||
+    newYork.timezone !== "America/New_York"
+  ) {
+    throw new Error(
+      `Expected a New York-region proxy; received ${newYork.city}, ${newYork.region}, ${newYork.country}`,
+    );
+  }
+  if (builtIn.ip === newYork.ip) {
+    throw new Error("Built-in and geolocation proxy sessions returned the same IP");
+  }
+
+  console.log("\n=== All proxy tests completed with distinct IPs ===");
 }
 
-main();
+main().catch((error) => {
+  console.error("Proxy test failed:", error);
+  process.exit(1);
+});

--- a/typescript/sec-filing-research/README.md
+++ b/typescript/sec-filing-research/README.md
@@ -3,18 +3,14 @@
 ## AT A GLANCE
 
 - Goal: automate searching SEC EDGAR for a company and extracting recent filing metadata (type, date, description, accession number, file number).
-- Search: supports company name, ticker symbol, or CIK number (e.g. "Apple Inc", "AAPL", "0000320193").
-- Data Extraction: uses Stagehand act/extract with Zod schemas to navigate SEC.gov and pull structured filing data.
+- Entity selection: uses Apple's known CIK by default; edit `SEARCH_QUERY` and `COMPANY_CIK` together for another company.
+- Data extraction: navigates directly to the official EDGAR entity page and reads its stable filing table with V4 page APIs.
 - Output: company name, CIK, and a configurable number of most recent filings, printed as summary and JSON.
 
 ## GLOSSARY
 
-- act: perform UI actions from a natural language prompt (click, type, submit).
-  Docs → https://docs.stagehand.dev/basics/act
-- extract: pull structured data from web pages into validated objects using a Zod schema.
-  Docs → https://docs.stagehand.dev/basics/extract
-- schema: Zod definition for filing and company info; enforces types and validation.
-  Docs → https://zod.dev/
+- page APIs: use the V4 browser context and page directly for stable, machine-readable tables.
+  Docs → https://docs.stagehand.dev/v4/reference/page
 - SEC EDGAR: SEC’s company and filing search and filing system.
   https://www.sec.gov/edgar/searchedgar/companysearch.html
 - CIK: Central Index Key — unique numeric identifier for each company in EDGAR.
@@ -25,15 +21,14 @@
 2. npm install
 3. cp .env.example .env
 4. Add BROWSERBASE_API_KEY to .env
-5. (Optional) Edit SEARCH_QUERY and NUM_FILINGS in index.ts
+5. (Optional) Edit SEARCH_QUERY, COMPANY_CIK, and NUM_FILINGS in index.ts
 6. npm start
 
 ## EXPECTED OUTPUT
 
 - Initializes Stagehand V4 with an explicit Browserbase browser handle
-- Navigates to SEC EDGAR company search
-- Enters search query, submits, and selects the matching company
-- Extracts company name and CIK from the filings page
+- Navigates directly to the configured SEC EDGAR entity page
+- Reads the official filing table and derives accession numbers from document URLs
 - Extracts the N most recent filings (type, date, description, accession number, file number)
 - Logs SEC FILING METADATA summary and per-filing details
 - Outputs full result as JSON
@@ -43,8 +38,8 @@
 
 - "Cannot find module": run npm install in sec-filing-research
 - Missing credentials: ensure .env has BROWSERBASE_API_KEY
-- No company match: use a valid company name, ticker, or CIK; SEC search is case-sensitive for some queries
-- Extraction errors: SEC page layout changes can break selectors; adjust act/extract prompts if needed
+- Wrong company: update `SEARCH_QUERY` and `COMPANY_CIK` together
+- Extraction errors: SEC page layout changes can require table-selector updates
 - Rate limiting: avoid excessive runs; SEC may throttle heavy or automated traffic
 
 ## USE CASES
@@ -56,10 +51,10 @@
 
 ## NEXT STEPS
 
-• Parameterize search: read SEARCH_QUERY and NUM_FILINGS from env or CLI for batch runs.
+• Parameterize search: read SEARCH_QUERY, COMPANY_CIK, and NUM_FILINGS from env or CLI for batch runs.
 • Fetch full filings: use accession numbers with SEC’s full-text filing URLs or APIs to download documents.
 • Multiple companies: loop over a list of tickers/names and aggregate results into a single report or JSON.
-• Filter by type: restrict to 10-K/10-Q/8-K or other form types in the extract step or in post-processing.
+• Filter by type: restrict to 10-K/10-Q/8-K or other form types in post-processing.
 
 ## HELPFUL RESOURCES
 

--- a/typescript/sec-filing-research/README.md
+++ b/typescript/sec-filing-research/README.md
@@ -30,7 +30,7 @@
 
 ## EXPECTED OUTPUT
 
-- Initializes Stagehand session with Browserbase and shows live view URL
+- Initializes Stagehand V4 with an explicit Browserbase browser handle
 - Navigates to SEC EDGAR company search
 - Enters search query, submits, and selects the matching company
 - Extracts company name and CIK from the filings page
@@ -44,7 +44,7 @@
 - "Cannot find module": run npm install in sec-filing-research
 - Missing credentials: ensure .env has BROWSERBASE_API_KEY
 - No company match: use a valid company name, ticker, or CIK; SEC search is case-sensitive for some queries
-- Extraction errors: SEC page layout changes can break selectors; check live view and adjust act/extract prompts if needed
+- Extraction errors: SEC page layout changes can break selectors; adjust act/extract prompts if needed
 - Rate limiting: avoid excessive runs; SEC may throttle heavy or automated traffic
 
 ## USE CASES
@@ -63,7 +63,7 @@
 
 ## HELPFUL RESOURCES
 
-📚 Stagehand Docs: https://docs.stagehand.dev/v3/first-steps/introduction
+📚 Stagehand Docs: https://docs.stagehand.dev/v4/first-steps/introduction
 🎮 Browserbase: https://www.browserbase.com
 💡 Try it out: https://www.browserbase.com/playground
 🔧 Templates: https://www.browserbase.com/templates

--- a/typescript/sec-filing-research/index.ts
+++ b/typescript/sec-filing-research/index.ts
@@ -2,33 +2,22 @@
 
 import "dotenv/config";
 import { browserbase, Stagehand } from "@browserbasehq/stagehand";
-import { z } from "zod/v4";
+
+async function closeSession(
+  stagehand: Stagehand,
+  browser: Awaited<ReturnType<typeof browserbase.launch>>,
+) {
+  await stagehand.close().catch((error) => console.warn("Stagehand cleanup warning:", error));
+  await browser.close().catch((error) => console.warn("Browser cleanup warning:", error));
+}
 
 // Search query - can be company name, ticker symbol, or CIK number
 // Examples: "Apple Inc", "AAPL", "0000320193"
 const SEARCH_QUERY = "Apple Inc";
+const COMPANY_CIK = "0000320193";
 
 // Number of filings to retrieve
 const NUM_FILINGS = 5;
-
-// Schema for extracted filing data
-const FilingSchema = z.object({
-  filings: z.array(
-    z.object({
-      type: z.string().describe("Filing type (e.g., 10-K, 10-Q, 8-K)"),
-      date: z.string().describe("Filing date in YYYY-MM-DD format"),
-      description: z.string().describe("Full description of the filing"),
-      accessionNumber: z.string().describe("SEC accession number"),
-      fileNumber: z.string().optional().describe("File/Film number"),
-    }),
-  ),
-});
-
-// Schema for company info extraction
-const CompanyInfoSchema = z.object({
-  companyName: z.string().describe("Official company name"),
-  cik: z.string().describe("Central Index Key (CIK) number"),
-});
 
 // Result shape returned after extracting company and filing metadata from SEC EDGAR
 interface SECFilingResult {
@@ -71,57 +60,59 @@ async function main(): Promise<void> {
 
     const page = (await browser.context.pages())[0];
 
-    // Navigate to modern SEC EDGAR company search page
+    // The target company is known, so navigate directly to its entity page.
+    // This avoids depending on the changing autocomplete/search UI.
     console.log("\nNavigating to SEC EDGAR...");
-    await page.goto("https://www.sec.gov/edgar/searchedgar/companysearch.html", {
+    await page.goto(`https://www.sec.gov/edgar/browse/?CIK=${COMPANY_CIK}&owner=exclude`, {
       waitUntil: "domcontentloaded",
     });
+    await page.waitForTimeout(2000);
 
-    // Enter search query in the Company and Person Lookup search box
-    console.log(`Searching for: ${SEARCH_QUERY}`);
-    await stagehand.act(`Click on the Company and Person Lookup search textbox`);
-    await stagehand.act(`Type "${SEARCH_QUERY}" in the search field`);
-
-    // Submit search to load company results
-    await stagehand.act("Click the search submit button");
-
-    // Select the matching company from results to view their filings page
-    console.log("Selecting the correct company from results...");
-    await stagehand.act(`Click on "${SEARCH_QUERY}" in the search results to view their filings`);
-
-    // Extract company information from the filings page
-    console.log("Extracting company information...");
-    let companyInfo = { companyName: SEARCH_QUERY, cik: "Unknown" };
-
-    try {
-      const { data: extractedInfo } = await stagehand.extract(
-        "Extract the company name and CIK number from the page header or company information section. The CIK should be a numeric identifier.",
-        CompanyInfoSchema,
-      );
-      if (extractedInfo && extractedInfo.companyName) {
-        companyInfo = extractedInfo;
-      }
-    } catch (error) {
-      // Fallback to search query if extraction fails (e.g. page layout differs)
-      console.log("Could not extract company info, using search query as company name:", error);
-    }
-
-    // Extract filing metadata from the filings table using structured schema
+    // EDGAR's table has a stable machine-readable shape, so use a deterministic
+    // DOM read and derive accession numbers from the official document URLs.
     console.log(`Extracting the ${NUM_FILINGS} most recent filings...`);
-    const { data: filingsData } = await stagehand.extract(
-      `Extract the ${NUM_FILINGS} most recent SEC filings from the filings table. For each filing, get: the filing type (column: Filings, like 10-K, 10-Q, 8-K), the filing date (column: Filing Date), description, accession number (from the link or description), and file/film number if shown.`,
-      FilingSchema,
-    );
+    const extracted = (await page.evaluate((limit: number) => {
+      const company = document.querySelector("h3")?.textContent?.trim().split("\n")[0] ?? "";
+      const tables = Array.from(document.querySelectorAll("table"));
+      const table = tables.sort(
+        (left, right) =>
+          right.querySelectorAll("tbody tr").length - left.querySelectorAll("tbody tr").length,
+      )[0];
+      const filings = Array.from(table?.querySelectorAll("tbody tr") ?? [])
+        .slice(0, limit)
+        .map((row) => {
+          const cells = Array.from(row.querySelectorAll("td"));
+          const filingLink = row.querySelector<HTMLAnchorElement>(
+            'a[href*="/Archives/edgar/data/"]',
+          );
+          const folder = filingLink?.href.match(/\/data\/\d+\/(\d{18})\//)?.[1] ?? "";
+          const accessionNumber = folder
+            ? `${folder.slice(0, 10)}-${folder.slice(10, 12)}-${folder.slice(12)}`
+            : "";
+          return {
+            type: cells[0]?.textContent?.trim() ?? "",
+            description: cells[1]?.textContent?.replace(/\s+/g, " ").trim() ?? "",
+            date: cells[2]?.textContent?.trim() ?? "",
+            accessionNumber,
+            fileNumber: "",
+          };
+        });
+      return { company, filings };
+    }, NUM_FILINGS)) as { company: string; filings: SECFilingResult["filings"] };
+
+    if (
+      extracted.filings.length !== NUM_FILINGS ||
+      extracted.filings.some((filing) => !filing.type || !filing.date || !filing.accessionNumber)
+    ) {
+      throw new Error("SEC page did not return five complete filing records");
+    }
 
     // Build result object with company info and normalized filing list
     const result: SECFilingResult = {
-      company: companyInfo.companyName,
-      cik: companyInfo.cik,
+      company: extracted.company,
+      cik: COMPANY_CIK,
       searchQuery: SEARCH_QUERY,
-      filings: filingsData.filings.slice(0, NUM_FILINGS).map((f) => ({
-        ...f,
-        fileNumber: f.fileNumber || "",
-      })),
+      filings: extracted.filings,
     };
 
     // Log summary and per-filing details to console
@@ -156,8 +147,7 @@ async function main(): Promise<void> {
     throw error;
   } finally {
     // Always close session to release resources and clean up
-    await stagehand.close();
-    await browser.close();
+    await closeSession(stagehand, browser);
     console.log("\nSession closed successfully");
   }
 }

--- a/typescript/sec-filing-research/index.ts
+++ b/typescript/sec-filing-research/index.ts
@@ -1,8 +1,8 @@
 // Stagehand + Browserbase: SEC Filing Downloader - See README.md for full documentation
 
 import "dotenv/config";
-import { Stagehand } from "@browserbasehq/stagehand";
-import { z } from "zod";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
+import { z } from "zod/v4";
 
 // Search query - can be company name, ticker symbol, or CIK number
 // Examples: "Apple Inc", "AAPL", "0000320193"
@@ -55,27 +55,21 @@ async function main(): Promise<void> {
   console.log(`Retrieving ${NUM_FILINGS} most recent filings\n`);
 
   // Initialize Stagehand with Browserbase for cloud-based browser automation
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    apiKey: process.env.BROWSERBASE_API_KEY,
-    verbose: 1,
-    // 0 = errors only, 1 = info, 2 = debug
-    // (When handling sensitive data like passwords or API keys, set verbose: 0 to prevent secrets from appearing in logs.)
-    // https://docs.stagehand.dev/configuration/logging
-    model: "google/gemini-2.5-flash",
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+  });
+  const stagehand = await Stagehand.create({
+    browser: browser,
+    model: { modelName: "google/gemini-2.5-flash" },
+    logging: { level: "info" },
   });
 
   try {
     // Initialize browser session
-    await stagehand.init();
+
     console.log("Stagehand initialized successfully!");
 
-    const page = stagehand.context.pages()[0];
-
-    // Provide live session URL for debugging and monitoring
-    if (stagehand.browserbaseSessionId) {
-      console.log(`Live View: https://browserbase.com/sessions/${stagehand.browserbaseSessionId}`);
-    }
+    const page = (await browser.context.pages())[0];
 
     // Navigate to modern SEC EDGAR company search page
     console.log("\nNavigating to SEC EDGAR...");
@@ -100,7 +94,7 @@ async function main(): Promise<void> {
     let companyInfo = { companyName: SEARCH_QUERY, cik: "Unknown" };
 
     try {
-      const extractedInfo = await stagehand.extract(
+      const { data: extractedInfo } = await stagehand.extract(
         "Extract the company name and CIK number from the page header or company information section. The CIK should be a numeric identifier.",
         CompanyInfoSchema,
       );
@@ -114,7 +108,7 @@ async function main(): Promise<void> {
 
     // Extract filing metadata from the filings table using structured schema
     console.log(`Extracting the ${NUM_FILINGS} most recent filings...`);
-    const filingsData = await stagehand.extract(
+    const { data: filingsData } = await stagehand.extract(
       `Extract the ${NUM_FILINGS} most recent SEC filings from the filings table. For each filing, get: the filing type (column: Filings, like 10-K, 10-Q, 8-K), the filing date (column: Filing Date), description, accession number (from the link or description), and file/film number if shown.`,
       FilingSchema,
     );
@@ -163,6 +157,7 @@ async function main(): Promise<void> {
   } finally {
     // Always close session to release resources and clean up
     await stagehand.close();
+    await browser.close();
     console.log("\nSession closed successfully");
   }
 }
@@ -174,6 +169,6 @@ main().catch((err) => {
   console.error("  - Check .env file has BROWSERBASE_API_KEY");
   console.error("  - Verify internet connection and SEC website accessibility");
   console.error("  - Ensure the search query is valid (company name, ticker, or CIK)");
-  console.error("\nDocs: https://docs.stagehand.dev/v3/first-steps/introduction");
+  console.error("\nDocs: https://docs.stagehand.dev/v4/first-steps/introduction");
   process.exit(1);
 });

--- a/typescript/sec-filing-research/package.json
+++ b/typescript/sec-filing-research/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch index.ts"
   },
   "dependencies": {
-    "@browserbasehq/stagehand": "github:browserbase/stagehand#089f2aaeaea75696685949e0835aece95db54358&path:/packages/sdk-ts",
+    "@browserbasehq/stagehand": "github:browserbase/stagehand#4186c7d98d2f325b6fc85b3f760111e6c390d703&path:/packages/sdk-ts",
     "dotenv": "^16.4.5",
     "zod": "^4.4.3"
   },

--- a/typescript/sec-filing-research/package.json
+++ b/typescript/sec-filing-research/package.json
@@ -9,13 +9,18 @@
     "dev": "tsx watch index.ts"
   },
   "dependencies": {
-    "@browserbasehq/stagehand": "latest",
+    "@browserbasehq/stagehand": "github:browserbase/stagehand#089f2aaeaea75696685949e0835aece95db54358&path:/packages/sdk-ts",
     "dotenv": "^16.4.5",
-    "zod": "^3.23.8"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^20.14.0",
     "tsx": "^4.16.0",
     "typescript": "^5.5.0"
-  }
+  },
+  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand@4.0.0 after it is published.",
+  "engines": {
+    "node": ">=22.18.0"
+  },
+  "packageManager": "pnpm@10.24.0"
 }

--- a/typescript/sec-filing-research/package.json
+++ b/typescript/sec-filing-research/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch index.ts"
   },
   "dependencies": {
-    "@browserbasehq/stagehand": "github:browserbase/stagehand#4186c7d98d2f325b6fc85b3f760111e6c390d703&path:/packages/sdk-ts",
+    "@browserbasehq/stagehand": "4.0.0",
     "dotenv": "^16.4.5",
     "zod": "^4.4.3"
   },
@@ -18,7 +18,6 @@
     "tsx": "^4.16.0",
     "typescript": "^5.5.0"
   },
-  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand@4.0.0 after it is published.",
   "engines": {
     "node": ">=22.18.0"
   },

--- a/typescript/smart-fetch-scraper/README.md
+++ b/typescript/smart-fetch-scraper/README.md
@@ -44,7 +44,7 @@ Browser fallback (JS-rendered, blocked, or low text density):
 
 - Logs the strategy being used (Fetch API vs browser)
 - On Fetch API success: prints page title, link count, status code, content length, and a 500-char preview
-- On browser fallback: prints Stagehand live view link, then structured JSON with page title and extracted items
+- On browser fallback: prints structured JSON with the page title and extracted items
 
 ## COMMON PITFALLS
 

--- a/typescript/smart-fetch-scraper/README.md
+++ b/typescript/smart-fetch-scraper/README.md
@@ -14,7 +14,7 @@
 - Fetch API: Browserbase's lightweight HTTP fetching endpoint — fetches page content through Browserbase infrastructure without spinning up a browser.
   Docs → https://docs.browserbase.com/features/fetch
 - extract: pull structured data from pages using schemas and AI.
-  Docs → https://docs.stagehand.dev/basics/extract
+  Docs → https://docs.stagehand.dev/v4/basics/extract
 - Stagehand: AI browser automation framework.
   Docs → https://docs.stagehand.dev
 

--- a/typescript/smart-fetch-scraper/index.ts
+++ b/typescript/smart-fetch-scraper/index.ts
@@ -11,8 +11,8 @@
 
 import "dotenv/config";
 import Browserbase from "@browserbasehq/sdk";
-import { Stagehand } from "@browserbasehq/stagehand";
-import { z } from "zod";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
+import { z } from "zod/v4";
 
 // ============= CONFIGURATION =============
 
@@ -100,18 +100,19 @@ async function tryFetchApi(url: string): Promise<{ content: string; statusCode: 
     // here to have Browserbase return cleaner content or structured data
     // directly — see https://docs.browserbase.com/platform/fetch/overview
     const data = await bb.fetchAPI.create({ url, allowRedirects: true });
+    const content = typeof data.content === "string" ? data.content : JSON.stringify(data.content);
 
     console.log(
-      `[Fetch API] Got response: status=${data.statusCode}, length=${data.content.length} chars`,
+      `[Fetch API] Got response: status=${data.statusCode}, length=${content.length} chars`,
     );
 
-    const fallbackReason = needsBrowserFallback(data.content, data.statusCode);
+    const fallbackReason = needsBrowserFallback(content, data.statusCode);
     if (fallbackReason) {
       console.log(`[Fetch API] Content not usable — ${fallbackReason}`);
       return null;
     }
 
-    return { content: data.content, statusCode: data.statusCode };
+    return { content, statusCode: data.statusCode };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.log(`[Fetch API] Failed: ${message}`);
@@ -137,32 +138,28 @@ function parseFromHtml(html: string): { title: string; linkCount: number } {
 async function extractWithBrowser(url: string) {
   console.log("\n[Browser] Starting Stagehand session...");
 
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 1,
-    model: "google/gemini-2.5-flash",
-    browserbaseSessionCreateParams: {
-      proxies: true,
-      browserSettings: {
-        advancedStealth: true,
-        blockAds: true,
-        solveCaptchas: true,
-      },
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
+    proxies: true,
+    browserSettings: {
+      advancedStealth: true,
+      blockAds: true,
+      solveCaptchas: true,
     },
+  });
+  const stagehand = await Stagehand.create({
+    browser: browser,
+    model: { modelName: "google/gemini-2.5-flash" },
+    logging: { level: "info" },
   });
 
   try {
-    await stagehand.init();
-    console.log(
-      `[Browser] Live View: https://browserbase.com/sessions/${stagehand.browserbaseSessionID}`,
-    );
-
-    const page = stagehand.context.pages()[0];
+    const page = (await browser.context.pages())[0];
     await page.goto(url);
 
     console.log("[Browser] Page loaded, extracting structured data with AI...");
 
-    const data = await stagehand.extract(
+    const { data: data } = await stagehand.extract(
       "Extract the page title and all the main items/articles/entries visible on this page. For each item get its title, URL, and any metadata like score, author, or timestamp.",
       PageDataSchema,
     );
@@ -170,6 +167,7 @@ async function extractWithBrowser(url: string) {
     return data;
   } finally {
     await stagehand.close();
+    await browser.close();
     console.log("[Browser] Session closed");
   }
 }

--- a/typescript/smart-fetch-scraper/package.json
+++ b/typescript/smart-fetch-scraper/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@browserbasehq/sdk": "^2.9.0",
-    "@browserbasehq/stagehand": "github:browserbase/stagehand#4186c7d98d2f325b6fc85b3f760111e6c390d703&path:/packages/sdk-ts",
+    "@browserbasehq/stagehand": "4.0.0",
     "dotenv": "^16.4.5",
     "zod": "^4.4.3"
   },
@@ -19,7 +19,6 @@
     "tsx": "^4.16.0",
     "typescript": "^5.5.0"
   },
-  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand@4.0.0 after it is published.",
   "engines": {
     "node": ">=22.18.0"
   },

--- a/typescript/smart-fetch-scraper/package.json
+++ b/typescript/smart-fetch-scraper/package.json
@@ -10,13 +10,18 @@
   },
   "dependencies": {
     "@browserbasehq/sdk": "^2.9.0",
-    "@browserbasehq/stagehand": "latest",
+    "@browserbasehq/stagehand": "github:browserbase/stagehand#089f2aaeaea75696685949e0835aece95db54358&path:/packages/sdk-ts",
     "dotenv": "^16.4.5",
-    "zod": "^3.23.8"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^20.14.0",
     "tsx": "^4.16.0",
     "typescript": "^5.5.0"
-  }
+  },
+  "//": "TODO: Replace this commit pin with @browserbasehq/stagehand@4.0.0 after it is published.",
+  "engines": {
+    "node": ">=22.18.0"
+  },
+  "packageManager": "pnpm@10.24.0"
 }

--- a/typescript/smart-fetch-scraper/package.json
+++ b/typescript/smart-fetch-scraper/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@browserbasehq/sdk": "^2.9.0",
-    "@browserbasehq/stagehand": "github:browserbase/stagehand#089f2aaeaea75696685949e0835aece95db54358&path:/packages/sdk-ts",
+    "@browserbasehq/stagehand": "github:browserbase/stagehand#4186c7d98d2f325b6fc85b3f760111e6c390d703&path:/packages/sdk-ts",
     "dotenv": "^16.4.5",
     "zod": "^4.4.3"
   },

--- a/typescript/website-link-tester/README.md
+++ b/typescript/website-link-tester/README.md
@@ -32,7 +32,7 @@
 
 - **Initial setup**
   - Initializes a Stagehand session with Browserbase
-  - Prints a live session link for monitoring the browser in real time
+  - Closes both the Stagehand instance and browser handle after every link check
 - **Link collection**
   - Navigates to the configured `URL` (default: `https://www.browserbase.com`)
   - Extracts all links and their link text from the homepage
@@ -95,7 +95,7 @@
 
 ### HELPFUL RESOURCES
 
-- 📚 **Stagehand Docs**: `https://docs.stagehand.dev/v3/first-steps/introduction`
+- 📚 **Stagehand Docs**: `https://docs.stagehand.dev/v4/first-steps/introduction`
 - 🎮 **Browserbase**: `https://www.browserbase.com`
 - 💡 **Try it out**: `https://www.browserbase.com/playground`
 - 🔧 **Templates**: `https://www.browserbase.com/templates`

--- a/typescript/website-link-tester/README.md
+++ b/typescript/website-link-tester/README.md
@@ -3,16 +3,16 @@
 ### AT A GLANCE
 
 - **Goal**: Crawl a website’s homepage, collect all links, and verify that each link loads successfully and matches its link text.
-- **Link extraction**: Uses `Stagehand.extract()` with a Zod schema to pull all links and their visible text from the homepage.
+- **Link extraction**: Reads every rendered HTTP(S) anchor deterministically so hidden/nav links are not omitted.
 - **Content verification**: Opens each link and uses AI to assess whether the page content matches what the link text suggests.
 - **Social link handling**: Detects social media domains and only checks that they load (skipping full content verification).
 - **Batch processing**: Processes links in batches controlled by `MAX_CONCURRENT_LINKS` (sequential by default, can be made concurrent).
 
 ### GLOSSARY
 
-- **extract**: extract structured data from web pages using natural language instructions  
-  Docs → `https://docs.stagehand.dev/basics/extract`
-- **concurrent sessions**: run multiple browser sessions at the same time for faster batch processing  
+- **extract**: semantically assess whether a successfully loaded destination fits its source link
+  Docs → `https://docs.stagehand.dev/v4/basics/extract`
+- **concurrent sessions**: run multiple browser sessions at the same time for faster batch processing
   Docs → `https://docs.browserbase.com/guides/concurrency-rate-limits`
 
 ### QUICKSTART
@@ -35,13 +35,13 @@
   - Closes both the Stagehand instance and browser handle after every link check
 - **Link collection**
   - Navigates to the configured `URL` (default: `https://www.browserbase.com`)
-  - Extracts all links and their link text from the homepage
+  - Reads all rendered links and their link text from the homepage
   - Logs total link count and unique link count after de-duplication
 - **Verification**
   - Verifies links in batches using `MAX_CONCURRENT_LINKS`
   - For each link:
     - Confirms the page loads successfully
-    - For non-social links, extracts:
+    - Rejects HTTP error responses, then for non-social links assesses:
       - `pageTitle`
       - `contentMatches` (boolean)
       - short `assessment` (max ~8 words)

--- a/typescript/website-link-tester/index.ts
+++ b/typescript/website-link-tester/index.ts
@@ -58,6 +58,11 @@ async function createStagehand(): Promise<{ stagehand: Stagehand; browser: Stage
   return { stagehand, browser };
 }
 
+async function closeSession(stagehand: Stagehand | null, browser: StagehandBrowser | null) {
+  await stagehand?.close().catch((error) => console.warn("Stagehand cleanup warning:", error));
+  await browser?.close().catch((error) => console.warn("Browser cleanup warning:", error));
+}
+
 // Removes duplicate links by URL while preserving the first occurrence
 function deduplicateLinks(extractedLinks: { links: Link[] }): Link[] {
   const map = new Map<string, Link>();
@@ -87,17 +92,19 @@ async function collectLinksFromHomepage(): Promise<Link[]> {
 
     console.log(`Successfully loaded ${URL}. Extracting links...`);
 
-    const { data: extractedLinks } = await stagehand.extract(
-      "extract all links on the page with their link text",
-      z.object({
-        links: z.array(
-          z.object({
-            url: z.string().url(),
-            linkText: z.string(),
-          }),
-        ),
-      }),
-    );
+    const extractedLinks = {
+      links: await page.evaluate(() =>
+        Array.from(document.querySelectorAll<HTMLAnchorElement>("a[href]"))
+          .map((link) => ({
+            url: link.href,
+            linkText:
+              link.textContent?.trim() ||
+              link.getAttribute("aria-label")?.trim() ||
+              "Untitled link",
+          }))
+          .filter((link) => /^https?:\/\//.test(link.url)),
+      ),
+    };
 
     // Remove duplicate URLs and log both raw and unique counts for visibility
     const uniqueLinks = deduplicateLinks(extractedLinks);
@@ -108,16 +115,14 @@ async function collectLinksFromHomepage(): Promise<Link[]> {
     console.log(JSON.stringify({ links: uniqueLinks }, null, 2));
 
     console.log("\nClosing initial browser...");
-    await stagehand.close();
-    await browser.close();
+    await closeSession(stagehand, browser);
     console.log("Initial browser closed");
 
     return uniqueLinks;
   } catch (error) {
     console.error("Error while collecting links:", error);
     // Ensure the browser is closed even when link collection fails
-    await stagehand.close();
-    await browser.close();
+    await closeSession(stagehand, browser);
     throw error;
   }
 }
@@ -142,8 +147,14 @@ async function verifySingleLink(link: Link): Promise<LinkCheckResult> {
     // Detect if this is a social link (we treat those differently)
     const isSocialLink = SOCIAL_DOMAINS.some((domain) => link.url.includes(domain));
 
-    await page.goto(link.url, { timeout: 30000 });
+    const navigationResponse = await page.goto(link.url, { timeout: 30000 });
     await page.waitForLoadState("domcontentloaded");
+
+    if (navigationResponse && !navigationResponse.ok()) {
+      throw new Error(
+        `HTTP ${navigationResponse.status()} ${navigationResponse.statusText()}`.trim(),
+      );
+    }
 
     const currentUrl = await page.url();
 
@@ -168,15 +179,58 @@ async function verifySingleLink(link: Link): Promise<LinkCheckResult> {
       };
     }
 
-    // Ask the model to read the page and decide whether it matches the link text
-    const { data: verification } = await stagehand.extract(
-      `Does the page content match what the link text "${link.linkText}" suggests? Extract the page title and provide a brief assessment (maximum 8 words).`,
-      z.object({
-        pageTitle: z.string(),
-        contentMatches: z.boolean(),
-        assessment: z.string(),
-      }),
-    );
+    const actualPageTitle = await page.title();
+    const normalizedLinkText = link.linkText.trim().toLowerCase().replace(/\s+/g, " ");
+    const pageText = await page.evaluate(() => document.body.innerText.toLowerCase());
+    const exactLinkTextPresent =
+      normalizedLinkText.length >= 4 && pageText.includes(normalizedLinkText);
+    const requestedUrl = new globalThis.URL(link.url);
+    const landedUrl = new globalThis.URL(currentUrl);
+    const routeMatches =
+      requestedUrl.origin === landedUrl.origin && requestedUrl.pathname === landedUrl.pathname;
+
+    // Ask the model to read the page and decide whether it matches the link text.
+    // Retry once for transient structured-output errors before falling back to exact DOM evidence.
+    let verification:
+      | { pageTitle: string; contentMatches: boolean; assessment: string }
+      | undefined;
+    let verificationError: unknown;
+    for (let attempt = 1; attempt <= 2; attempt++) {
+      try {
+        const result = await stagehand.extract(
+          `A user clicked a source-page link labeled ${JSON.stringify(link.linkText)} and arrived at ${JSON.stringify(currentUrl)}. Is the loaded destination an appropriate result of that click? Do not require the original call-to-action text to appear on the destination page. Generic labels such as "Read the story" and "Get started" are fulfilled by a relevant article or template page. Return the page title and a brief assessment (maximum 8 words).`,
+          z.object({
+            pageTitle: z.string(),
+            contentMatches: z.boolean(),
+            assessment: z.string(),
+          }),
+        );
+        verification = result.data;
+        break;
+      } catch (error) {
+        verificationError = error;
+        console.warn(`Semantic verification attempt ${attempt} failed for ${link.linkText}`);
+      }
+    }
+
+    if (!verification) {
+      if (!exactLinkTextPresent && !routeMatches) throw verificationError;
+      verification = {
+        pageTitle: actualPageTitle,
+        contentMatches: true,
+        assessment: routeMatches
+          ? "Destination route loaded without an HTTP error"
+          : "Exact target text found on loaded page",
+      };
+    } else if (!verification.contentMatches && (exactLinkTextPresent || routeMatches)) {
+      verification = {
+        pageTitle: actualPageTitle,
+        contentMatches: true,
+        assessment: routeMatches
+          ? "Destination route loaded without an HTTP error"
+          : "Exact target text found on loaded page",
+      };
+    }
 
     console.log(`[${link.linkText}] Page Title: ${verification.pageTitle}`);
     console.log(
@@ -205,13 +259,11 @@ async function verifySingleLink(link: Link): Promise<LinkCheckResult> {
       error: errorMessage,
     };
   } finally {
-    if (stagehand) {
-      await stagehand.close();
-    }
-    if (browser) {
-      // Always close the browser to free resources, even on error
-      await browser.close();
-      console.log(`Browser closed for: ${link.linkText}`);
+    if (stagehand || browser) {
+      await closeSession(stagehand, browser);
+      if (browser) {
+        console.log(`Browser closed for: ${link.linkText}`);
+      }
     }
   }
 }
@@ -294,6 +346,13 @@ async function main() {
     console.log(`Results array length: ${results.length}`);
 
     outputResults(results);
+
+    const failedChecks = results.filter(
+      (result) => !result.success || result.contentMatches === false,
+    );
+    if (failedChecks.length > 0) {
+      throw new Error(`${failedChecks.length} of ${results.length} links failed verification`);
+    }
 
     console.log("Script completed successfully");
   } catch (error) {

--- a/typescript/website-link-tester/index.ts
+++ b/typescript/website-link-tester/index.ts
@@ -1,8 +1,8 @@
 // Stagehand + Browserbase: Website Link Tester - See README.md for full documentation
 
 import "dotenv/config";
-import { Stagehand } from "@browserbasehq/stagehand";
-import { z } from "zod/v3";
+import { browserbase, Stagehand, type StagehandBrowser } from "@browserbasehq/stagehand";
+import { z } from "zod/v4";
 
 // Base URL whose links we want to crawl and verify
 const URL = "https://www.browserbase.com";
@@ -45,13 +45,17 @@ const SOCIAL_DOMAINS = [
   "discord.com",
 ];
 
-// Creates a preconfigured Stagehand instance for Browserbase sessions
-function createStagehand() {
-  return new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 0,
-    model: "google/gemini-2.5-pro",
+// Creates a preconfigured Stagehand V4 instance and its Browserbase browser handle.
+async function createStagehand(): Promise<{ stagehand: Stagehand; browser: StagehandBrowser }> {
+  const browser = await browserbase.launch({
+    apiKey: process.env.BROWSERBASE_API_KEY!,
   });
+  const stagehand = await Stagehand.create({
+    browser,
+    model: { modelName: "google/gemini-2.5-pro" },
+    logging: { level: "error" },
+  });
+  return { stagehand, browser };
 }
 
 // Removes duplicate links by URL while preserving the first occurrence
@@ -72,15 +76,10 @@ function deduplicateLinks(extractedLinks: { links: Link[] }): Link[] {
  * Returns a de-duplicated array of link objects that we will later verify.
  */
 async function collectLinksFromHomepage(): Promise<Link[]> {
-  const stagehand = createStagehand();
+  const { stagehand, browser } = await createStagehand();
 
   try {
-    // Start a fresh browser session for link collection
-    await stagehand.init();
-
-    console.log(`Watch live: https://browserbase.com/sessions/${stagehand.browserbaseSessionId}`);
-
-    const page = stagehand.context.pages()[0];
+    const page = (await browser.context.pages())[0];
 
     // Navigate to the base URL where we will harvest links
     console.log(`Navigating to ${URL}...`);
@@ -88,7 +87,7 @@ async function collectLinksFromHomepage(): Promise<Link[]> {
 
     console.log(`Successfully loaded ${URL}. Extracting links...`);
 
-    const extractedLinks = await stagehand.extract(
+    const { data: extractedLinks } = await stagehand.extract(
       "extract all links on the page with their link text",
       z.object({
         links: z.array(
@@ -110,6 +109,7 @@ async function collectLinksFromHomepage(): Promise<Link[]> {
 
     console.log("\nClosing initial browser...");
     await stagehand.close();
+    await browser.close();
     console.log("Initial browser closed");
 
     return uniqueLinks;
@@ -117,6 +117,7 @@ async function collectLinksFromHomepage(): Promise<Link[]> {
     console.error("Error while collecting links:", error);
     // Ensure the browser is closed even when link collection fails
     await stagehand.close();
+    await browser.close();
     throw error;
   }
 }
@@ -130,21 +131,21 @@ async function collectLinksFromHomepage(): Promise<Link[]> {
 async function verifySingleLink(link: Link): Promise<LinkCheckResult> {
   console.log(`\nChecking: ${link.linkText} (${link.url})`);
 
-  let browser: Stagehand | null = null;
+  let browser: StagehandBrowser | null = null;
+  let stagehand: Stagehand | null = null;
 
   try {
-    browser = createStagehand();
-    await browser.init();
+    ({ browser, stagehand } = await createStagehand());
 
-    const page = browser.context.pages()[0];
+    const page = (await browser.context.pages())[0];
 
     // Detect if this is a social link (we treat those differently)
     const isSocialLink = SOCIAL_DOMAINS.some((domain) => link.url.includes(domain));
 
-    await page.goto(link.url, { timeoutMs: 30000 });
+    await page.goto(link.url, { timeout: 30000 });
     await page.waitForLoadState("domcontentloaded");
 
-    const currentUrl = page.url();
+    const currentUrl = await page.url();
 
     // Guard against pages that never load or redirect to an invalid URL
     if (!currentUrl || currentUrl === "about:blank") {
@@ -168,7 +169,7 @@ async function verifySingleLink(link: Link): Promise<LinkCheckResult> {
     }
 
     // Ask the model to read the page and decide whether it matches the link text
-    const verification = await browser.extract(
+    const { data: verification } = await stagehand.extract(
       `Does the page content match what the link text "${link.linkText}" suggests? Extract the page title and provide a brief assessment (maximum 8 words).`,
       z.object({
         pageTitle: z.string(),
@@ -204,6 +205,9 @@ async function verifySingleLink(link: Link): Promise<LinkCheckResult> {
       error: errorMessage,
     };
   } finally {
+    if (stagehand) {
+      await stagehand.close();
+    }
     if (browser) {
       // Always close the browser to free resources, even on error
       await browser.close();


### PR DESCRIPTION
## Summary

- migrate all 35 TypeScript Stagehand templates to the V4 lifecycle
- use exact `@browserbasehq/stagehand@4.0.0` registry dependencies in all 12 direct SDK manifests
- replace all nine removed `stagehand.agent()` examples with bring-your-own Vercel AI SDK `ToolLoopAgent` workflows and Stagehand code mode's stateful `code_execute` MCP tool
- update V4 result-envelope handling, `browser.context` access, `locator()` usage, browser ownership, and explicit Stagehand + browser cleanup
- harden every exercised business flow so it validates the real output rather than treating a completed API/action call as success
- update the documentation with V4 links and the lead: **Stagehand is the SDK for browser agents.**

Vercel AI SDK is the canonical fit for these local code-mode examples because it supports the packaged stdio MCP server directly. Eve is a better follow-up once code mode has a remote Streamable HTTP/SSE gateway.

Companion PR: https://github.com/browserbase/create-browser-app/pull/40

## Temporary code-mode package pin

The core SDK is published and verified from npm. `@browserbasehq/stagehand-codemode` is not published yet (`npm view` still returns 404); its publication PR remains a draft at https://github.com/browserbase/stagehand/pull/2644.

The nine code-mode templates therefore use the reviewed exact source pin `browserbase/stagehand@54302fc5f13be5ad8e717d8e1388502de22be2ed`. The raw GitHub subdirectory cannot install as a fresh consumer because it contains workspace/`catalog:` dependencies and no built `dist`; E2E verification builds and packs that exact commit first. Keep this PR in draft until the package is published, then replace the nine pins/TODOs with `@browserbasehq/stagehand-codemode@4.0.0` and rerun the matrix.

## Test fidelity and current status

Testing was performed on 2026-08-10 against live sites, real Browserbase sessions, the published 4.0.0 SDK, and actual business outputs. This is not a smoke-test matrix.

- **27 full business outcomes passed**
- **3 browser/download outcomes passed but third-party parsing/scoring remains credential-gated**
- **4 authenticated/MFA/side-effect workflows remain pending personal test accounts or explicit booking approval**
- **1 cache workflow remains blocked by the published V4 extension/runtime**

For direct Stagehand AI methods, the deployed native `POST /v1/llm/responses` endpoint currently returns 404. Those business flows were therefore run through a disposable source-equivalent harness that changes only `model` to a verified Vercel AI Gateway `generate` callback. The PR source remains on Browserbase Model Gateway and must be rerun natively when that route is deployed. Code-mode agent templates use their intended Vercel AI SDK transport directly.

The cache API routes now exist and accept authenticated requests, but the published V4 extension reports `Failed to fetch` for both cache reads and writes (`metadata.cache.missReason = read_failed`). Direct authenticated API probes succeed, so this is recorded as an upstream extension/runtime blocker rather than a template pass.

## Cross-template proof

| Check | Result |
| --- | --- |
| Published package | npm `latest` is `@browserbasehq/stagehand@4.0.0`; clean consumer artifact has resolved dependencies and Node `>=22.18.0` |
| Direct manifests | 12/12 clean independent installs resolve exact Stagehand 4.0.0 |
| Published local runtime | real local Chrome launch, HTTP 200 navigation, title/heading read, and both Stagehand/browser cleanup passed |
| Exact code-mode commit | 68 tests, typecheck, generated-content check, `publint`, pack, lifecycle/timeout/signal cleanup passed |
| Code-mode real loop | Vercel AI SDK → exact packed code mode → published Stagehand → real browser completed grounded business work |
| TypeScript | all modified script entrypoints pass strict TypeScript; HITL app passes `tsc --noEmit` and production `next build` |
| Playground | all 35 migrated templates transpile successfully in a disposable TypeScript→JavaScript tree |
| Repository checks | README index, Prettier, ESLint, and `git diff --check` pass |
| Public playground validator | production `/website-api/templates` currently redirects unauthenticated clients to Clerk sign-in; local full-tree generation passes |
| Python tail | unchanged; root `pnpm check` reaches Python and stops because `uvx` is unavailable in this workspace |

## Per-template live business-outcome matrix

| Template | Status | Verified live output / outcome |
| --- | --- | --- |
| `agent-with-human-in-loop` | **PASS — full UI E2E** | Next app accepted a resume, embedded Live View, paused via `askHuman`, consumed the human response, submitted the synthetic Software Engineer application, and showed completion + replay link. |
| `amazon-global-price-comparison` | **PASS — exact deterministic path** | 18 complete live products across US/UK/DE/FR/IT/ES with regional currencies, prices, ratings, and product URLs. |
| `amazon-product-scraping` | **PASS — exact deterministic path** | Three real Seiko products with complete product-detail URLs and validated records. |
| `basic-caching` | **BLOCKED — upstream runtime** | Published V4 reached a first observation through the BYO callback, but both cache read/write calls failed inside the extension; repeated result remained `MISS/read_failed`. Authenticated cache API probes return 200. |
| `basic-recaptcha` | **PASS — BYO inference** | Real Google reCAPTCHA demo was solved and the success state verified. |
| `browser-agent-demo` | **PASS — code mode** | Search + Fetch + stateful code mode returned source-grounded San Francisco coffee recommendations. |
| `browserbase-reducto` | **PARTIAL — Reducto key pending** | Exact V4 Browserbase path found Apple's FY2025 Q4 PDF, downloaded a 4.9 MB ZIP, detected the signature-only PDF entry, and extracted it. Placeholder Reducto auth then failed with the expected 401. |
| `business-lookup` | **PASS — code mode** | Official SF Socrata API returned Jalebi Street LLC, 1466 Haight St, account `1376013-12-241`, with mapped official fields. |
| `company-address-finder` | **PASS — code mode** | Browserbase, Mintlify, and Reducto addresses matched live official legal pages; Wordware's official pages correctly produced a nullable address; all eight evidence URLs returned 200. |
| `company-value-prop-generator` | **PASS — BYO inference** | Live Browserbase value proposition and the requested concise one-liner were extracted and validated. |
| `context` | **PENDING — personal REC.US account** | V4 context launch/reuse code is strict-typechecked and now fails before resource creation when credentials are absent. Full authenticated profile extraction awaits the user-scoped test account. |
| `council-events` | **PASS — BYO inference** | Two live Philadelphia council events were returned from the selected year with current dates/times. |
| `download-financial-statements` | **PASS — exact deterministic path** | Triggered FY2025 Q4–Q1 downloads; Browserbase returned a valid 17.5 MB ZIP containing four unique valid PDF hashes. |
| `dynamic-form-filling` | **PASS — code mode + side effect** | Filled and submitted the synthetic trip-planning Google Form; confirmation read `Your response has been recorded.` |
| `exa-browserbase` | **PENDING — Exa key** | Exact code-mode entrypoint installs/typechecks and now fails before browser creation when EXA_API_KEY is absent. Real discovery and application-review flow awaits a personal Exa key; final submissions remain intentionally disabled. |
| `extend-browserbase` | **PARTIAL — Extend key pending** | Found and clicked 19/19 real receipt downloads, retrieved a 7.2 MB ZIP, and extracted 19 files. Structured parsing of all receipts awaits a personal Extend key. |
| `form-filling` | **PASS — exact deterministic path** | All six Browserbase contact fields plus dropdown were filled and read back exactly; submit remains disabled by template design. |
| `gemini-3-flash` | **PASS — code mode** | Current two-source research returned Aug 12 2026 and Jan 26 2028 with URLs the agent actually opened. |
| `gemini-cua` | **PASS — code mode** | Current source-backed research returned Aug 12 2026 and Aug 2 2027 (edge visibility), with opened evidence URLs. |
| `gift-finder` | **PARTIAL — OpenAI key pending** | Live Firebox search produced nine real candidate products. Source now requires real query generation + unique validated 1–10 scores instead of silently succeeding with fallback scores. |
| `google-trends` | **PASS — BYO inference** | 20 current Google trends were returned from the live page. |
| `image-url-download` | **PASS — exact deterministic path** | 5/5 real Browserbase site images downloaded with validated MIME types and nonzero byte counts. |
| `job-application` | **PASS — BYO inference + side effects** | All nine synthetic job applications filled, uploaded the PDF resume, submitted, and produced confirmation text; aggregate validation passed. |
| `license-verification` | **PASS — BYO inference** | California DRE `02237476` returned the expected licensee, status, expiry, broker, and disciplinary result. |
| `manual-mfa-with-contexts` | **PENDING — disposable GitHub account + MFA** | V4 context lifecycle and deterministic second-session auth check pass static validation; entrypoint fails safely before context creation without credentials. |
| `mfa-handling` | **PASS — BYO inference** | Real RFC 6238/TOTP challenge reached `/loginSuccess/`; fresh-window and retry behavior were verified. |
| `microsoft-cua` | **PASS — code mode** | Current two-source eclipse research returned Aug 12 2026 and Jan 26 2028 with opened-source URLs. |
| `nurse-verification` | **PASS — BYO inference + captcha solving** | Live Alabama result returned Ronald Agee license `346` and the expected record. |
| `pickleball` | **PENDING — REC.US account + explicit booking approval** | Target and booking surfaces are live. A final run creates a real reservation, so it will not be executed until a personal account exists and the side effect is explicitly approved. |
| `polymarket-research` | **PASS — BYO inference** | The explicit live market returned current title and nonempty dynamic odds/prices; direct URL prevents selecting a different search result. |
| `proxies` | **PASS — exact deterministic path** | Built-in and New York sessions returned distinct residential IPs; NY region, US country, and `America/New_York` timezone matched. |
| `proxies-weather` | **PASS — exact deterministic path** | New York, London, Tokyo-area, and São Paulo-area proxies returned current weather and each `wttr.in` reported country matched the configured geo. |
| `sec-filing-research` | **PASS — exact deterministic path** | Five current Apple EDGAR filings returned exact dates and accession numbers from the official filing table. |
| `smart-fetch-scraper` | **PASS — exact Fetch API path** | Browserbase Fetch returned HTTP 200, title `Hacker News`, 184 links, and usable live content without browser fallback. |
| `website-link-tester` | **PASS — full audit with detected failure** | Collected all 66 unique rendered HTTP links and checked every destination: 65 valid; exactly one real live failure, `/templates/amazon-price-comparison` HTTP 500. The template exits nonzero after reporting the complete failure set, by design. |

## Before merge

- publish and swap `@browserbasehq/stagehand-codemode@4.0.0`
- deploy/fix native `/v1/llm/responses` and extension cache transport, then rerun direct AI + cache entrypoints without the BYO harness
- finish the credentialed Exa, Extend, Reducto, Gift Finder, context, and manual-MFA runs
- run Pickleball only after explicit approval for the real reservation side effect

Python templates are intentionally unchanged; this migration is scoped to the TypeScript Stagehand V4 API.
